### PR TITLE
Implement database helpers for licence import/export

### DIFF
--- a/includes/core/class-import-export.php
+++ b/includes/core/class-import-export.php
@@ -457,85 +457,19 @@ class UFSC_Import_Export {
         );
     }
 
-    // STUB METHODS - To be implemented according to database schema
-
-
+    /**
+     * Retrieve club licences for export.
+     *
+     * @param int   $club_id Club identifier.
+     * @param array $filters Optional filters (status, season).
+     *
+     * @return array List of licences.
+     */
     protected static function get_club_licences_for_export( $club_id, $filters ) {
-        // TODO: Implement actual licence retrieval for export
-        return array();
-    }
-
-    protected static function get_club_name( $club_id ) {
-        // TODO: Implement club name retrieval
-        return "Club_{$club_id}";
-    }
-
-    protected static function get_club_quota_info( $club_id ) {
-        // TODO: Implement quota info retrieval
-        return array( 'total' => 10, 'used' => 3, 'remaining' => 7 );
-    }
-
-    protected static function create_licence_record( $club_id, $data ) {
-        // TODO: Implement licence creation
-        return 0;
-    }
-
-
-    private static function create_payment_order( $club_id, $licence_ids ) {
-        if ( ! function_exists( 'ufsc_is_woocommerce_active' ) || ! ufsc_is_woocommerce_active() ) {
-            return false;
-        }
-
-        $wc_settings       = ufsc_get_woocommerce_settings();
-        $license_product_id = $wc_settings['product_license_id'];
-        $product            = wc_get_product( $license_product_id );
-
-        if ( ! $product || ! $product->exists() ) {
-            return false;
-        }
-
-        $quantity = max( 1, count( $licence_ids ) );
-
-        try {
-            $order = wc_create_order();
-            if ( ! $order ) {
-                return false;
-            }
-
-            $user_id = get_current_user_id();
-            if ( $user_id > 0 ) {
-                $order->set_customer_id( $user_id );
-            }
-
-            $item_id = $order->add_product( $product, $quantity );
-            if ( ! $item_id ) {
-                $order->delete( true );
-                return false;
-            }
-
-            if ( ! empty( $licence_ids ) ) {
-                wc_add_order_item_meta( $item_id, '_ufsc_licence_ids', $licence_ids );
-            }
-            wc_add_order_item_meta( $item_id, '_ufsc_club_id', $club_id );
-
-            $order->calculate_totals();
-            $order->update_status( 'pending', __( 'Commande créée pour licences UFSC additionnelles', 'ufsc-clubs' ) );
-            $order->add_order_note( sprintf( __( 'Commande créée automatiquement pour %d licence(s) additionnelle(s) - Club ID: %d', 'ufsc-clubs' ), $quantity, $club_id ) );
-
-            return $order->get_id();
-        } catch ( Exception $e ) {
-            error_log( 'UFSC: Error creating additional license order: ' . $e->getMessage() );
-            return false;
-        }
-
-    protected static function create_payment_order( $club_id, $licence_ids ) {
-        // TODO: Implement payment order creation
-
-    private static function get_club_licences_for_export( $club_id, $filters ) {
         global $wpdb;
 
-        $settings        = UFSC_SQL::get_settings();
-        $licences_table  = $settings['table_licences'];
+        $settings       = UFSC_SQL::get_settings();
+        $licences_table = $settings['table_licences'];
 
         $where  = array( 'club_id = %d' );
         $values = array( $club_id );
@@ -562,13 +496,19 @@ class UFSC_Import_Export {
         return is_array( $results ) ? $results : array();
     }
 
-    private static function get_club_name( $club_id ) {
+    /**
+     * Retrieve club name.
+     *
+     * @param int $club_id Club identifier.
+     *
+     * @return string Club name or default string.
+     */
+    protected static function get_club_name( $club_id ) {
         global $wpdb;
 
         $settings    = UFSC_SQL::get_settings();
         $clubs_table = $settings['table_clubs'];
-
-        $name_col = ufsc_club_col( 'name' );
+        $name_col    = ufsc_club_col( 'name' );
 
         $name = $wpdb->get_var( $wpdb->prepare(
             "SELECT {$name_col} FROM {$clubs_table} WHERE id = %d",
@@ -578,7 +518,14 @@ class UFSC_Import_Export {
         return $name ? $name : "Club_{$club_id}";
     }
 
-    private static function get_club_quota_info( $club_id ) {
+    /**
+     * Retrieve club licence quota information.
+     *
+     * @param int $club_id Club identifier.
+     *
+     * @return array Quota information (total, used, remaining).
+     */
+    protected static function get_club_quota_info( $club_id ) {
         global $wpdb;
 
         $settings       = UFSC_SQL::get_settings();
@@ -598,20 +545,31 @@ class UFSC_Import_Export {
         return array(
             'total'     => $quota_total,
             'used'      => $used,
-            'remaining' => max( 0, $quota_total - $used )
+            'remaining' => max( 0, $quota_total - $used ),
         );
     }
 
-    private static function create_licence_record( $club_id, $data ) {
+    /**
+     * Create a licence record in database.
+     *
+     * @param int   $club_id Club identifier.
+     * @param array $data    Licence data.
+     *
+     * @return int Inserted licence ID or 0 on failure.
+     */
+    protected static function create_licence_record( $club_id, $data ) {
         global $wpdb;
 
         $settings       = UFSC_SQL::get_settings();
         $licences_table = $settings['table_licences'];
 
-        $insert_data = array_merge( $data, array(
-            'club_id'       => $club_id,
-            'date_creation' => current_time( 'mysql' )
-        ) );
+        $insert_data = array_merge(
+            $data,
+            array(
+                'club_id'       => $club_id,
+                'date_creation' => current_time( 'mysql' ),
+            )
+        );
 
         $result = $wpdb->insert( $licences_table, $insert_data );
 
@@ -623,14 +581,20 @@ class UFSC_Import_Export {
         return (int) $wpdb->insert_id;
     }
 
-    private static function create_payment_order( $club_id, $licence_ids ) {
+    /**
+     * Create a WooCommerce order for additional licences.
+     *
+     * @param int   $club_id     Club identifier.
+     * @param array $licence_ids Licence IDs exceeding the quota.
+     *
+     * @return int|false Order ID on success, false otherwise.
+     */
+    protected static function create_payment_order( $club_id, $licence_ids ) {
         if ( ! function_exists( 'ufsc_create_additional_license_order' ) ) {
             return false;
         }
 
-
         return ufsc_create_additional_license_order( $club_id, $licence_ids, get_current_user_id() );
-
     }
 }
 


### PR DESCRIPTION
## Summary
- add SQL-backed lookup for club licence exports
- fetch club metadata and quota information
- record licence creations and trigger payment order generation

## Testing
- `php -l includes/core/class-import-export.php`
- `phpunit --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ecf21d9c832bab1c4b10a76e04a0