### PR TITLE
Remove duplicate licence handlers

### DIFF
--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -45,23 +45,6 @@ class UFSC_Unified_Handlers {
         add_action( 'wp_ajax_nopriv_ufsc_export_stats', array( __CLASS__, 'ajax_export_stats' ) );
     }
 
-    /**
-
-     * Handle licence creation
-
-     * Handle add licence form submission
-     */
-    public static function handle_add_licence() {
-        self::process_licence_request( 0 );
-    }
-
-    /**
-     * Handle update licence form submission
-     */
-    public static function handle_update_licence() {
-        $licence_id = isset( $_POST['licence_id'] ) ? intval( $_POST['licence_id'] ) : 0;
-        self::process_licence_request( $licence_id );
-    }
 
     /**
      * // UFSC: Handle license save (create/update)


### PR DESCRIPTION
## Summary
- delete stub `handle_add_licence` and `handle_update_licence` methods from Unified Handlers class
- keep full implementations to avoid duplicate method definitions

## Testing
- `php -l includes/core/class-unified-handlers.php`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e6bbad04832baccbb5c3cb2ac1c0