### PR TITLE
Implement club quota and payment utilities

### DIFF
--- a/inc/woocommerce/admin-actions.php
+++ b/inc/woocommerce/admin-actions.php
@@ -7,52 +7,37 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  */
 
 /**
- * Check if club should be charged for additional licenses
- * TODO: Implement according to existing database schema
- * 
- * @param int $club_id Club ID
- * @param string $season Season identifier
- * @return bool True if club has exhausted included quota
+ * Check if a club has exhausted its licence quota.
+ *
+ * The implementation compares the number of licences created for the club
+ * with the quota stored in the clubs table. If the quota is reached or
+ * exceeded, any additional licence should be charged.
+ *
+ * @param int    $club_id Club ID.
+ * @param string $season  Season identifier (unused).
+ * @return bool  True if quota exhausted, false otherwise.
  */
 function ufsc_should_charge_license( $club_id, $season ) {
-    // STUB: This should check if the club has exhausted its included quota
-    // Implementation depends on how quota tracking is implemented in the database
-    
-    // Example logic (to be implemented according to actual schema):
-    /*
     global $wpdb;
-    $clubs_table = ufsc_get_clubs_table();
+
+    $clubs_table    = ufsc_get_clubs_table();
     $licences_table = ufsc_get_licences_table();
-    
-    // Get total credits from paid packs for this season
-    $pack_credits = $wpdb->get_var( $wpdb->prepare(
-        "SELECT COALESCE(SUM(quota_included), 0) FROM {$clubs_table} 
-         WHERE id = %d AND affiliation_paid_season = %s",
-        $club_id,
-        $season
-    ) );
-    
-    // Get total paid additional licenses
-    $paid_additional = $wpdb->get_var( $wpdb->prepare(
-        "SELECT COALESCE(SUM(quota_paid), 0) FROM {$clubs_table} 
-         WHERE id = %d",
-        $club_id
-    ) );
-    
-    // Get total licenses used (both included and paid)
-    $used_licenses = $wpdb->get_var( $wpdb->prepare(
-        "SELECT COUNT(*) FROM {$licences_table} 
-         WHERE club_id = %d AND (is_included = 1 OR paid_season = %s)",
-        $club_id,
-        $season
-    ) );
-    
-    $total_available = $pack_credits + $paid_additional;
-    return $used_licenses >= $total_available;
-    */
-    
-    // Temporary implementation for testing
-    return false;
+
+    $quota_total = (int) $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT quota_licences FROM {$clubs_table} WHERE id = %d",
+            $club_id
+        )
+    );
+
+    $used = (int) $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$licences_table} WHERE club_id = %d",
+            $club_id
+        )
+    );
+
+    return $used >= $quota_total && $quota_total >= 0;
 }
 
 /**
@@ -239,30 +224,22 @@ function ufsc_handle_admin_send_to_payment() {
 
 /**
  * Get responsible user ID for a club
- * TODO: Implement according to existing database schema
- * 
+ *
  * @param int $club_id Club ID
  * @return int|false User ID or false if not found
  */
 function ufsc_get_club_responsible_user_id( $club_id ) {
-    // STUB: This should query the existing database to find the responsible user for this club
-    // Implementation depends on how the relationship is stored
-    
-    // Example implementation (to be adjusted):
-    /*
     global $wpdb;
+
     $clubs_table = ufsc_get_clubs_table();
-    
-    $user_id = $wpdb->get_var( $wpdb->prepare(
-        "SELECT responsable_id FROM {$clubs_table} WHERE id = %d",
-        $club_id
-    ) );
-    
+    $user_id     = $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT responsable_id FROM {$clubs_table} WHERE id = %d",
+            $club_id
+        )
+    );
+
     return $user_id ? (int) $user_id : false;
-    */
-    
-    // Temporary fallback
-    return false;
 }
 
 // Register admin action

--- a/inc/woocommerce/cart-integration.php
+++ b/inc/woocommerce/cart-integration.php
@@ -151,24 +151,23 @@ function ufsc_display_cart_item_data( $item_data, $cart_item ) {
  * @return string|false Club name or false if not found
  */
 function ufsc_get_club_name( $club_id ) {
-    // STUB: This should query the existing database to get the club name
-    // Implementation depends on the actual database schema
-    
-    // Example implementation (to be adjusted):
-    /*
     global $wpdb;
+
+    // Retrieve club name from configured clubs table
     $clubs_table = ufsc_get_clubs_table();
-    
-    $club_name = $wpdb->get_var( $wpdb->prepare(
-        "SELECT nom FROM {$clubs_table} WHERE id = %d",
-        $club_id
-    ) );
-    
-    return $club_name ?: false;
-    */
-    
-    // Temporary fallback
-    return sprintf( __( 'Club #%d', 'ufsc-clubs' ), $club_id );
+    $club_name   = $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT nom FROM {$clubs_table} WHERE id = %d",
+            $club_id
+        )
+    );
+
+    // Return false if club not found
+    if ( null === $club_name ) {
+        return false;
+    }
+
+    return $club_name;
 }
 
 /**

--- a/inc/woocommerce/hooks.php
+++ b/inc/woocommerce/hooks.php
@@ -161,103 +161,78 @@ if ( ! function_exists( 'ufsc_get_user_club_id' ) ) {
  */
 if ( ! function_exists( 'ufsc_mark_affiliation_paid' ) ) {
     function ufsc_mark_affiliation_paid( $club_id, $season ) {
-        // STUB: This should update the club record to mark affiliation as paid for the season
-        // Implementation depends on how affiliation payment status is stored
-        
-        // Example implementation (to be adjusted):
-        /*
         global $wpdb;
+
         $clubs_table = ufsc_get_clubs_table();
-        
+
+        // Update affiliation date to mark payment
         $wpdb->update(
             $clubs_table,
-            array( 'affiliation_paid_' . str_replace( '-', '_', $season ) => 1 ),
+            array( 'date_affiliation' => current_time( 'mysql' ) ),
             array( 'id' => $club_id ),
-            array( '%d' ),
+            array( '%s' ),
             array( '%d' )
         );
-        */
     }
 }
 
 /**
  * Mark a specific license as paid
- * TODO: Implement according to existing database schema
- * 
+ *
  * @param int $license_id License ID
  * @param string $season Season identifier
  */
 if ( ! function_exists( 'ufsc_mark_licence_paid' ) ) {
     function ufsc_mark_licence_paid( $license_id, $season ) {
-        // STUB: This should update the license record to mark it as paid for the season
-        // Implementation depends on how license payment status is stored
-        
-        // Example implementation (to be adjusted):
-        /*
         global $wpdb;
+
         $licences_table = ufsc_get_licences_table();
-        
         $wpdb->update(
             $licences_table,
-            array( 'paid_season' => $season, 'is_included' => 0 ),
+            array( 'statut' => 'en_attente', 'is_included' => 0 ),
             array( 'id' => $license_id ),
             array( '%s', '%d' ),
             array( '%d' )
         );
-        */
     }
 }
 
 /**
  * Add included licenses to club quota
- * TODO: Implement according to existing database schema
- * 
+ *
  * @param int $club_id Club ID
  * @param int $quantity Number of licenses to add
  * @param string $season Season identifier
  */
 function ufsc_quota_add_included( $club_id, $quantity, $season ) {
-    // STUB: This should add included licenses to the club's quota for the season
-    // Implementation depends on how quota is tracked in the database
-    
-    // Example implementation (to be adjusted):
-    /*
     global $wpdb;
+
     $clubs_table = ufsc_get_clubs_table();
-    
-    $wpdb->query( $wpdb->prepare(
-        "UPDATE {$clubs_table} 
-         SET quota_included = quota_included + %d 
-         WHERE id = %d",
-        $quantity,
-        $club_id
-    ) );
-    */
+    $wpdb->query(
+        $wpdb->prepare(
+            "UPDATE {$clubs_table} SET quota_licences = COALESCE(quota_licences,0) + %d WHERE id = %d",
+            $quantity,
+            $club_id
+        )
+    );
 }
 
 /**
  * Add paid licenses to club quota
- * TODO: Implement according to existing database schema
- * 
+ *
  * @param int $club_id Club ID
  * @param int $quantity Number of licenses to add
  * @param string $season Season identifier
  */
 function ufsc_quota_add_paid( $club_id, $quantity, $season ) {
-    // STUB: This should add paid licenses to the club's available quota for the season
-    // Implementation depends on how quota is tracked in the database
-    
-    // Example implementation (to be adjusted):
-    /*
     global $wpdb;
+
     $clubs_table = ufsc_get_clubs_table();
-    
-    $wpdb->query( $wpdb->prepare(
-        "UPDATE {$clubs_table} 
-         SET quota_paid = quota_paid + %d 
-         WHERE id = %d",
-        $quantity,
-        $club_id
-    ) );
-    */
+    $wpdb->query(
+        $wpdb->prepare(
+            "UPDATE {$clubs_table} SET quota_licences = COALESCE(quota_licences,0) + %d WHERE id = %d",
+            $quantity,
+            $club_id
+        )
+    );
 }


### PR DESCRIPTION
## Summary
- Retrieve club names and responsible users directly from SQL tables
- Enforce licence quota checks and update affiliation/licence payments
- Credit included and paid licence quotas to track remaining capacity

## Testing
- `php -l inc/woocommerce/cart-integration.php`
- `php -l inc/woocommerce/admin-actions.php`
- `php -l inc/woocommerce/hooks.php`
- `phpunit tests/test-frontend.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e73df75c832bb9bf1612ec11ad28