### PR TITLE
Implement unified licence save handler

### DIFF
--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -47,8 +47,16 @@ class UFSC_Unified_Handlers {
 
 
     /**
-     * // UFSC: Handle license save (create/update)
+     * Handle licence save (create or update based on presence of licence_id).
+     */
+    public static function handle_save_licence() {
+        $licence_id = isset( $_POST['licence_id'] ) ? intval( $_POST['licence_id'] ) : 0;
 
+        self::process_licence_request( $licence_id );
+    }
+
+    /**
+     * Handle licence creation.
      */
     public static function handle_add_licence() {
         if ( ! wp_verify_nonce( $_POST['ufsc_nonce'], 'ufsc_add_licence' ) ) {
@@ -357,7 +365,7 @@ class UFSC_Unified_Handlers {
             }
         }
 
-        $data = self::validate_licence_data( $_POST );
+        $data = self::process_licence_data( $_POST );
         if ( is_wp_error( $data ) ) {
             self::store_form_and_redirect( $_POST, array( $data->get_error_message() ), $licence_id );
         }


### PR DESCRIPTION
## Summary
- add `handle_save_licence` to process create and update requests
- ensure licence request handler uses existing data processor

## Testing
- `php -l includes/core/class-unified-handlers.php`
- `php tests/integration-test.php` *(no output)*
- `php tests/test-frontend.php` *(fails: Class "PHPUnit\Framework\TestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e7e89f7c832ba39db69d1c649b9f