### PR TITLE
Sanitize uploads and track document statuses

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -308,7 +308,7 @@ class UFSC_SQL_Admin {
         // Attestation UFSC section
         echo '<div style="margin-bottom: 20px;">';
         echo '<h4>' . esc_html__( 'Attestation UFSC', 'ufsc-clubs' ) . '</h4>';
-        
+
         $attestation_id = get_option( 'ufsc_club_doc_attestation_ufsc_' . $club_id );
         if ( $attestation_id ) {
             $attestation_url = wp_get_attachment_url( $attestation_id );
@@ -324,13 +324,47 @@ class UFSC_SQL_Admin {
                 echo '</p>';
             }
         }
-        
+
         echo '<p>';
         echo '<label for="attestation_ufsc_upload">' . esc_html__( 'Nouvelle attestation (PDF, JPG, PNG, max 5MB):', 'ufsc-clubs' ) . '</label><br>';
         echo '<input type="file" id="attestation_ufsc_upload" name="attestation_ufsc_upload" accept=".pdf,.jpg,.jpeg,.png">';
         echo '</p>';
         echo '</div>';
-        
+
+        // Other club documents
+        $documents = array(
+            'doc_statuts' => __( 'Statuts', 'ufsc-clubs' ),
+            'doc_recepisse' => __( 'Récépissé', 'ufsc-clubs' ),
+            'doc_jo' => __( 'Journal Officiel', 'ufsc-clubs' ),
+            'doc_pv_ag' => __( 'PV AG', 'ufsc-clubs' ),
+            'doc_cer' => __( 'CER', 'ufsc-clubs' ),
+            'doc_attestation_cer' => __( 'Attestation CER', 'ufsc-clubs' ),
+        );
+
+        $status_options = array(
+            'pending' => __( 'En attente', 'ufsc-clubs' ),
+            'approved' => __( 'Approuvé', 'ufsc-clubs' ),
+            'rejected' => __( 'Rejeté', 'ufsc-clubs' ),
+        );
+
+        foreach ( $documents as $doc_key => $label ) {
+            $url = get_post_meta( $club_id, $doc_key, true );
+            $status = get_post_meta( $club_id, $doc_key . '_status', true );
+            echo '<div style="margin-bottom: 20px;">';
+            echo '<h4>' . esc_html( $label ) . '</h4>';
+            if ( $url ) {
+                echo '<p><a href="' . esc_url( $url ) . '" target="_blank" class="button">' . esc_html__( 'Télécharger', 'ufsc-clubs' ) . '</a></p>';
+            } else {
+                echo '<p>' . esc_html__( 'Aucun fichier.', 'ufsc-clubs' ) . '</p>';
+            }
+            echo '<p><label>' . esc_html__( 'Statut:', 'ufsc-clubs' ) . ' <select name="' . esc_attr( $doc_key . '_status' ) . '">';
+            foreach ( $status_options as $value => $label_option ) {
+                echo '<option value="' . esc_attr( $value ) . '" ' . selected( $status, $value, false ) . '>' . esc_html( $label_option ) . '</option>';
+            }
+            echo '</select></label></p>';
+            echo '</div>';
+        }
+
         echo '</div>';
     }
 
@@ -437,6 +471,15 @@ class UFSC_SQL_Admin {
             // Handle file uploads after club is saved/updated
             if ( $id ) {
                 self::handle_club_document_uploads( $id );
+
+                // Update document statuses
+                $documents = array( 'doc_statuts', 'doc_recepisse', 'doc_jo', 'doc_pv_ag', 'doc_cer', 'doc_attestation_cer' );
+                foreach ( $documents as $doc_key ) {
+                    if ( isset( $_POST[ $doc_key . '_status' ] ) ) {
+                        $status = sanitize_text_field( $_POST[ $doc_key . '_status' ] );
+                        update_post_meta( $id, $doc_key . '_status', $status );
+                    }
+                }
             }
 
             wp_safe_redirect( admin_url('admin.php?page=ufsc-sql-clubs&action=edit&id='.$id.'&updated=1') );

--- a/includes/core/class-uploads.php
+++ b/includes/core/class-uploads.php
@@ -57,8 +57,16 @@ class UFSC_CL_Uploads {
             require_once ABSPATH . 'wp-admin/includes/image.php';
         }
         
-        // Handle upload
-        $upload_overrides = array( 'test_form' => false );
+        // Handle upload with custom filename sanitization
+        $upload_overrides = array(
+            'test_form' => false,
+            'unique_filename_callback' => function( $dir, $name, $ext ) {
+                $name = remove_accents( $name );
+                $name = sanitize_file_name( $name );
+                $hash = substr( md5( uniqid( '', true ) ), 0, 8 );
+                return $name . '-' . $hash . $ext;
+            },
+        );
         $uploaded_file = wp_handle_upload( $file, $upload_overrides );
         
         if ( isset( $uploaded_file['error'] ) ) {

--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -204,9 +204,9 @@ class UFSC_CL_Club_Form {
                         <label for="logo_upload" class="ufsc-label"><?php esc_html_e( 'Logo du club', 'ufsc-clubs' ); ?></label>
                         <input type="file" id="logo_upload" name="logo_upload" accept=".jpg,.jpeg,.png,.gif" />
                         <p class="ufsc-description"><?php esc_html_e( 'Formats acceptés : JPG, PNG, GIF. Taille max : 2 MB', 'ufsc-clubs' ); ?></p>
-                        <?php if ( ! empty( $club_data['logo_url'] ) ): ?>
+                        <?php if ( ! empty( $club_data['logo_url'] ) && UFSC_CL_Permissions::ufsc_user_can_edit_club( $club_id ) ): ?>
                             <p class="ufsc-current-file">
-                                <?php esc_html_e( 'Fichier actuel :', 'ufsc-clubs' ); ?> 
+                                <?php esc_html_e( 'Fichier actuel :', 'ufsc-clubs' ); ?>
                                 <a href="<?php echo esc_url( $club_data['logo_url'] ); ?>" target="_blank"><?php esc_html_e( 'Voir le logo', 'ufsc-clubs' ); ?></a>
                             </p>
                         <?php endif; ?>
@@ -300,9 +300,9 @@ class UFSC_CL_Club_Form {
                             </label>
                             <input type="file" id="<?php echo esc_attr( $upload_key ); ?>" name="<?php echo esc_attr( $upload_key ); ?>" accept=".pdf,.jpg,.jpeg,.png" <?php echo $doc_info['required'] ? 'required' : ''; ?> />
                             <p class="ufsc-description"><?php esc_html_e( 'Formats acceptés : PDF, JPG, PNG. Taille max : 5 MB', 'ufsc-clubs' ); ?></p>
-                            <?php if ( ! empty( $club_data[$doc_key] ) ): ?>
+                            <?php if ( ! empty( $club_data[$doc_key] ) && UFSC_CL_Permissions::ufsc_user_can_edit_club( $club_id ) ): ?>
                                 <p class="ufsc-current-file">
-                                    <?php esc_html_e( 'Fichier actuel :', 'ufsc-clubs' ); ?> 
+                                    <?php esc_html_e( 'Fichier actuel :', 'ufsc-clubs' ); ?>
                                     <a href="<?php echo esc_url( $club_data[$doc_key] ); ?>" target="_blank"><?php esc_html_e( 'Voir le document', 'ufsc-clubs' ); ?></a>
                                 </p>
                             <?php endif; ?>


### PR DESCRIPTION
## Summary
- sanitize upload filenames by removing accents and appending hash
- store uploaded document URLs in post meta with initial pending status
- restrict document links to club owners and expose document management in admin

## Testing
- `php -l includes/core/class-uploads.php`
- `php -l includes/frontend/class-club-form-handler.php`
- `php -l includes/frontend/class-club-form.php`
- `php -l includes/admin/class-sql-admin.php`
- `php tests/integration-test.php` *(no output)*
- `php tests/test-frontend.php` *(fatal: Class "PHPUnit\\Framework\\TestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dc2f7278832bb880aaf9ef29249a