### PR TITLE
Clean up unified handlers callbacks

### DIFF
--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -13,8 +13,6 @@ class UFSC_Unified_Handlers {
     public static function init() {
         // License handlers
 
-        add_action( 'admin_post_ufsc_save_licence', array( __CLASS__, 'handle_save_licence' ) );
-        add_action( 'admin_post_nopriv_ufsc_save_licence', array( __CLASS__, 'handle_save_licence' ) );
 
         add_action( 'admin_post_ufsc_add_licence', array( __CLASS__, 'handle_add_licence' ) );
         add_action( 'admin_post_nopriv_ufsc_add_licence', array( __CLASS__, 'handle_add_licence' ) );
@@ -43,24 +41,6 @@ class UFSC_Unified_Handlers {
         add_action( 'admin_post_nopriv_ufsc_export_stats', array( __CLASS__, 'handle_export_stats' ) );
         add_action( 'wp_ajax_ufsc_export_stats', array( __CLASS__, 'ajax_export_stats' ) );
         add_action( 'wp_ajax_nopriv_ufsc_export_stats', array( __CLASS__, 'ajax_export_stats' ) );
-    }
-
-    /**
-
-     * Handle licence creation
-
-     * Handle add licence form submission
-     */
-    public static function handle_add_licence() {
-        self::process_licence_request( 0 );
-    }
-
-    /**
-     * Handle update licence form submission
-     */
-    public static function handle_update_licence() {
-        $licence_id = isset( $_POST['licence_id'] ) ? intval( $_POST['licence_id'] ) : 0;
-        self::process_licence_request( $licence_id );
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove unused `admin_post_ufsc_save_licence` hooks
- drop duplicate placeholder handler methods so callbacks map to real methods

## Testing
- `php -l includes/core/class-unified-handlers.php`
- `php tests/integration-test.php` *(no output)*
- `php tests/test-frontend.php` *(fails: Class "PHPUnit\Framework\TestCase" not found)*
- `sudo apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e6bea908832bb028b3cc36643a2d