### PR TITLE
Add WP_List_Table classes for clubs and licences

### DIFF
--- a/inc/admin/class-ufsc-gestion-clubs-list-table.php
+++ b/inc/admin/class-ufsc-gestion-clubs-list-table.php
@@ -1,0 +1,147 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * WP_List_Table implementation for UFSC clubs.
+ */
+class UFSC_Gestion_Clubs_List_Table extends WP_List_Table {
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        parent::__construct(
+            array(
+                'singular' => 'ufsc_club',
+                'plural'   => 'ufsc_clubs',
+                'ajax'     => false,
+            )
+        );
+    }
+
+    /**
+     * Retrieve table columns.
+     *
+     * @return array
+     */
+    public function get_columns() {
+        return array(
+            'cb'             => '<input type="checkbox" />',
+            'nom'            => __( 'Nom', 'ufsc-clubs' ),
+            'region'         => __( 'Région', 'ufsc-clubs' ),
+            'statut'         => __( 'Statut', 'ufsc-clubs' ),
+            'quota_licences' => __( 'Quota', 'ufsc-clubs' ),
+            'date_creation'  => __( 'Créé le', 'ufsc-clubs' ),
+        );
+    }
+
+    /**
+     * Sortable columns.
+     */
+    protected function get_sortable_columns() {
+        return array(
+            'nom'           => array( 'nom', false ),
+            'region'        => array( 'region', false ),
+            'date_creation' => array( 'date_creation', true ),
+        );
+    }
+
+    /**
+     * Bulk actions.
+     */
+    protected function get_bulk_actions() {
+        return array(
+            'delete' => __( 'Supprimer', 'ufsc-clubs' ),
+        );
+    }
+
+    /**
+     * Checkbox column.
+     */
+    protected function column_cb( $item ) {
+        return sprintf( '<input type="checkbox" name="club_ids[]" value="%d" />', $item['id'] );
+    }
+
+    /**
+     * Render club name column with row actions.
+     */
+    protected function column_nom( $item ) {
+        $edit_url   = admin_url( 'admin.php?page=ufsc-gestion-clubs&action=edit&id=' . $item['id'] );
+        $delete_url = wp_nonce_url( admin_url( 'admin-post.php?action=ufsc_sql_delete_club&id=' . $item['id'] ), 'ufsc_sql_delete_club' );
+
+        $actions = array(
+            'edit'   => sprintf( '<a href="%s">%s</a>', esc_url( $edit_url ), __( 'Modifier', 'ufsc-clubs' ) ),
+            'delete' => sprintf( '<a href="%s">%s</a>', esc_url( $delete_url ), __( 'Supprimer', 'ufsc-clubs' ) ),
+        );
+
+        return sprintf( '<strong>%1$s</strong> %2$s', esc_html( $item['nom'] ), $this->row_actions( $actions ) );
+    }
+
+    /**
+     * Default column handler.
+     */
+    protected function column_default( $item, $column_name ) {
+        switch ( $column_name ) {
+            case 'region':
+            case 'statut':
+            case 'quota_licences':
+                return esc_html( $item[ $column_name ] );
+            case 'date_creation':
+                return esc_html( mysql2date( 'Y-m-d', $item['date_creation'] ) );
+            default:
+                return '';
+        }
+    }
+
+    /**
+     * Message displayed when no items found.
+     */
+    public function no_items() {
+        esc_html_e( 'Aucun club trouvé.', 'ufsc-clubs' );
+    }
+
+    /**
+     * Prepare table items.
+     */
+    public function prepare_items() {
+        global $wpdb;
+
+        $clubs_table = ufsc_get_clubs_table();
+        $per_page    = 20;
+        $current_page = $this->get_pagenum();
+        $offset       = ( $current_page - 1 ) * $per_page;
+
+        $allowed_orderby = array( 'id', 'nom', 'region', 'statut', 'quota_licences', 'date_creation' );
+        $orderby = isset( $_REQUEST['orderby'] ) && in_array( $_REQUEST['orderby'], $allowed_orderby, true ) ? $_REQUEST['orderby'] : 'date_creation';
+        $order   = isset( $_REQUEST['order'] ) && 'asc' === strtolower( $_REQUEST['order'] ) ? 'ASC' : 'DESC';
+
+        $total_items = (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$clubs_table}`" );
+
+        $query = $wpdb->prepare(
+            "SELECT id, nom, region, statut, quota_licences, date_creation FROM `{$clubs_table}` ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d",
+            $per_page,
+            $offset
+        );
+
+        $items = $wpdb->get_results( $query, ARRAY_A );
+
+        $this->items = $items;
+
+        $this->set_pagination_args(
+            array(
+                'total_items' => $total_items,
+                'per_page'    => $per_page,
+            )
+        );
+
+        $columns  = $this->get_columns();
+        $hidden   = array();
+        $sortable = $this->get_sortable_columns();
+        $this->_column_headers = array( $columns, $hidden, $sortable );
+    }
+}
+

--- a/inc/admin/class-ufsc-gestion-licences-list-table.php
+++ b/inc/admin/class-ufsc-gestion-licences-list-table.php
@@ -1,0 +1,126 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * WP_List_Table implementation for UFSC licences.
+ */
+class UFSC_Gestion_Licences_List_Table extends WP_List_Table {
+
+    public function __construct() {
+        parent::__construct(
+            array(
+                'singular' => 'ufsc_licence',
+                'plural'   => 'ufsc_licences',
+                'ajax'     => false,
+            )
+        );
+    }
+
+    /**
+     * Table columns.
+     */
+    public function get_columns() {
+        return array(
+            'cb'            => '<input type="checkbox" />',
+            'full_name'     => __( 'Nom', 'ufsc-clubs' ),
+            'club_nom'      => __( 'Club', 'ufsc-clubs' ),
+            'statut'        => __( 'Statut', 'ufsc-clubs' ),
+            'payment_status'=> __( 'Paiement', 'ufsc-clubs' ),
+            'date_creation' => __( 'Créée le', 'ufsc-clubs' ),
+        );
+    }
+
+    protected function get_sortable_columns() {
+        return array(
+            'full_name'     => array( 'full_name', false ),
+            'club_nom'      => array( 'club_nom', false ),
+            'date_creation' => array( 'date_creation', true ),
+        );
+    }
+
+    protected function get_bulk_actions() {
+        return array(
+            'delete' => __( 'Supprimer', 'ufsc-clubs' ),
+        );
+    }
+
+    protected function column_cb( $item ) {
+        return sprintf( '<input type="checkbox" name="licence_ids[]" value="%d" />', $item['id'] );
+    }
+
+    protected function column_full_name( $item ) {
+        $edit_url   = admin_url( 'admin.php?page=ufsc-gestion-licences&action=edit&id=' . $item['id'] );
+        $delete_url = wp_nonce_url( admin_url( 'admin-post.php?action=ufsc_sql_delete_licence&id=' . $item['id'] ), 'ufsc_sql_delete_licence' );
+
+        $actions = array(
+            'edit'   => sprintf( '<a href="%s">%s</a>', esc_url( $edit_url ), __( 'Modifier', 'ufsc-clubs' ) ),
+            'delete' => sprintf( '<a href="%s">%s</a>', esc_url( $delete_url ), __( 'Supprimer', 'ufsc-clubs' ) ),
+        );
+
+        return sprintf( '<strong>%1$s</strong> %2$s', esc_html( $item['full_name'] ), $this->row_actions( $actions ) );
+    }
+
+    protected function column_default( $item, $column_name ) {
+        switch ( $column_name ) {
+            case 'club_nom':
+            case 'statut':
+            case 'payment_status':
+                return esc_html( $item[ $column_name ] );
+            case 'date_creation':
+                return esc_html( mysql2date( 'Y-m-d', $item['date_creation'] ) );
+            default:
+                return '';
+        }
+    }
+
+    public function no_items() {
+        esc_html_e( 'Aucune licence trouvée.', 'ufsc-clubs' );
+    }
+
+    public function prepare_items() {
+        global $wpdb;
+
+        $licences_table = ufsc_get_licences_table();
+        $clubs_table    = ufsc_get_clubs_table();
+        $per_page       = 20;
+        $current_page   = $this->get_pagenum();
+        $offset         = ( $current_page - 1 ) * $per_page;
+
+        $allowed_orderby = array( 'full_name', 'club_nom', 'statut', 'payment_status', 'date_creation', 'id' );
+        $orderby = isset( $_REQUEST['orderby'] ) && in_array( $_REQUEST['orderby'], $allowed_orderby, true ) ? $_REQUEST['orderby'] : 'date_creation';
+        $order   = isset( $_REQUEST['order'] ) && 'asc' === strtolower( $_REQUEST['order'] ) ? 'ASC' : 'DESC';
+
+        $total_items = (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$licences_table}`" );
+
+        $query = $wpdb->prepare(
+            "SELECT l.id, CONCAT(l.prenom, ' ', l.nom_licence) AS full_name, c.nom AS club_nom, l.statut, l.payment_status, l.date_creation
+             FROM `{$licences_table}` l
+             LEFT JOIN `{$clubs_table}` c ON l.club_id = c.id
+             ORDER BY {$orderby} {$order}
+             LIMIT %d OFFSET %d",
+            $per_page,
+            $offset
+        );
+
+        $items = $wpdb->get_results( $query, ARRAY_A );
+
+        $this->items = $items;
+
+        $this->set_pagination_args(
+            array(
+                'total_items' => $total_items,
+                'per_page'    => $per_page,
+            )
+        );
+
+        $columns  = $this->get_columns();
+        $hidden   = array();
+        $sortable = $this->get_sortable_columns();
+        $this->_column_headers = array( $columns, $hidden, $sortable );
+    }
+}
+

--- a/inc/admin/menu.php
+++ b/inc/admin/menu.php
@@ -176,21 +176,27 @@ function ufsc_render_dashboard_page() {
  * Render clubs page placeholder
  */
 function ufsc_render_clubs_page() {
+    require_once __DIR__ . '/class-ufsc-gestion-clubs-list-table.php';
+    $list_table = new UFSC_Gestion_Clubs_List_Table();
+    $list_table->prepare_items();
     ?>
     <div class="wrap">
         <h1><?php esc_html_e( 'Gestion des Clubs', 'ufsc-clubs' ); ?></h1>
         <div class="notice notice-info">
-            <p><?php esc_html_e( 'Cette page sera connectée à la table clubs via WP_List_Table.', 'ufsc-clubs' ); ?></p>
+            <p><?php esc_html_e( 'Liste des clubs provenant de la base de données.', 'ufsc-clubs' ); ?></p>
             <p><?php esc_html_e( 'Table configurée:', 'ufsc-clubs' ); ?> <strong><?php echo esc_html( ufsc_get_clubs_table() ); ?></strong></p>
         </div>
-        
+
         <p>
             <a href="<?php echo admin_url( 'admin.php?page=ufsc-gestion-clubs&action=new' ); ?>" class="button button-primary">
                 <?php esc_html_e( 'Ajouter un club', 'ufsc-clubs' ); ?>
             </a>
         </p>
-        
-        <!-- TODO: Implement WP_List_Table for clubs -->
+
+        <form method="get">
+            <input type="hidden" name="page" value="ufsc-gestion-clubs" />
+            <?php $list_table->display(); ?>
+        </form>
     </div>
     <?php
 }
@@ -199,22 +205,28 @@ function ufsc_render_clubs_page() {
  * Render licences page placeholder
  */
 function ufsc_render_licences_page() {
+    require_once __DIR__ . '/class-ufsc-gestion-licences-list-table.php';
+    $list_table = new UFSC_Gestion_Licences_List_Table();
+    $list_table->prepare_items();
     ?>
     <div class="wrap">
         <h1><?php esc_html_e( 'Gestion des Licences', 'ufsc-clubs' ); ?></h1>
         <div class="notice notice-info">
-            <p><?php esc_html_e( 'Cette page sera connectée à la table licences via WP_List_Table.', 'ufsc-clubs' ); ?></p>
+            <p><?php esc_html_e( 'Liste des licences provenant de la base de données.', 'ufsc-clubs' ); ?></p>
             <p><?php esc_html_e( 'Table configurée:', 'ufsc-clubs' ); ?> <strong><?php echo esc_html( ufsc_get_licences_table() ); ?></strong></p>
         </div>
-        
+
         <p>
             <a href="<?php echo admin_url( 'admin.php?page=ufsc-gestion-licences&action=new' ); ?>" class="button button-primary">
                 <?php esc_html_e( 'Ajouter une licence', 'ufsc-clubs' ); ?>
             </a>
         </p>
-        
-        <!-- TODO: Implement WP_List_Table for licences -->
-        
+
+        <form method="get">
+            <input type="hidden" name="page" value="ufsc-gestion-licences" />
+            <?php $list_table->display(); ?>
+        </form>
+
         <h3><?php esc_html_e( 'Actions sur les licences sélectionnées', 'ufsc-clubs' ); ?></h3>
         <form method="post" action="<?php echo admin_url( 'admin-post.php' ); ?>">
             <?php wp_nonce_field( 'ufsc_send_to_payment' ); ?>
@@ -222,7 +234,7 @@ function ufsc_render_licences_page() {
             <input type="hidden" name="club_id" value="1" />
             <input type="hidden" name="license_ids[]" value="1" />
             <input type="hidden" name="license_ids[]" value="2" />
-            
+
             <p>
                 <input type="submit" class="button button-secondary" value="<?php esc_attr_e( 'Envoyer au paiement (exemple)', 'ufsc-clubs' ); ?>" />
             </p>
@@ -236,7 +248,6 @@ function ufsc_render_licences_page() {
 
 /**
  * Get clubs count from database
- * TODO: Implement according to existing database schema
  */
 function ufsc_get_clubs_count() {
     global $wpdb;
@@ -253,7 +264,6 @@ function ufsc_get_clubs_count() {
 
 /**
  * Get licences count from database
- * TODO: Implement according to existing database schema
  */
 function ufsc_get_licences_count() {
     global $wpdb;
@@ -270,3 +280,4 @@ function ufsc_get_licences_count() {
 
 // Register the menu
 add_action( 'admin_menu', 'ufsc_register_admin_menu' );
+


### PR DESCRIPTION
## Summary
- implement WP_List_Table subclasses to list clubs and licences from database
- wire list tables into admin pages
- query database for club and licence counts

## Testing
- `php -l inc/admin/menu.php`
- `php -l inc/admin/class-ufsc-gestion-clubs-list-table.php`
- `php -l inc/admin/class-ufsc-gestion-licences-list-table.php`
- `php tests/integration-test.php`
- `php tests/test-frontend.php` *(fails: Class `PHPUnit\Framework\TestCase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e746aee8832b94e33f3d332d2855