### PR TITLE
Implement SQL-backed helpers for licence import/export

### DIFF
--- a/includes/core/class-import-export.php
+++ b/includes/core/class-import-export.php
@@ -460,27 +460,102 @@ class UFSC_Import_Export {
     // STUB METHODS - To be implemented according to database schema
 
     private static function get_club_licences_for_export( $club_id, $filters ) {
-        // TODO: Implement actual licence retrieval for export
-        return array();
+        global $wpdb;
+
+        $settings        = UFSC_SQL::get_settings();
+        $licences_table  = $settings['table_licences'];
+
+        $where  = array( 'club_id = %d' );
+        $values = array( $club_id );
+
+        if ( ! empty( $filters['status'] ) ) {
+            $where[]  = 'statut = %s';
+            $values[] = sanitize_text_field( $filters['status'] );
+        }
+
+        if ( ! empty( $filters['season'] ) ) {
+            $season_col = ufsc_get_mapped_column_if_exists( $licences_table, 'season', 'licences' );
+            if ( $season_col ) {
+                $where[]  = "`{$season_col}` = %s";
+                $values[] = sanitize_text_field( $filters['season'] );
+            }
+        }
+
+        $sql = "SELECT id, nom, prenom, email, telephone, date_naissance, sexe, adresse, ville, code_postal, statut, date_creation, date_validation
+                FROM {$licences_table}
+                WHERE " . implode( ' AND ', $where );
+
+        $results = $wpdb->get_results( $wpdb->prepare( $sql, $values ), ARRAY_A );
+
+        return is_array( $results ) ? $results : array();
     }
 
     private static function get_club_name( $club_id ) {
-        // TODO: Implement club name retrieval
-        return "Club_{$club_id}";
+        global $wpdb;
+
+        $settings    = UFSC_SQL::get_settings();
+        $clubs_table = $settings['table_clubs'];
+
+        $name_col = ufsc_club_col( 'name' );
+
+        $name = $wpdb->get_var( $wpdb->prepare(
+            "SELECT {$name_col} FROM {$clubs_table} WHERE id = %d",
+            $club_id
+        ) );
+
+        return $name ? $name : "Club_{$club_id}";
     }
 
     private static function get_club_quota_info( $club_id ) {
-        // TODO: Implement quota info retrieval
-        return array( 'total' => 10, 'used' => 3, 'remaining' => 7 );
+        global $wpdb;
+
+        $settings       = UFSC_SQL::get_settings();
+        $clubs_table    = $settings['table_clubs'];
+        $licences_table = $settings['table_licences'];
+
+        $quota_total = (int) $wpdb->get_var( $wpdb->prepare(
+            "SELECT quota_licences FROM {$clubs_table} WHERE id = %d",
+            $club_id
+        ) );
+
+        $used = (int) $wpdb->get_var( $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$licences_table} WHERE club_id = %d",
+            $club_id
+        ) );
+
+        return array(
+            'total'     => $quota_total,
+            'used'      => $used,
+            'remaining' => max( 0, $quota_total - $used )
+        );
     }
 
     private static function create_licence_record( $club_id, $data ) {
-        // TODO: Implement licence creation
-        return 0;
+        global $wpdb;
+
+        $settings       = UFSC_SQL::get_settings();
+        $licences_table = $settings['table_licences'];
+
+        $insert_data = array_merge( $data, array(
+            'club_id'       => $club_id,
+            'date_creation' => current_time( 'mysql' )
+        ) );
+
+        $result = $wpdb->insert( $licences_table, $insert_data );
+
+        if ( $result === false ) {
+            error_log( 'UFSC: Failed to insert licence - ' . $wpdb->last_error );
+            return 0;
+        }
+
+        return (int) $wpdb->insert_id;
     }
 
     private static function create_payment_order( $club_id, $licence_ids ) {
-        // TODO: Implement payment order creation
+        if ( ! function_exists( 'ufsc_create_additional_license_order' ) ) {
+            return false;
+        }
+
         return ufsc_create_additional_license_order( $club_id, $licence_ids, get_current_user_id() );
     }
 }


### PR DESCRIPTION
## Summary
- Implement SQL queries for licence export helpers
- Fetch club name and quota information from database
- Insert licences and create payment orders with error handling

## Testing
- `php -l includes/core/class-import-export.php`
- `php -r "require 'tests/integration-test.php'; UFSC_Club_Form_Integration_Test::run_all_tests();"` *(fails: Shortcode [ufsc_club_form] is NOT registered)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e7291b58832bb2e5ec7e1ad0cb10