### PR TITLE
Add frontend licences templates and shortcode

### DIFF
--- a/assets/js/ufsc-licences.js
+++ b/assets/js/ufsc-licences.js
@@ -1,0 +1,17 @@
+/**
+ * UFSC Licences helper
+ * Handle conditional fields display
+ */
+(function($){
+    'use strict';
+    function toggleFields(){
+        var postier = $('#reduction_postier').is(':checked');
+        $('.ufsc-field-identifiant-laposte')[ postier ? 'show' : 'hide' ]();
+        var delegataire = $('#licence_delegataire').is(':checked');
+        $('.ufsc-field-numero-delegataire')[ delegataire ? 'show' : 'hide' ]();
+    }
+    $(document).ready(function(){
+        toggleFields();
+        $('#reduction_postier, #licence_delegataire').on('change', toggleFields);
+    });
+})(jQuery);

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -16,6 +16,7 @@ class UFSC_Frontend_Shortcodes {
         add_shortcode( 'ufsc_club_stats', array( __CLASS__, 'render_club_stats' ) );
         add_shortcode( 'ufsc_club_profile', array( __CLASS__, 'render_club_profile' ) );
         add_shortcode( 'ufsc_add_licence', array( __CLASS__, 'render_add_licence' ) );
+        add_shortcode( 'ufsc_licences', array( __CLASS__, 'render_licences' ) );
     }
 
     /**
@@ -831,6 +832,55 @@ class UFSC_Frontend_Shortcodes {
         </div>
         <?php
         return ob_get_clean();
+    }
+
+    /**
+     * Render licences list or form based on action
+     */
+    public static function render_licences( $atts = array() ) {
+        $atts = shortcode_atts( array(
+            'club_id' => 0,
+        ), $atts );
+
+        if ( ! $atts['club_id'] && is_user_logged_in() ) {
+            $atts['club_id'] = self::get_user_club_id( get_current_user_id() );
+        }
+
+        if ( ! $atts['club_id'] ) {
+            return '<div class="ufsc-message ufsc-error">' .
+                   esc_html__( 'Club non trouv\u00e9.', 'ufsc-clubs' ) .
+                   '</div>';
+        }
+
+        $action     = isset( $_GET['ufsc_action'] ) ? sanitize_key( $_GET['ufsc_action'] ) : '';
+        $licence_id = isset( $_GET['licence_id'] ) ? intval( $_GET['licence_id'] ) : 0;
+
+        wp_enqueue_script( 'ufsc-licences', UFSC_CL_URL . 'assets/js/ufsc-licences.js', array( 'jquery' ), UFSC_CL_VERSION, true );
+
+        ob_start();
+        if ( in_array( $action, array( 'edit', 'new' ), true ) ) {
+            $licence = null;
+            if ( 'edit' === $action && $licence_id ) {
+                $licence = self::get_licence( $atts['club_id'], $licence_id );
+            }
+            include UFSC_CL_DIR . 'templates/frontend/licence-form.php';
+        } else {
+            $licences = self::get_club_licences( $atts['club_id'], array( 'per_page' => 100 ) );
+            include UFSC_CL_DIR . 'templates/frontend/licences-list.php';
+        }
+        return ob_get_clean();
+    }
+
+    /**
+     * Get single licence
+     */
+    private static function get_licence( $club_id, $licence_id ) {
+        global $wpdb;
+        if ( ! function_exists( 'ufsc_get_licences_table' ) ) {
+            return null;
+        }
+        $table = ufsc_get_licences_table();
+        return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$table}` WHERE id = %d AND club_id = %d", $licence_id, $club_id ) );
     }
 
     // Helper methods - STUBS to be implemented

--- a/templates/frontend/licence-form.php
+++ b/templates/frontend/licence-form.php
@@ -1,0 +1,64 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+?>
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-licence-form">
+    <input type="hidden" name="action" value="ufsc_save_licence" />
+    <?php wp_nonce_field( 'ufsc_save_licence' ); ?>
+    <input type="hidden" name="licence_id" value="<?php echo isset( $licence->id ) ? intval( $licence->id ) : 0; ?>" />
+
+    <div class="ufsc-grid">
+        <div class="ufsc-field">
+            <label for="prenom"><?php esc_html_e( 'Pr\u00e9nom', 'ufsc-clubs' ); ?></label>
+            <input type="text" id="prenom" name="prenom" value="<?php echo esc_attr( $licence->prenom ?? '' ); ?>" required />
+        </div>
+        <div class="ufsc-field">
+            <label for="nom"><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></label>
+            <input type="text" id="nom" name="nom" value="<?php echo esc_attr( $licence->nom ?? '' ); ?>" required />
+        </div>
+        <div class="ufsc-field">
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" value="<?php echo esc_attr( $licence->email ?? '' ); ?>" />
+        </div>
+        <div class="ufsc-field">
+            <label for="date_naissance"><?php esc_html_e( 'Date de naissance', 'ufsc-clubs' ); ?></label>
+            <input type="date" id="date_naissance" name="date_naissance" value="<?php echo esc_attr( $licence->date_naissance ?? '' ); ?>" />
+        </div>
+        <div class="ufsc-field">
+            <label for="role"><?php esc_html_e( 'R\u00f4le', 'ufsc-clubs' ); ?></label>
+            <select id="role" name="role">
+                <option value=""<?php selected( $licence->role ?? '', '' ); ?>><?php esc_html_e( 'S\u00e9lectionner', 'ufsc-clubs' ); ?></option>
+                <option value="president"<?php selected( $licence->role ?? '', 'president' ); ?>><?php esc_html_e( 'Pr\u00e9sident', 'ufsc-clubs' ); ?></option>
+                <option value="secretaire"<?php selected( $licence->role ?? '', 'secretaire' ); ?>><?php esc_html_e( 'Secr\u00e9taire', 'ufsc-clubs' ); ?></option>
+                <option value="tresorier"<?php selected( $licence->role ?? '', 'tresorier' ); ?>><?php esc_html_e( 'Tr\u00e9sorier', 'ufsc-clubs' ); ?></option>
+                <option value="entraineur"<?php selected( $licence->role ?? '', 'entraineur' ); ?>><?php esc_html_e( 'Entra\u00eeneur', 'ufsc-clubs' ); ?></option>
+                <option value="adherent"<?php selected( $licence->role ?? '', 'adherent' ); ?>><?php esc_html_e( 'Adh\u00e9rent', 'ufsc-clubs' ); ?></option>
+            </select>
+        </div>
+        <div class="ufsc-field">
+            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_postier" name="reduction_postier" value="1" <?php checked( $licence->reduction_postier ?? 0, 1 ); ?> /> <?php esc_html_e( 'R\u00e9duction postier', 'ufsc-clubs' ); ?></label>
+        </div>
+        <div class="ufsc-field ufsc-field-identifiant-laposte" style="display:none;">
+            <label for="identifiant_laposte"><?php esc_html_e( 'Identifiant La Poste', 'ufsc-clubs' ); ?></label>
+            <input type="text" id="identifiant_laposte" name="identifiant_laposte" value="<?php echo esc_attr( $licence->identifiant_laposte ?? '' ); ?>" />
+        </div>
+        <div class="ufsc-field">
+            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_benevole" name="reduction_benevole" value="1" <?php checked( $licence->reduction_benevole ?? 0, 1 ); ?> /> <?php esc_html_e( 'R\u00e9duction b\u00e9n\u00e9vole', 'ufsc-clubs' ); ?></label>
+        </div>
+        <div class="ufsc-field">
+            <label class="ufsc-checkbox"><input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1" <?php checked( $licence->licence_delegataire ?? 0, 1 ); ?> /> <?php esc_html_e( 'Licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
+        </div>
+        <div class="ufsc-field ufsc-field-numero-delegataire" style="display:none;">
+            <label for="numero_licence_delegataire"><?php esc_html_e( 'Num\u00e9ro de licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
+            <input type="text" id="numero_licence_delegataire" name="numero_licence_delegataire" value="<?php echo esc_attr( $licence->numero_licence_delegataire ?? '' ); ?>" />
+        </div>
+        <div class="ufsc-field">
+            <label for="note"><?php esc_html_e( 'Note', 'ufsc-clubs' ); ?></label>
+            <textarea id="note" name="note" rows="3"><?php echo esc_textarea( $licence->note ?? '' ); ?></textarea>
+        </div>
+    </div>
+    <div class="ufsc-form-actions">
+        <button type="submit" class="ufsc-btn ufsc-btn-primary">
+            <?php echo isset( $licence->id ) && $licence->id ? esc_html__( 'Mettre \u00e0 jour', 'ufsc-clubs' ) : esc_html__( 'Cr\u00e9er', 'ufsc-clubs' ); ?>
+        </button>
+    </div>
+</form>

--- a/templates/frontend/licences-list.php
+++ b/templates/frontend/licences-list.php
@@ -1,0 +1,48 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+?>
+<table class="ufsc-table ufsc-licences-table">
+    <thead>
+        <tr>
+            <th><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></th>
+            <th><?php esc_html_e( 'R\u00f4le', 'ufsc-clubs' ); ?></th>
+            <th><?php esc_html_e( 'Statut', 'ufsc-clubs' ); ?></th>
+            <th><?php esc_html_e( 'Actions', 'ufsc-clubs' ); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php if ( ! empty( $licences ) ) : ?>
+        <?php foreach ( $licences as $licence ) : ?>
+            <tr>
+                <td><?php echo esc_html( trim( ( $licence->prenom ?? '' ) . ' ' . ( $licence->nom ?? '' ) ) ); ?></td>
+                <td><?php echo esc_html( $licence->role ?? '' ); ?></td>
+                <td>
+                    <?php echo UFSC_Badges::render_licence_badge( $licence->statut ?? '', array( 'custom_class' => 'ufsc-badge' ) ); ?>
+                </td>
+                <td>
+                    <div class="ufsc-actions">
+                        <a class="ufsc-action" href="<?php echo esc_url( add_query_arg( array( 'ufsc_action' => 'view', 'licence_id' => $licence->id ) ) ); ?>"><?php esc_html_e( 'Consulter', 'ufsc-clubs' ); ?></a>
+                        <?php if ( empty( $licence->statut ) || ! UFSC_Badges::is_active_licence_status( $licence->statut ) ) : ?>
+                            <a class="ufsc-action" href="<?php echo esc_url( add_query_arg( array( 'ufsc_action' => 'edit', 'licence_id' => $licence->id ) ) ); ?>"><?php esc_html_e( 'Modifier', 'ufsc-clubs' ); ?></a>
+                            <?php if ( current_user_can( 'manage_options' ) ) : ?>
+                                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-inline-form">
+                                    <input type="hidden" name="action" value="ufsc_delete_licence" />
+                                    <input type="hidden" name="licence_id" value="<?php echo intval( $licence->id ); ?>" />
+                                    <?php wp_nonce_field( 'ufsc_delete_licence_' . $licence->id ); ?>
+                                    <button type="submit" class="ufsc-action ufsc-delete">
+                                        <?php esc_html_e( 'Supprimer', 'ufsc-clubs' ); ?>
+                                    </button>
+                                </form>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                    </div>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+    <?php else : ?>
+        <tr>
+            <td colspan="4" class="ufsc-no-items"><?php esc_html_e( 'Aucune licence trouv\u00e9e.', 'ufsc-clubs' ); ?></td>
+        </tr>
+    <?php endif; ?>
+    </tbody>
+</table>


### PR DESCRIPTION
## Summary
- Add responsive licences list template with status badges and action links
- Add licence form template in ufsc-grid and conditional fields
- Introduce `ufsc_licences` shortcode and JS for conditional form sections

## Testing
- `php -l templates/frontend/licences-list.php`
- `php -l templates/frontend/licence-form.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php tests/test-frontend.php` *(fails: Class "PHPUnit\Framework\TestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7da38dfbc832ba58998d4d80192fe