### PR TITLE
Refactor affiliation form layout and accessibility

### DIFF
--- a/assets/css/ufsc-frontend.css
+++ b/assets/css/ufsc-frontend.css
@@ -56,6 +56,119 @@
     text-align: center;
 }
 
+/* Affiliation form grid structure */
+.ufsc-grid {
+    display: grid;
+    gap: var(--ufsc-spacing-sm, 16px);
+}
+
+.ufsc-field {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: var(--ufsc-spacing-sm, 16px);
+}
+
+.ufsc-field-group {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: var(--ufsc-spacing-sm, 16px);
+}
+
+.ufsc-field label {
+    font-weight: 600;
+    margin-bottom: var(--ufsc-spacing-xs, 8px);
+}
+
+.ufsc-field label.required::after {
+    content: " *";
+    color: var(--ufsc-danger, #ef4444);
+}
+
+.ufsc-field input,
+.ufsc-field select {
+    width: 100%;
+    padding: var(--ufsc-spacing-xs, 8px) var(--ufsc-spacing-sm, 16px);
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    font-size: 14px;
+}
+
+.ufsc-field input:focus,
+.ufsc-field select:focus {
+    outline: 2px solid var(--ufsc-primary, #2271b1);
+    outline-offset: 2px;
+}
+
+.ufsc-field input[type="file"]:focus {
+    outline: 2px solid var(--ufsc-primary, #2271b1);
+    outline-offset: 2px;
+}
+
+.ufsc-checkbox-row label {
+    align-items: center;
+    font-weight: normal;
+    display: flex;
+}
+
+.ufsc-checkbox-row input[type="checkbox"] {
+    width: auto;
+    margin-right: var(--ufsc-spacing-xs, 8px);
+}
+
+.ufsc-error-message {
+    color: var(--ufsc-danger, #ef4444);
+    font-size: 0.875rem;
+    margin-top: 4px;
+}
+
+.ufsc-help {
+    font-size: 0.875rem;
+    color: var(--ufsc-neutral, #6b7280);
+    margin-top: 4px;
+}
+
+.ufsc-affiliation-form {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.ufsc-form-section {
+    background: #f9f9f9;
+    padding: var(--ufsc-spacing-md, 24px);
+    margin-bottom: var(--ufsc-spacing-md, 24px);
+    border-radius: 5px;
+}
+
+.ufsc-form-section h3 {
+    margin-top: 0;
+    border-bottom: 1px solid #ddd;
+    padding-bottom: var(--ufsc-spacing-xs, 8px);
+}
+
+.ufsc-message.ufsc-success {
+    background: #d4edda;
+    border-left: 4px solid var(--ufsc-success, #059669);
+    color: #155724;
+}
+
+.ufsc-message.ufsc-error {
+    background: #f8d7da;
+    border-left: 4px solid var(--ufsc-danger, #ef4444);
+    color: #721c24;
+}
+
+.ufsc-message.ufsc-info {
+    background: #d1ecf1;
+    border-left: 4px solid var(--ufsc-info, #3b82f6);
+    color: #0c5460;
+}
+
+@media (max-width: 768px) {
+    .ufsc-field-group {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* Frontend buttons */
 .ufsc-btn {
     display: inline-block;

--- a/includes/frontend/class-affiliation-form.php
+++ b/includes/frontend/class-affiliation-form.php
@@ -68,10 +68,12 @@ class UFSC_Affiliation_Form {
             <h2><?php echo esc_html__( 'Créer un club', 'ufsc-clubs' ); ?></h2>
             <?php endif; ?>
 
-            <?php echo $success_message; ?>
-            <?php echo $error_message; ?>
+            <div id="ufsc-form-status" aria-live="polite">
+                <?php echo $success_message; ?>
+                <?php echo $error_message; ?>
+            </div>
 
-            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-form">
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-form ufsc-grid" enctype="multipart/form-data">
                 <?php wp_nonce_field( 'ufsc_create_club', 'ufsc_nonce' ); ?>
                 <input type="hidden" name="action" value="ufsc_create_club">
                 <input type="hidden" name="redirect_to" value="<?php echo esc_attr( $atts['redirect_to'] ); ?>">
@@ -79,21 +81,23 @@ class UFSC_Affiliation_Form {
                 <div class="ufsc-form-section">
                     <h3><?php echo esc_html__( 'Informations du club', 'ufsc-clubs' ); ?></h3>
 
-                    <div class="ufsc-form-row">
+                    <div class="ufsc-field">
                         <label for="club_nom" class="required"><?php echo esc_html__( 'Nom du club', 'ufsc-clubs' ); ?> *</label>
-                        <input type="text" id="club_nom" name="club_nom" required maxlength="255" 
+                        <input type="text" id="club_nom" name="club_nom" required maxlength="255" aria-describedby="club_nom_error"
                                value="<?php echo esc_attr( self::get_form_value( 'club_nom' ) ); ?>">
+                        <p id="club_nom_error" class="ufsc-error-message"></p>
                     </div>
 
-                    <div class="ufsc-form-row">
+                    <div class="ufsc-field">
                         <label for="club_email" class="required"><?php echo esc_html__( 'Email du club', 'ufsc-clubs' ); ?> *</label>
-                        <input type="email" id="club_email" name="club_email" required 
+                        <input type="email" id="club_email" name="club_email" required aria-describedby="club_email_error"
                                value="<?php echo esc_attr( self::get_form_value( 'club_email' ) ); ?>">
+                        <p id="club_email_error" class="ufsc-error-message"></p>
                     </div>
 
-                    <div class="ufsc-form-row">
+                    <div class="ufsc-field">
                         <label for="club_region" class="required"><?php echo esc_html__( 'Région', 'ufsc-clubs' ); ?> *</label>
-                        <select id="club_region" name="club_region" required>
+                        <select id="club_region" name="club_region" required aria-describedby="club_region_error">
                             <option value=""><?php echo esc_html__( '-- Sélectionnez une région --', 'ufsc-clubs' ); ?></option>
                             <?php foreach ( self::get_regions() as $region ) : ?>
                             <option value="<?php echo esc_attr( $region ); ?>" <?php selected( self::get_form_value( 'club_region' ), $region ); ?>>
@@ -101,28 +105,46 @@ class UFSC_Affiliation_Form {
                             </option>
                             <?php endforeach; ?>
                         </select>
+                        <p id="club_region_error" class="ufsc-error-message"></p>
+                    </div>
+
+                    <div class="ufsc-field">
+                        <label for="club_statuts"><?php echo esc_html__( 'Statuts du club', 'ufsc-clubs' ); ?></label>
+                        <input type="file" id="club_statuts" name="club_statuts" aria-describedby="club_statuts_help club_statuts_error">
+                        <p id="club_statuts_help" class="ufsc-help"><?php echo esc_html__( 'Format PDF, 2 Mo max.', 'ufsc-clubs' ); ?></p>
+                        <p id="club_statuts_error" class="ufsc-error-message"></p>
+                    </div>
+
+                    <div class="ufsc-field">
+                        <label for="responsable_id_doc"><?php echo esc_html__( 'Pièce d\'identité du responsable', 'ufsc-clubs' ); ?></label>
+                        <input type="file" id="responsable_id_doc" name="responsable_id_doc" aria-describedby="responsable_id_doc_help responsable_id_doc_error">
+                        <p id="responsable_id_doc_help" class="ufsc-help"><?php echo esc_html__( 'PDF ou image, 2 Mo max.', 'ufsc-clubs' ); ?></p>
+                        <p id="responsable_id_doc_error" class="ufsc-error-message"></p>
                     </div>
                 </div>
 
                 <div class="ufsc-form-section">
                     <h3><?php echo esc_html__( 'Adresse', 'ufsc-clubs' ); ?></h3>
 
-                    <div class="ufsc-form-row">
+                    <div class="ufsc-field">
                         <label for="club_adresse"><?php echo esc_html__( 'Adresse', 'ufsc-clubs' ); ?></label>
-                        <input type="text" id="club_adresse" name="club_adresse" 
+                        <input type="text" id="club_adresse" name="club_adresse" aria-describedby="club_adresse_error"
                                value="<?php echo esc_attr( self::get_form_value( 'club_adresse' ) ); ?>">
+                        <p id="club_adresse_error" class="ufsc-error-message"></p>
                     </div>
 
-                    <div class="ufsc-form-row-group">
-                        <div class="ufsc-form-row">
+                    <div class="ufsc-field-group">
+                        <div class="ufsc-field">
                             <label for="club_code_postal"><?php echo esc_html__( 'Code postal', 'ufsc-clubs' ); ?></label>
-                            <input type="text" id="club_code_postal" name="club_code_postal" maxlength="10"
+                            <input type="text" id="club_code_postal" name="club_code_postal" maxlength="10" aria-describedby="club_code_postal_error"
                                    value="<?php echo esc_attr( self::get_form_value( 'club_code_postal' ) ); ?>">
+                            <p id="club_code_postal_error" class="ufsc-error-message"></p>
                         </div>
-                        <div class="ufsc-form-row">
+                        <div class="ufsc-field">
                             <label for="club_ville"><?php echo esc_html__( 'Ville', 'ufsc-clubs' ); ?></label>
-                            <input type="text" id="club_ville" name="club_ville" 
+                            <input type="text" id="club_ville" name="club_ville" aria-describedby="club_ville_error"
                                    value="<?php echo esc_attr( self::get_form_value( 'club_ville' ) ); ?>">
+                            <p id="club_ville_error" class="ufsc-error-message"></p>
                         </div>
                     </div>
                 </div>
@@ -130,20 +152,22 @@ class UFSC_Affiliation_Form {
                 <div class="ufsc-form-section">
                     <h3><?php echo esc_html__( 'Contact', 'ufsc-clubs' ); ?></h3>
 
-                    <div class="ufsc-form-row">
+                    <div class="ufsc-field">
                         <label for="club_telephone"><?php echo esc_html__( 'Téléphone', 'ufsc-clubs' ); ?></label>
-                        <input type="tel" id="club_telephone" name="club_telephone" 
+                        <input type="tel" id="club_telephone" name="club_telephone" aria-describedby="club_telephone_error"
                                value="<?php echo esc_attr( self::get_form_value( 'club_telephone' ) ); ?>">
+                        <p id="club_telephone_error" class="ufsc-error-message"></p>
                     </div>
                 </div>
 
                 <div class="ufsc-form-section">
-                    <div class="ufsc-form-row ufsc-checkbox-row">
-                        <label>
-                            <input type="checkbox" name="accept_cgu" value="1" required 
+                    <div class="ufsc-field ufsc-checkbox-row">
+                        <label for="accept_cgu">
+                            <input type="checkbox" id="accept_cgu" name="accept_cgu" value="1" required aria-describedby="accept_cgu_error"
                                    <?php checked( self::get_form_value( 'accept_cgu' ), '1' ); ?>>
                             <?php echo esc_html__( 'J\'accepte les conditions générales d\'utilisation', 'ufsc-clubs' ); ?> *
                         </label>
+                        <p id="accept_cgu_error" class="ufsc-error-message"></p>
                     </div>
                 </div>
 
@@ -155,86 +179,6 @@ class UFSC_Affiliation_Form {
             </form>
         </div>
 
-        <style>
-        .ufsc-affiliation-form {
-            max-width: 600px;
-            margin: 0 auto;
-        }
-        .ufsc-form-section {
-            background: #f9f9f9;
-            padding: 20px;
-            margin-bottom: 20px;
-            border-radius: 5px;
-        }
-        .ufsc-form-section h3 {
-            margin-top: 0;
-            border-bottom: 1px solid #ddd;
-            padding-bottom: 10px;
-        }
-        .ufsc-form-row {
-            margin-bottom: 15px;
-        }
-        .ufsc-form-row-group {
-            display: grid;
-            grid-template-columns: 1fr 2fr;
-            gap: 15px;
-        }
-        .ufsc-form-row label {
-            display: block;
-            margin-bottom: 5px;
-            font-weight: bold;
-        }
-        .ufsc-form-row label.required::after {
-            content: " *";
-            color: #e74c3c;
-        }
-        .ufsc-form-row input,
-        .ufsc-form-row select {
-            width: 100%;
-            padding: 8px 12px;
-            border: 1px solid #ddd;
-            border-radius: 3px;
-            font-size: 14px;
-        }
-        .ufsc-checkbox-row label {
-            display: flex;
-            align-items: center;
-            font-weight: normal;
-        }
-        .ufsc-checkbox-row input[type="checkbox"] {
-            width: auto;
-            margin-right: 8px;
-        }
-        .ufsc-form-actions {
-            text-align: center;
-            margin-top: 30px;
-        }
-        .ufsc-message {
-            padding: 15px;
-            border-radius: 5px;
-            margin: 20px 0;
-        }
-        .ufsc-message.ufsc-success {
-            background: #d4edda;
-            border-left: 4px solid #28a745;
-            color: #155724;
-        }
-        .ufsc-message.ufsc-error {
-            background: #f8d7da;
-            border-left: 4px solid #dc3545;
-            color: #721c24;
-        }
-        .ufsc-message.ufsc-info {
-            background: #d1ecf1;
-            border-left: 4px solid #17a2b8;
-            color: #0c5460;
-        }
-        @media (max-width: 768px) {
-            .ufsc-form-row-group {
-                grid-template-columns: 1fr;
-            }
-        }
-        </style>
         <?php
 
         return ob_get_clean();


### PR DESCRIPTION
## Summary
- restructure club affiliation form with grid layout and inline error messaging
- move embedded styles into `ufsc-frontend.css` using design tokens
- add document upload fields with help text and focus styles

## Testing
- `php -l includes/frontend/class-affiliation-form.php`
- `composer global require phpunit/phpunit:^9` *(failed: CONNECT tunnel failed, response 403)*
- `phpunit --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7da1d5930832b8592bbe475ce8846