### PR TITLE
Add unified front CSS and enqueue across shortcodes

### DIFF
--- a/assets/css/ufsc-front.css
+++ b/assets/css/ufsc-front.css
@@ -1,0 +1,263 @@
+/**
+ * UFSC Frontend Styles
+ * Design tokens and base components for front shortcodes
+ */
+
+:root {
+    --ufsc-primary: #2271b1;      /* Bleu UFSC */
+    --ufsc-secondary: #135e96;    /* Bleu foncé */
+    --ufsc-success: #059669;      /* Vert validation */
+    --ufsc-warning: #f59e0b;      /* Orange attention */
+    --ufsc-danger: #ef4444;       /* Rouge erreur */
+    --ufsc-info: #3b82f6;         /* Bleu information */
+    --ufsc-neutral: #6b7280;      /* Gris neutre */
+
+    --ufsc-spacing-xs: 8px;
+    --ufsc-spacing-sm: 16px;
+    --ufsc-spacing-md: 24px;
+    --ufsc-spacing-lg: 32px;
+    --ufsc-spacing-xl: 48px;
+
+    --mobile: 480px;
+    --tablet: 768px;
+    --desktop: 1024px;
+    --wide: 1200px;
+}
+
+/* Grid system */
+.ufsc-grid {
+    display: grid;
+    gap: var(--ufsc-spacing-md);
+    grid-template-columns: 1fr;
+}
+@media (min-width: var(--tablet)) {
+    .ufsc-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+@media (min-width: var(--desktop)) {
+    .ufsc-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+.ufsc-grid.-wide {
+    grid-template-columns: 1fr;
+}
+@media (min-width: var(--tablet)) {
+    .ufsc-grid.-wide {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+/* Card */
+.ufsc-card {
+    background: #ffffff;
+    border: 1px solid #e1e5e9;
+    border-radius: 8px;
+    padding: var(--ufsc-spacing-md);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+.ufsc-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+}
+
+/* Field */
+.ufsc-field {
+    margin-bottom: var(--ufsc-spacing-sm);
+}
+.ufsc-field label {
+    display: block;
+    margin-bottom: 4px;
+    font-weight: 600;
+}
+.ufsc-field input,
+.ufsc-field select,
+.ufsc-field textarea {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+/* Buttons */
+.ufsc-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+.ufsc-btn-primary {
+    background: var(--ufsc-primary);
+    color: #fff;
+}
+.ufsc-btn-primary:hover {
+    background: #005a87;
+    color: #fff;
+}
+.ufsc-btn-secondary {
+    background: var(--ufsc-neutral);
+    color: #fff;
+}
+.ufsc-btn-secondary:hover {
+    background: #4b5563;
+    color: #fff;
+}
+
+/* Badges */
+.ufsc-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.ufsc-badge-success {
+    background: var(--ufsc-success);
+    color: #fff;
+}
+.ufsc-badge-warning {
+    background: var(--ufsc-warning);
+    color: #fff;
+}
+.ufsc-badge-info {
+    background: var(--ufsc-info);
+    color: #fff;
+}
+.ufsc-badge-danger {
+    background: var(--ufsc-danger);
+    color: #fff;
+}
+.ufsc-badge-region {
+    background: var(--ufsc-primary);
+    color: #fff;
+}
+
+.ufsc-badge-doc-complete {
+    background: var(--ufsc-success);
+    color: #fff;
+}
+.ufsc-badge-doc-partial {
+    background: var(--ufsc-warning);
+    color: #fff;
+}
+.ufsc-badge-doc-missing {
+    background: var(--ufsc-danger);
+    color: #fff;
+}
+
+.ufsc-badge:hover {
+    opacity: 0.8;
+    text-decoration: none;
+}
+
+.ufsc-badge-sm {
+    padding: 0.2em 0.5em;
+    font-size: 0.65em;
+}
+
+.ufsc-badge-lg {
+    padding: 0.35em 0.8em;
+    font-size: 0.85em;
+}
+
+/* Login form */
+.ufsc-login-form {
+    max-width: 400px;
+    margin: 0 auto;
+    padding: var(--ufsc-spacing-md);
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    background: #fff;
+}
+.ufsc-login-title {
+    text-align: center;
+    margin-bottom: var(--ufsc-spacing-md);
+    color: #333;
+}
+.ufsc-form-group {
+    margin-bottom: var(--ufsc-spacing-sm);
+}
+.ufsc-form-group label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+    color: #555;
+}
+.ufsc-form-control {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+}
+.ufsc-form-control:focus {
+    border-color: var(--ufsc-primary);
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(34,113,177,0.2);
+}
+.ufsc-form-links {
+    text-align: center;
+    margin-top: 10px;
+}
+.ufsc-form-links a {
+    color: var(--ufsc-primary);
+    text-decoration: none;
+    font-size: 13px;
+}
+.ufsc-form-links a:hover {
+    text-decoration: underline;
+}
+
+/* User status */
+.ufsc-user-status {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px;
+    background: #f8f9fa;
+    border-radius: 4px;
+    border: 1px solid #e9ecef;
+}
+.ufsc-user-status.ufsc-not-logged-in {
+    text-align: center;
+    color: #6c757d;
+}
+.ufsc-user-avatar img {
+    border-radius: 50%;
+}
+.ufsc-user-info {
+    flex: 1;
+}
+.ufsc-user-name {
+    margin-bottom: 2px;
+}
+.ufsc-user-role,
+.ufsc-user-club {
+    font-size: 12px;
+    color: #6c757d;
+    margin-bottom: 2px;
+}
+.ufsc-user-actions {
+    margin-top: 5px;
+}
+.ufsc-logout-button {
+    font-size: 12px;
+    color: #dc3545;
+    text-decoration: none;
+}
+.ufsc-logout-button:hover {
+    text-decoration: underline;
+}

--- a/includes/core/class-badge-helper.php
+++ b/includes/core/class-badge-helper.php
@@ -138,102 +138,15 @@ class UFSC_Badge_Helper {
     }
 
     /**
-     * Get CSS for badges
-     * 
-     * @return string CSS code
-     */
-    public static function get_badge_css() {
-        ob_start();
-        ?>
-        <style>
-        .ufsc-badge {
-            display: inline-block;
-            padding: 0.25em 0.6em;
-            font-size: 0.75em;
-            font-weight: 600;
-            line-height: 1;
-            text-align: center;
-            white-space: nowrap;
-            vertical-align: baseline;
-            border-radius: 0.25rem;
-            border: 1px solid transparent;
-            text-decoration: none;
-        }
-        
-        /* Status badges */
-        .ufsc-badge-success {
-            background-color: <?php echo self::$status_badges['valide']['color']; ?>;
-            color: <?php echo self::$status_badges['valide']['text_color']; ?>;
-        }
-        
-        .ufsc-badge-warning {
-            background-color: <?php echo self::$status_badges['a_regler']['color']; ?>;
-            color: <?php echo self::$status_badges['a_regler']['text_color']; ?>;
-        }
-        
-        .ufsc-badge-info {
-            background-color: <?php echo self::$status_badges['en_attente']['color']; ?>;
-            color: <?php echo self::$status_badges['en_attente']['text_color']; ?>;
-        }
-        
-        .ufsc-badge-danger {
-            background-color: <?php echo self::$status_badges['desactive']['color']; ?>;
-            color: <?php echo self::$status_badges['desactive']['text_color']; ?>;
-        }
-        
-        /* Region badges */
-        .ufsc-badge-region {
-            background-color: <?php echo self::$region_badges['default']['color']; ?>;
-            color: <?php echo self::$region_badges['default']['text_color']; ?>;
-        }
-        
-        /* Document badges */
-        .ufsc-badge-doc-complete {
-            background-color: <?php echo self::$document_badges['complete']['color']; ?>;
-            color: <?php echo self::$document_badges['complete']['text_color']; ?>;
-        }
-        
-        .ufsc-badge-doc-partial {
-            background-color: <?php echo self::$document_badges['partial']['color']; ?>;
-            color: <?php echo self::$document_badges['partial']['text_color']; ?>;
-        }
-        
-        .ufsc-badge-doc-missing {
-            background-color: <?php echo self::$document_badges['missing']['color']; ?>;
-            color: <?php echo self::$document_badges['missing']['text_color']; ?>;
-        }
-        
-        /* Hover effects */
-        .ufsc-badge:hover {
-            opacity: 0.8;
-            text-decoration: none;
-        }
-        
-        /* Size variations */
-        .ufsc-badge-sm {
-            padding: 0.2em 0.5em;
-            font-size: 0.65em;
-        }
-        
-        .ufsc-badge-lg {
-            padding: 0.35em 0.8em;
-            font-size: 0.85em;
-        }
-        </style>
-        <?php
-        return ob_get_clean();
-    }
-
-    /**
      * Enqueue badge styles
      */
     public static function enqueue_styles() {
-        add_action( 'wp_head', function() {
-            echo self::get_badge_css();
+        add_action( 'wp_enqueue_scripts', function() {
+            wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
         } );
-        
-        add_action( 'admin_head', function() {
-            echo self::get_badge_css();
+
+        add_action( 'admin_enqueue_scripts', function() {
+            wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
         } );
     }
 }

--- a/includes/frontend/class-auth-shortcodes.php
+++ b/includes/frontend/class-auth-shortcodes.php
@@ -23,6 +23,8 @@ class UFSC_Auth_Shortcodes {
      * @return string HTML output
      */
     public static function render_login_form( $atts = array() ) {
+        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
+
         $atts = shortcode_atts( array(
             'redirect_admin' => admin_url( 'admin.php?page=ufsc-gestion' ),
             'redirect_club' => home_url( '/club-dashboard/' ),
@@ -89,78 +91,6 @@ class UFSC_Auth_Shortcodes {
                 <?php endif; ?>
             </form>
         </div>
-
-        <style>
-        .ufsc-login-form {
-            max-width: 400px;
-            margin: 0 auto;
-            padding: 20px;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            background: #fff;
-        }
-        .ufsc-login-title {
-            text-align: center;
-            margin-bottom: 20px;
-            color: #333;
-        }
-        .ufsc-form-group {
-            margin-bottom: 15px;
-        }
-        .ufsc-form-group label {
-            display: block;
-            margin-bottom: 5px;
-            font-weight: bold;
-            color: #555;
-        }
-        .ufsc-form-control {
-            width: 100%;
-            padding: 10px;
-            border: 1px solid #ddd;
-            border-radius: 4px;
-            font-size: 14px;
-        }
-        .ufsc-form-control:focus {
-            border-color: #0073aa;
-            outline: none;
-            box-shadow: 0 0 0 2px rgba(0, 115, 170, 0.2);
-        }
-        .ufsc-form-checkbox label {
-            display: inline;
-            font-weight: normal;
-            margin-left: 5px;
-        }
-        .ufsc-btn {
-            display: inline-block;
-            padding: 10px 20px;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            text-decoration: none;
-            font-size: 14px;
-            transition: all 0.3s ease;
-        }
-        .ufsc-btn-primary {
-            background-color: #0073aa;
-            color: #fff;
-            width: 100%;
-        }
-        .ufsc-btn-primary:hover {
-            background-color: #005a87;
-        }
-        .ufsc-form-links {
-            text-align: center;
-            margin-top: 10px;
-        }
-        .ufsc-form-links a {
-            color: #0073aa;
-            text-decoration: none;
-            font-size: 13px;
-        }
-        .ufsc-form-links a:hover {
-            text-decoration: underline;
-        }
-        </style>
         <?php
         return ob_get_clean();
     }
@@ -204,6 +134,8 @@ class UFSC_Auth_Shortcodes {
      * @return string HTML output
      */
     public static function render_user_status( $atts = array() ) {
+        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
+
         $atts = shortcode_atts( array(
             'show_avatar' => 'true',
             'show_role' => 'true',
@@ -255,47 +187,6 @@ class UFSC_Auth_Shortcodes {
                 <?php endif; ?>
             </div>
         </div>
-
-        <style>
-        .ufsc-user-status {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-            padding: 10px;
-            background: #f8f9fa;
-            border-radius: 4px;
-            border: 1px solid #e9ecef;
-        }
-        .ufsc-user-status.ufsc-not-logged-in {
-            text-align: center;
-            color: #6c757d;
-        }
-        .ufsc-user-avatar img {
-            border-radius: 50%;
-        }
-        .ufsc-user-info {
-            flex: 1;
-        }
-        .ufsc-user-name {
-            margin-bottom: 2px;
-        }
-        .ufsc-user-role, .ufsc-user-club {
-            font-size: 12px;
-            color: #6c757d;
-            margin-bottom: 2px;
-        }
-        .ufsc-user-actions {
-            margin-top: 5px;
-        }
-        .ufsc-logout-button {
-            font-size: 12px;
-            color: #dc3545;
-            text-decoration: none;
-        }
-        .ufsc-logout-button:hover {
-            text-decoration: underline;
-        }
-        </style>
         <?php
         return ob_get_clean();
     }

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -25,6 +25,7 @@ class UFSC_Frontend_Shortcodes {
      * @return string HTML output
      */
     public static function render_club_dashboard( $atts = array() ) {
+        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
         $atts = shortcode_atts( array(
             'show_sections' => 'licences,stats,profile,add_licence'
         ), $atts );
@@ -144,6 +145,7 @@ class UFSC_Frontend_Shortcodes {
      * @return string HTML output
      */
     public static function render_club_licences( $atts = array() ) {
+        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
         $atts = shortcode_atts( array(
             'club_id' => 0,
             'per_page' => 20,
@@ -407,6 +409,7 @@ class UFSC_Frontend_Shortcodes {
      * @return string HTML output
      */
     public static function render_club_profile( $atts = array() ) {
+        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
         $atts = shortcode_atts( array(
             'club_id' => 0
         ), $atts );


### PR DESCRIPTION
## Summary
- add `assets/css/ufsc-front.css` with UFSC design tokens and component styles
- enqueue shared stylesheet for login, dashboard, licences and club profile shortcodes
- remove inline styles from auth shortcodes and load badge styles via stylesheet

## Testing
- `php -l includes/frontend/class-auth-shortcodes.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l includes/core/class-badge-helper.php`
- `phpunit tests/test-frontend.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7da4079ac832bb9b533a1c219c644