### PR TITLE
Add PDF generation and WooCommerce order logic

### DIFF
--- a/includes/core/class-import-export.php
+++ b/includes/core/class-import-export.php
@@ -480,8 +480,51 @@ class UFSC_Import_Export {
     }
 
     private static function create_payment_order( $club_id, $licence_ids ) {
-        // TODO: Implement payment order creation
-        return ufsc_create_additional_license_order( $club_id, $licence_ids, get_current_user_id() );
+        if ( ! function_exists( 'ufsc_is_woocommerce_active' ) || ! ufsc_is_woocommerce_active() ) {
+            return false;
+        }
+
+        $wc_settings       = ufsc_get_woocommerce_settings();
+        $license_product_id = $wc_settings['product_license_id'];
+        $product            = wc_get_product( $license_product_id );
+
+        if ( ! $product || ! $product->exists() ) {
+            return false;
+        }
+
+        $quantity = max( 1, count( $licence_ids ) );
+
+        try {
+            $order = wc_create_order();
+            if ( ! $order ) {
+                return false;
+            }
+
+            $user_id = get_current_user_id();
+            if ( $user_id > 0 ) {
+                $order->set_customer_id( $user_id );
+            }
+
+            $item_id = $order->add_product( $product, $quantity );
+            if ( ! $item_id ) {
+                $order->delete( true );
+                return false;
+            }
+
+            if ( ! empty( $licence_ids ) ) {
+                wc_add_order_item_meta( $item_id, '_ufsc_licence_ids', $licence_ids );
+            }
+            wc_add_order_item_meta( $item_id, '_ufsc_club_id', $club_id );
+
+            $order->calculate_totals();
+            $order->update_status( 'pending', __( 'Commande créée pour licences UFSC additionnelles', 'ufsc-clubs' ) );
+            $order->add_order_note( sprintf( __( 'Commande créée automatiquement pour %d licence(s) additionnelle(s) - Club ID: %d', 'ufsc-clubs' ), $quantity, $club_id ) );
+
+            return $order->get_id();
+        } catch ( Exception $e ) {
+            error_log( 'UFSC: Error creating additional license order: ' . $e->getMessage() );
+            return false;
+        }
     }
 }
 

--- a/includes/lib/class-simple-pdf.php
+++ b/includes/lib/class-simple-pdf.php
@@ -1,0 +1,55 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Simple PDF generation utility for UFSC
+ * Generates very basic PDFs without external dependencies
+ */
+class UFSC_Simple_PDF {
+    /**
+     * Generate a basic PDF file with provided lines of text.
+     *
+     * @param string $file_path Destination file path
+     * @param array  $lines     Lines of text to include in PDF
+     * @param string $title     Optional document title
+     * @return bool             True on success
+     */
+    public static function generate( $file_path, $lines, $title = '' ) {
+        $escape = function( $text ) {
+            return str_replace( [ '\\', '(', ')' ], [ '\\\\', '\\(', '\\)' ], $text );
+        };
+
+        $content = "BT\n/F1 16 Tf\n50 780 Td\n";
+        if ( ! empty( $title ) ) {
+            $content .= '(' . $escape( $title ) . ') Tj\n0 -24 Td\n';
+        }
+        foreach ( $lines as $line ) {
+            $content .= '(' . $escape( $line ) . ') Tj\n0 -18 Td\n';
+        }
+        $content .= "ET";
+
+        $objects = [];
+        $objects[] = "<</Type/Catalog/Pages 2 0 R>>"; // 1: Catalog
+        $objects[] = "<</Type/Pages/Count 1/Kids[3 0 R]>>"; // 2: Pages
+        $objects[] = "<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>"; // 3: Page
+        $objects[] = "<</Length " . strlen( $content ) . ">>stream\n$content\nendstream"; // 4: Contents
+        $objects[] = "<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>"; // 5: Font
+
+        $pdf = "%PDF-1.4\n";
+        $offsets = [ 0 ];
+        foreach ( $objects as $i => $obj ) {
+            $offsets[] = strlen( $pdf );
+            $pdf .= ( $i + 1 ) . " 0 obj\n$obj\nendobj\n";
+        }
+        $xref_pos = strlen( $pdf );
+        $pdf .= "xref\n0 " . ( count( $objects ) + 1 ) . "\n";
+        $pdf .= "0000000000 65535 f \n";
+        for ( $i = 1; $i <= count( $objects ); $i++ ) {
+            $pdf .= sprintf( '%010d 00000 n %s', $offsets[ $i ], "\n" );
+        }
+        $pdf .= "trailer<</Size " . ( count( $objects ) + 1 ) . "/Root 1 0 R>>\n";
+        $pdf .= "startxref\n" . $xref_pos . "\n%%EOF";
+
+        return file_put_contents( $file_path, $pdf ) !== false;
+    }
+}

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -24,6 +24,7 @@ require_once UFSC_CL_DIR.'includes/core/class-uploads.php';
 require_once UFSC_CL_DIR.'includes/core/class-permissions.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-badges.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-pdf-attestations.php';
+require_once UFSC_CL_DIR.'includes/lib/class-simple-pdf.php';
 require_once UFSC_CL_DIR.'includes/core/class-unified-handlers.php';
 require_once UFSC_CL_DIR.'includes/core/class-cache-manager.php';
 


### PR DESCRIPTION
## Summary
- add lightweight PDF utility and generate real PDF attestation files
- implement WooCommerce order creation for additional licences

## Testing
- `php -l includes/lib/class-simple-pdf.php`
- `php -l includes/api/class-rest-api.php`
- `php -l includes/core/class-import-export.php`
- `php -l ufsc-clubs-licences-sql.php`
- `php tests/test-frontend.php` *(fails: Class "PHPUnit\Framework\TestCase" not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7e7381144832b9e7602fdc028c983