### PR TITLE
Add AJAX affiliation payment script with fallback

### DIFF
--- a/assets/js/ufsc-affiliation.js
+++ b/assets/js/ufsc-affiliation.js
@@ -1,0 +1,20 @@
+(function($){
+    function handleClick(e){
+        e.preventDefault();
+        var $form = $(this).closest('form');
+        $.post(ufscAffiliation.ajax_url, {
+            action: 'ufsc_affiliation_pay',
+            nonce: ufscAffiliation.nonce
+        }).done(function(response){
+            if(response && response.success && response.data.redirect){
+                window.location.href = response.data.redirect;
+            } else {
+                $form.off('submit').trigger('submit');
+            }
+        }).fail(function(){
+            $form.off('submit').trigger('submit');
+        });
+    }
+
+    $(document).on('click', '#ufsc-pay-affiliation', handleClick);
+})(jQuery);


### PR DESCRIPTION
## Summary
- Add frontend script to pay affiliation via AJAX and redirect to checkout
- Register script and AJAX/admin-post handlers with non-JS fallback in affiliation form

## Testing
- `php -l includes/frontend/class-affiliation-form.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7da3781c8832bbf0e554c39192625