### PR TITLE
Ensure admin tables query existing, sanitized tables

### DIFF
--- a/inc/admin/class-ufsc-gestion-clubs-list-table.php
+++ b/inc/admin/class-ufsc-gestion-clubs-list-table.php
@@ -110,8 +110,26 @@ class UFSC_Gestion_Clubs_List_Table extends WP_List_Table {
     public function prepare_items() {
         global $wpdb;
 
-        $clubs_table = ufsc_get_clubs_table();
+        $clubs_table = ufsc_sanitize_table_name( ufsc_get_clubs_table() );
         $per_page    = 20;
+
+        if ( ! ufsc_table_exists( $clubs_table ) ) {
+            $this->items = array();
+            $this->set_pagination_args(
+                array(
+                    'total_items' => 0,
+                    'per_page'    => $per_page,
+                )
+            );
+
+            $columns  = $this->get_columns();
+            $hidden   = array();
+            $sortable = $this->get_sortable_columns();
+            $this->_column_headers = array( $columns, $hidden, $sortable );
+
+            return;
+        }
+
         $current_page = $this->get_pagenum();
         $offset       = ( $current_page - 1 ) * $per_page;
 

--- a/inc/admin/class-ufsc-gestion-licences-list-table.php
+++ b/inc/admin/class-ufsc-gestion-licences-list-table.php
@@ -84,9 +84,27 @@ class UFSC_Gestion_Licences_List_Table extends WP_List_Table {
     public function prepare_items() {
         global $wpdb;
 
-        $licences_table = ufsc_get_licences_table();
-        $clubs_table    = ufsc_get_clubs_table();
+        $licences_table = ufsc_sanitize_table_name( ufsc_get_licences_table() );
+        $clubs_table    = ufsc_sanitize_table_name( ufsc_get_clubs_table() );
         $per_page       = 20;
+
+        if ( ! ufsc_table_exists( $licences_table ) || ! ufsc_table_exists( $clubs_table ) ) {
+            $this->items = array();
+            $this->set_pagination_args(
+                array(
+                    'total_items' => 0,
+                    'per_page'    => $per_page,
+                )
+            );
+
+            $columns  = $this->get_columns();
+            $hidden   = array();
+            $sortable = $this->get_sortable_columns();
+            $this->_column_headers = array( $columns, $hidden, $sortable );
+
+            return;
+        }
+
         $current_page   = $this->get_pagenum();
         $offset         = ( $current_page - 1 ) * $per_page;
 

--- a/inc/admin/menu.php
+++ b/inc/admin/menu.php
@@ -252,7 +252,7 @@ function ufsc_render_licences_page() {
 function ufsc_get_clubs_count() {
     global $wpdb;
     
-    $clubs_table = ufsc_get_clubs_table();
+    $clubs_table = ufsc_sanitize_table_name( ufsc_get_clubs_table() );
     
     if ( ! ufsc_table_exists( $clubs_table ) ) {
         return 0;
@@ -268,7 +268,7 @@ function ufsc_get_clubs_count() {
 function ufsc_get_licences_count() {
     global $wpdb;
     
-    $licences_table = ufsc_get_licences_table();
+    $licences_table = ufsc_sanitize_table_name( ufsc_get_licences_table() );
     
     if ( ! ufsc_table_exists( $licences_table ) ) {
         return 0;


### PR DESCRIPTION
## Summary
- add table-existence checks and sanitization to clubs and licences list tables
- sanitize table names in `ufsc_get_clubs_count` and `ufsc_get_licences_count`

## Testing
- `php -l inc/admin/class-ufsc-gestion-clubs-list-table.php`
- `php -l inc/admin/class-ufsc-gestion-licences-list-table.php`
- `php -l inc/admin/menu.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7eced2268832b97766a305f1491d4