### PR TITLE
feat: improve frontend accessibility

### DIFF
--- a/assets/css/ufsc-frontend.css
+++ b/assets/css/ufsc-frontend.css
@@ -3,6 +3,25 @@
  * Styles for frontend shortcodes and forms
  */
 
+/* Accessibility focus styles for interactive elements */
+a:focus,
+button:focus,
+input:focus,
+select:focus,
+textarea:focus,
+[tabindex]:focus {
+    outline: 2px solid var(--ufsc-primary);
+    outline-offset: 2px;
+}
+
+/* Smooth transitions on interactive elements */
+a,
+button,
+.ufsc-btn,
+table tr {
+    transition: 150ms ease;
+}
+
 /* Frontend form styling */
 .ufsc-frontend-form {
     max-width: 600px;
@@ -46,9 +65,10 @@
 .ufsc-form-row input:focus,
 .ufsc-form-row select:focus,
 .ufsc-form-row textarea:focus {
-    outline: none;
-    border-color: #3498db;
-    box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+    border-color: var(--ufsc-primary);
+    outline: 2px solid var(--ufsc-primary);
+    outline-offset: 2px;
+    box-shadow: none;
 }
 
 .ufsc-form-actions {
@@ -68,7 +88,7 @@
     font-size: 14px;
     font-weight: 500;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: 150ms ease;
 }
 
 .ufsc-btn:hover {

--- a/includes/frontend/class-affiliation-form.php
+++ b/includes/frontend/class-affiliation-form.php
@@ -71,6 +71,8 @@ class UFSC_Affiliation_Form {
             <?php echo $success_message; ?>
             <?php echo $error_message; ?>
 
+            <div class="ufsc-notices" aria-live="polite"></div>
+
             <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-form">
                 <?php wp_nonce_field( 'ufsc_create_club', 'ufsc_nonce' ); ?>
                 <input type="hidden" name="action" value="ufsc_create_club">

--- a/includes/frontend/class-auth-shortcodes.php
+++ b/includes/frontend/class-auth-shortcodes.php
@@ -43,6 +43,7 @@ class UFSC_Auth_Shortcodes {
             <?php if ( ! empty( $atts['title'] ) ): ?>
                 <h3 class="ufsc-login-title"><?php echo esc_html( $atts['title'] ); ?></h3>
             <?php endif; ?>
+            <div class="ufsc-notices" aria-live="polite"></div>
 
             <form method="post" action="<?php echo esc_url( site_url( 'wp-login.php', 'login_post' ) ); ?>" class="ufsc-login-form-inner">
                 <?php wp_nonce_field( 'ufsc_login', 'ufsc_login_nonce' ); ?>

--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -126,8 +126,9 @@ class UFSC_CL_Club_Form {
         // Display messages
         self::display_messages();
         ?>
-        
+
         <div class="ufsc-club-form-container">
+            <div class="ufsc-notices" aria-live="polite"></div>
             <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-club-form">
                 <?php wp_nonce_field( 'ufsc_save_club', 'ufsc_club_nonce' ); ?>
                 <input type="hidden" name="action" value="ufsc_save_club" />

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -204,6 +204,7 @@ class UFSC_Frontend_Shortcodes {
             <!-- Filters -->
             <div class="ufsc-licences-filters">
                 <form method="get" class="ufsc-filters-form">
+                    <div class="ufsc-notices" aria-live="polite"></div>
                     <div class="ufsc-filter-group">
                         <label for="ufsc_search"><?php esc_html_e( 'Recherche:', 'ufsc-clubs' ); ?></label>
                         <input type="text" id="ufsc_search" name="ufsc_search" 
@@ -467,6 +468,7 @@ class UFSC_Frontend_Shortcodes {
             </div>
 
             <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-club-form ufsc-club-profile">
+                <div class="ufsc-notices" aria-live="polite"></div>
                 <input type="hidden" name="action" value="ufsc_save_club">
                 <?php wp_nonce_field( 'ufsc_save_club', '_wpnonce' ); ?>
                 
@@ -710,6 +712,7 @@ class UFSC_Frontend_Shortcodes {
             </div>
 
             <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-licence-form">
+                <div class="ufsc-notices" aria-live="polite"></div>
                 <input type="hidden" name="action" value="ufsc_save_licence">
                 <?php wp_nonce_field( 'ufsc_save_licence', '_wpnonce' ); ?>
                 
@@ -1551,6 +1554,7 @@ class UFSC_Frontend_Shortcodes {
                 <span class="ufsc-modal-close" onclick="document.getElementById('ufsc-import-modal').style.display='none'">&times;</span>
                 <h3><?php esc_html_e( 'Importer des licences CSV', 'ufsc-clubs' ); ?></h3>
                 <form method="post" enctype="multipart/form-data" class="ufsc-import-form">
+                    <div class="ufsc-notices" aria-live="polite"></div>
                     <?php wp_nonce_field( 'ufsc_import_csv', 'ufsc_nonce' ); ?>
                     <input type="hidden" name="club_id" value="<?php echo esc_attr( $club_id ); ?>">
                     


### PR DESCRIPTION
## Summary
- standardize focus outlines and transitions for interactive elements
- add live validation notice containers across frontend forms

## Testing
- `php -l includes/frontend/class-auth-shortcodes.php`
- `php -l includes/frontend/class-affiliation-form.php`
- `php -l includes/frontend/class-club-form.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `phpunit --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7da36e07c832b93bc3ab99e57b216