### PR TITLE
feat: add document uploads section

### DIFF
--- a/includes/frontend/class-club-form-handler.php
+++ b/includes/frontend/class-club-form-handler.php
@@ -150,55 +150,42 @@ class UFSC_CL_Club_Form_Handler {
     }
     
     /**
-     * Handle file uploads for documents and logo
-     * 
+     * Handle file uploads for club documents with validation.
+     *
      * @param array $data Current form data
      * @return array|WP_Error Upload results or error
      */
     private static function handle_file_uploads( $data ) {
         $upload_results = array();
         
-        // Handle logo upload
-        if ( ! empty( $_FILES['logo_upload']['name'] ) ) {
-            $logo_result = UFSC_CL_Uploads::ufsc_safe_handle_upload(
-                $_FILES['logo_upload'],
-                UFSC_CL_Uploads::get_logo_mime_types(),
-                UFSC_CL_Uploads::get_logo_max_size()
-            );
-            
-            if ( is_wp_error( $logo_result ) ) {
-                return $logo_result;
-            }
-            
-            $upload_results['logo_url'] = $logo_result['url'];
-        }
-        
-        // Handle document uploads
+        $allowed_mimes = UFSC_CL_Uploads::get_document_mime_types();
+        $max_size      = UFSC_CL_Uploads::get_document_max_size();
+
         $documents = array(
-            'statuts_upload' => 'doc_statuts',
-            'recepisse_upload' => 'doc_recepisse',
-            'jo_upload' => 'doc_jo',
-            'pv_ag_upload' => 'doc_pv_ag',
-            'cer_upload' => 'doc_cer',
-            'attestation_cer_upload' => 'doc_attestation_cer'
+            'statuts_upload'      => 'doc_statuts',
+            'recepisse_upload'    => 'doc_recepisse',
+            'jo_upload'           => 'doc_jo',
+            'pv_ag_upload'        => 'doc_pv_ag',
+            'cer_upload'          => 'doc_cer',
+            'attestation_cer_upload' => 'doc_attestation_cer',
         );
-        
+
         foreach ( $documents as $upload_key => $db_field ) {
-            if ( ! empty( $_FILES[$upload_key]['name'] ) ) {
+            if ( ! empty( $_FILES[ $upload_key ]['name'] ) ) {
                 $doc_result = UFSC_CL_Uploads::ufsc_safe_handle_upload(
-                    $_FILES[$upload_key],
-                    UFSC_CL_Uploads::get_document_mime_types(),
-                    UFSC_CL_Uploads::get_document_max_size()
+                    $_FILES[ $upload_key ],
+                    $allowed_mimes,
+                    $max_size
                 );
-                
+
                 if ( is_wp_error( $doc_result ) ) {
                     return $doc_result;
                 }
-                
-                $upload_results[$db_field] = $doc_result['url'];
+
+                $upload_results[ $db_field ] = $doc_result['url'];
             }
         }
-        
+
         return $upload_results;
     }
     

--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -196,39 +196,6 @@ class UFSC_CL_Club_Form {
                     </div>
                 </fieldset>
                 
-                <!-- Logo & Web Section -->
-                <fieldset class="ufsc-form-section">
-                    <legend><?php esc_html_e( 'Logo & Web', 'ufsc-clubs' ); ?></legend>
-                    
-                    <div class="ufsc-form-row">
-                        <label for="logo_upload" class="ufsc-label"><?php esc_html_e( 'Logo du club', 'ufsc-clubs' ); ?></label>
-                        <input type="file" id="logo_upload" name="logo_upload" accept=".jpg,.jpeg,.png,.gif" />
-                        <p class="ufsc-description"><?php esc_html_e( 'Formats acceptés : JPG, PNG, GIF. Taille max : 2 MB', 'ufsc-clubs' ); ?></p>
-                        <?php if ( ! empty( $club_data['logo_url'] ) ): ?>
-                            <p class="ufsc-current-file">
-                                <?php esc_html_e( 'Fichier actuel :', 'ufsc-clubs' ); ?> 
-                                <a href="<?php echo esc_url( $club_data['logo_url'] ); ?>" target="_blank"><?php esc_html_e( 'Voir le logo', 'ufsc-clubs' ); ?></a>
-                            </p>
-                        <?php endif; ?>
-                    </div>
-                    
-                    <div class="ufsc-form-row">
-                        <label for="url_site" class="ufsc-label"><?php esc_html_e( 'Site web', 'ufsc-clubs' ); ?></label>
-                        <input type="url" id="url_site" name="url_site" value="<?php echo esc_attr( $club_data['url_site'] ?? '' ); ?>" />
-                    </div>
-                    
-                    <div class="ufsc-form-row ufsc-form-row-inline">
-                        <div class="ufsc-form-col">
-                            <label for="url_facebook" class="ufsc-label"><?php esc_html_e( 'Facebook', 'ufsc-clubs' ); ?></label>
-                            <input type="url" id="url_facebook" name="url_facebook" value="<?php echo esc_attr( $club_data['url_facebook'] ?? '' ); ?>" />
-                        </div>
-                        <div class="ufsc-form-col">
-                            <label for="url_instagram" class="ufsc-label"><?php esc_html_e( 'Instagram', 'ufsc-clubs' ); ?></label>
-                            <input type="url" id="url_instagram" name="url_instagram" value="<?php echo esc_attr( $club_data['url_instagram'] ?? '' ); ?>" />
-                        </div>
-                    </div>
-                </fieldset>
-                
                 <!-- Legal & Financial Section -->
                 <fieldset class="ufsc-form-section">
                     <legend><?php esc_html_e( 'Informations légales et financières', 'ufsc-clubs' ); ?></legend>
@@ -277,11 +244,11 @@ class UFSC_CL_Club_Form {
                     </div>
                 </fieldset>
                 
-                <!-- Legal Documents Section -->
+                <!-- Documents Section -->
                 <fieldset class="ufsc-form-section">
-                    <legend><?php esc_html_e( 'Documents légaux', 'ufsc-clubs' ); ?></legend>
-                    
-                    <?php 
+                    <legend><?php esc_html_e( 'Mes documents', 'ufsc-clubs' ); ?></legend>
+
+                    <?php
                     $documents = array(
                         'doc_statuts' => array( 'label' => __( 'Statuts', 'ufsc-clubs' ), 'required' => $affiliation ),
                         'doc_recepisse' => array( 'label' => __( 'Récépissé', 'ufsc-clubs' ), 'required' => $affiliation ),
@@ -290,19 +257,24 @@ class UFSC_CL_Club_Form {
                         'doc_cer' => array( 'label' => __( 'CER', 'ufsc-clubs' ), 'required' => $affiliation ),
                         'doc_attestation_cer' => array( 'label' => __( 'Attestation CER', 'ufsc-clubs' ), 'required' => false )
                     );
-                    
+
                     foreach ( $documents as $doc_key => $doc_info ):
                         $upload_key = str_replace( 'doc_', '', $doc_key ) . '_upload';
                     ?>
-                        <div class="ufsc-form-row">
+                        <div class="ufsc-field">
                             <label for="<?php echo esc_attr( $upload_key ); ?>" class="ufsc-label <?php echo $doc_info['required'] ? 'required' : ''; ?>">
                                 <?php echo esc_html( $doc_info['label'] ); ?>
                             </label>
-                            <input type="file" id="<?php echo esc_attr( $upload_key ); ?>" name="<?php echo esc_attr( $upload_key ); ?>" accept=".pdf,.jpg,.jpeg,.png" <?php echo $doc_info['required'] ? 'required' : ''; ?> />
-                            <p class="ufsc-description"><?php esc_html_e( 'Formats acceptés : PDF, JPG, PNG. Taille max : 5 MB', 'ufsc-clubs' ); ?></p>
+                            <input type="file"
+                                   id="<?php echo esc_attr( $upload_key ); ?>"
+                                   name="<?php echo esc_attr( $upload_key ); ?>"
+                                   accept=".pdf,.jpg,.jpeg,.png"
+                                   data-max-size="5242880"
+                                   <?php echo $doc_info['required'] ? 'required' : ''; ?> />
+                            <div class="ufsc-field-error" aria-live="polite"></div>
                             <?php if ( ! empty( $club_data[$doc_key] ) ): ?>
                                 <p class="ufsc-current-file">
-                                    <?php esc_html_e( 'Fichier actuel :', 'ufsc-clubs' ); ?> 
+                                    <?php esc_html_e( 'Fichier actuel :', 'ufsc-clubs' ); ?>
                                     <a href="<?php echo esc_url( $club_data[$doc_key] ); ?>" target="_blank"><?php esc_html_e( 'Voir le document', 'ufsc-clubs' ); ?></a>
                                 </p>
                             <?php endif; ?>

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -584,17 +584,17 @@ class UFSC_Frontend_Shortcodes {
                                 <div class="ufsc-document-header">
                                     <h5><?php echo esc_html( $doc_label ); ?></h5>
                                     <span class="ufsc-document-status">
-                                        <?php 
+                                        <?php
                                         $doc_value = isset( $club->$doc_key ) ? $club->$doc_key : '';
                                         if ( ! empty( $doc_value ) ):
                                         ?>
-                                            <span class="ufsc-status-transmitted">✅ <?php esc_html_e( 'Transmis', 'ufsc-clubs' ); ?></span>
+                                            <span class="ufsc-badge ufsc-badge-success" aria-label="<?php esc_attr_e( 'Transmis', 'ufsc-clubs' ); ?>">✅</span>
                                         <?php else: ?>
-                                            <span class="ufsc-status-pending">⏳ <?php esc_html_e( 'En cours de validation', 'ufsc-clubs' ); ?></span>
+                                            <span class="ufsc-badge ufsc-badge-pending" aria-label="<?php esc_attr_e( 'En attente', 'ufsc-clubs' ); ?>">⏳</span>
                                         <?php endif; ?>
                                     </span>
                                 </div>
-                                
+
                                 <div class="ufsc-document-content">
                                     <?php if ( ! empty( $doc_value ) ): ?>
                                         <div class="ufsc-document-current">
@@ -609,12 +609,12 @@ class UFSC_Frontend_Shortcodes {
                                             </div>
                                         </div>
                                     <?php endif; ?>
-                                    
+
                                     <?php if ( $can_edit ): ?>
                                         <div class="ufsc-document-upload">
-                                            <input type="file" 
-                                                   id="<?php echo esc_attr( $doc_key ); ?>_upload" 
-                                                   name="<?php echo esc_attr( $doc_key ); ?>_upload" 
+                                            <input type="file"
+                                                   id="<?php echo esc_attr( $doc_key ); ?>_upload"
+                                                   name="<?php echo esc_attr( $doc_key ); ?>_upload"
                                                    accept=".pdf,.jpg,.jpeg,.png"
                                                    class="ufsc-file-input">
                                             <label for="<?php echo esc_attr( $doc_key ); ?>_upload" class="ufsc-upload-label">
@@ -627,6 +627,7 @@ class UFSC_Frontend_Shortcodes {
                                             <p class="ufsc-help-text">
                                                 <?php esc_html_e( 'Formats: PDF, JPG, PNG - Max 5MB', 'ufsc-clubs' ); ?>
                                             </p>
+                                            <div class="ufsc-upload-feedback" role="status" aria-live="polite"></div>
                                         </div>
                                     <?php endif; ?>
                                 </div>


### PR DESCRIPTION
## Summary
- remove obsolete logo/web block from club form
- add "Mes documents" section with inline validation and feedback badges
- validate document uploads server-side

## Testing
- `php -l includes/frontend/class-club-form.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l includes/frontend/class-club-form-handler.php`
- `phpunit tests/test-frontend.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7da386100832bb46b1bb2b11fb54a