### PR TITLE
Fix PHP block closure before documents section

### DIFF
--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -284,9 +284,9 @@ class UFSC_CL_Club_Form {
                 <!-- Legal Documents Section -->
                 <fieldset class="ufsc-form-section ufsc-grid">
                     <legend><?php esc_html_e( 'Documents légaux', 'ufsc-clubs' ); ?></legend>
-                    
-                    <?php 
 
+                    <?php
+                    ?>
                 <!-- Documents Section -->
                 <fieldset class="ufsc-form-section">
                     <legend><?php esc_html_e( 'Mes documents', 'ufsc-clubs' ); ?></legend>
@@ -327,6 +327,7 @@ class UFSC_CL_Club_Form {
                                     <?php esc_html_e( 'Fichier actuel :', 'ufsc-clubs' ); ?>
                                     <a href="<?php echo esc_url( $club_data[$doc_key] ); ?>" target="_blank"><?php esc_html_e( 'Voir le document', 'ufsc-clubs' ); ?></a>
                                 </p>
+                            <?php endif; ?>
                             <?php endif; ?>
                         <div class="ufsc-field-error" aria-live="polite"></div></div>
                     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Close stray PHP block before documents section in club form
- Add missing endif for document upload conditional

## Testing
- `php -l includes/frontend/class-club-form.php`
- `vendor/bin/phpunit tests/` *(fails: No such file or directory)*
- `composer global require phpunit/phpunit --quiet` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e43f831c832b9ce6b566da07d081