### PR TITLE
Implement club quota and payment helpers

### DIFF
--- a/inc/woocommerce/cart-integration.php
+++ b/inc/woocommerce/cart-integration.php
@@ -144,16 +144,17 @@ function ufsc_display_cart_item_data( $item_data, $cart_item ) {
 }
 
 /**
- * Get club name by ID
- * TODO: Implement according to existing database schema
- * 
+ * Get club name by ID.
+ *
+ * Looks up the `nom` column in the configured clubs table. Returns the name
+ * or `false` when no matching club exists.
+ *
  * @param int $club_id Club ID
  * @return string|false Club name or false if not found
  */
 function ufsc_get_club_name( $club_id ) {
     global $wpdb;
 
-    // Retrieve club name from configured clubs table
     $clubs_table = ufsc_get_clubs_table();
     $club_name   = $wpdb->get_var(
         $wpdb->prepare(
@@ -162,12 +163,7 @@ function ufsc_get_club_name( $club_id ) {
         )
     );
 
-    // Return false if club not found
-    if ( null === $club_name ) {
-        return false;
-    }
-
-    return $club_name;
+    return $club_name !== null ? $club_name : false;
 }
 
 /**

--- a/inc/woocommerce/hooks.php
+++ b/inc/woocommerce/hooks.php
@@ -131,31 +131,42 @@ function ufsc_handle_additional_license_payment( $order, $item, $quantity ) {
     }
 }
 
-// STUB FUNCTIONS - TO BE IMPLEMENTED ACCORDING TO EXISTING DATABASE SCHEMA
+// Database helper functions
 
 /**
- * Get club ID for a user
- * TODO: Implement according to existing database schema
- * 
+ * Get club ID for a user.
+ *
+ * Tries to resolve the club via the optional UFSC_User_Club_Mapping class
+ * if available. If not, the function falls back to a direct lookup on the
+ * configured clubs table using the `responsable_id` column.
+ *
  * @param int $user_id User ID
  * @return int|false Club ID or false if not found
  */
 if ( ! function_exists( 'ufsc_get_user_club_id' ) ) {
     function ufsc_get_user_club_id( $user_id ) {
-        // Delegate to the proper implementation if available
+        // Delegate to the mapping class when present
         if ( class_exists( 'UFSC_User_Club_Mapping' ) ) {
             return UFSC_User_Club_Mapping::get_user_club_id( $user_id );
         }
-        
-        // Fallback implementation
-        return false;
+
+        global $wpdb;
+        $clubs_table = ufsc_get_clubs_table();
+
+        $club_id = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT id FROM {$clubs_table} WHERE responsable_id = %d",
+                $user_id
+            )
+        );
+
+        return $club_id ? (int) $club_id : false;
     }
 }
 
 /**
  * Mark affiliation as paid for a season
- * TODO: Implement according to existing database schema
- * 
+ *
  * @param int $club_id Club ID
  * @param string $season Season identifier
  */
@@ -189,9 +200,14 @@ if ( ! function_exists( 'ufsc_mark_licence_paid' ) ) {
         $licences_table = ufsc_get_licences_table();
         $wpdb->update(
             $licences_table,
-            array( 'statut' => 'en_attente', 'is_included' => 0 ),
+            array(
+                'statut'      => 'en_attente',
+                'is_included' => 0,
+                'paid_season' => $season,
+                'paid_date'   => current_time( 'mysql' ),
+            ),
             array( 'id' => $license_id ),
-            array( '%s', '%d' ),
+            array( '%s', '%d', '%s', '%s' ),
             array( '%d' )
         );
     }

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -34,7 +34,75 @@ if (!function_exists('wp_upload_dir')) { function wp_upload_dir(){ return ['path
 if (!function_exists('sanitize_file_name')) { function sanitize_file_name($n){ return $n; } }
 if (!function_exists('is_user_logged_in')) { function is_user_logged_in(){ return $GLOBALS['ufsc_is_logged_in'] ?? false; } }
 if (!function_exists('get_current_user_id')) { function get_current_user_id(){ return $GLOBALS['ufsc_current_user_id'] ?? 0; } }
-if (!function_exists('ufsc_get_user_club_id')) { function ufsc_get_user_club_id($u){ return $GLOBALS['ufsc_user_club_id'] ?? null; } }
+if (!function_exists('ufsc_get_clubs_table')) { function ufsc_get_clubs_table(){ return 'wp_ufsc_clubs'; } }
+if (!function_exists('ufsc_get_licences_table')) { function ufsc_get_licences_table(){ return 'wp_ufsc_licences'; } }
+
+class WPDB_Stub {
+    public $prefix = 'wp_';
+    public $clubs = [];
+    public $licences = [];
+
+    public function prepare( $query, ...$args ) {
+        $query = str_replace( array( '%d', '%s' ), '%s', $query );
+        return vsprintf( $query, $args );
+    }
+
+    public function get_var( $query ) {
+        if ( preg_match( '/SELECT nom FROM .*wp_ufsc_clubs.* WHERE id = (\d+)/', $query, $m ) ) {
+            return $this->clubs[ (int) $m[1] ]['nom'] ?? null;
+        }
+        if ( preg_match( '/SELECT quota_licences FROM .*wp_ufsc_clubs.* WHERE id = (\d+)/', $query, $m ) ) {
+            return $this->clubs[ (int) $m[1] ]['quota_licences'] ?? null;
+        }
+        if ( preg_match( '/SELECT responsable_id FROM .*wp_ufsc_clubs.* WHERE id = (\d+)/', $query, $m ) ) {
+            return $this->clubs[ (int) $m[1] ]['responsable_id'] ?? null;
+        }
+        if ( preg_match( '/SELECT COUNT\(\*\) FROM .*wp_ufsc_licences.* WHERE club_id = (\d+)/', $query, $m ) ) {
+            $club_id = (int) $m[1];
+            $count = 0;
+            foreach ( $this->licences as $licence ) {
+                if ( $licence['club_id'] == $club_id ) {
+                    $count++;
+                }
+            }
+            return $count;
+        }
+        return null;
+    }
+
+    public function query( $query ) {
+        if ( preg_match( '/UPDATE .*wp_ufsc_clubs.* SET quota_licences = COALESCE\(quota_licences,0\) \+ (\d+) WHERE id = (\d+)/', $query, $m ) ) {
+            $club_id = (int) $m[2];
+            $qty     = (int) $m[1];
+            if ( ! isset( $this->clubs[ $club_id ]['quota_licences'] ) ) {
+                $this->clubs[ $club_id ]['quota_licences'] = 0;
+            }
+            $this->clubs[ $club_id ]['quota_licences'] += $qty;
+            return 1;
+        }
+        return 0;
+    }
+
+    public function update( $table, $data, $where, $format = null, $where_format = null ) {
+        if ( 'wp_ufsc_clubs' === $table ) {
+            $id = $where['id'];
+            $this->clubs[ $id ] = array_merge( $this->clubs[ $id ] ?? [], $data );
+            return 1;
+        }
+        if ( 'wp_ufsc_licences' === $table ) {
+            $id = $where['id'];
+            $this->licences[ $id ] = array_merge( $this->licences[ $id ] ?? [], $data );
+            return 1;
+        }
+        return 0;
+    }
+}
+
+$GLOBALS['wpdb'] = new WPDB_Stub();
+
+require_once __DIR__ . '/../inc/woocommerce/admin-actions.php';
+require_once __DIR__ . '/../inc/woocommerce/cart-integration.php';
+require_once __DIR__ . '/../inc/woocommerce/hooks.php';
 
 // --- Testable subclasses for Import/Export ---
 class UFSC_Import_Export_Success extends UFSC_Import_Export {
@@ -110,11 +178,12 @@ class ApiPermissionsTest extends TestCase {
     }
 
     public function test_check_club_permissions_success() {
-        $GLOBALS['ufsc_is_logged_in'] = true;
+        global $wpdb;
+        $GLOBALS['ufsc_is_logged_in']  = true;
         $GLOBALS['ufsc_current_user_id'] = 1;
-        $GLOBALS['ufsc_user_club_id'] = 2;
-        $result = UFSC_REST_API::check_club_permissions(new WP_REST_Request());
-        $this->assertTrue($result);
+        $wpdb->clubs = array( 2 => array( 'responsable_id' => 1 ) );
+        $result = UFSC_REST_API::check_club_permissions( new WP_REST_Request() );
+        $this->assertTrue( $result );
     }
 }
 
@@ -131,5 +200,45 @@ class WooCommerceFunctionsTest extends TestCase {
         }
         $this->assertTrue(ufsc_is_woocommerce_active());
         $this->assertTrue(ufsc_validate_woocommerce_product(123));
+    }
+}
+
+class QuotaPaymentFunctionsTest extends TestCase {
+    protected function setUp(): void {
+        global $wpdb;
+        $wpdb->clubs = array(
+            1 => array( 'nom' => 'Club Test', 'quota_licences' => 2, 'responsable_id' => 99 ),
+        );
+        $wpdb->licences = array(
+            1 => array( 'club_id' => 1, 'statut' => 'draft', 'is_included' => 1 ),
+            2 => array( 'club_id' => 1, 'statut' => 'draft', 'is_included' => 1 ),
+        );
+    }
+
+    public function test_getters() {
+        $this->assertEquals( 'Club Test', ufsc_get_club_name( 1 ) );
+        $this->assertEquals( 99, ufsc_get_club_responsible_user_id( 1 ) );
+    }
+
+    public function test_should_charge_license() {
+        $this->assertTrue( ufsc_should_charge_license( 1, '2025' ) );
+        global $wpdb;
+        $wpdb->clubs[1]['quota_licences'] = 5;
+        $this->assertFalse( ufsc_should_charge_license( 1, '2025' ) );
+    }
+
+    public function test_quota_and_payment_updates() {
+        global $wpdb;
+        ufsc_quota_add_included( 1, 3, '2025' );
+        ufsc_quota_add_paid( 1, 2, '2025' );
+        $this->assertEquals( 7, $wpdb->clubs[1]['quota_licences'] );
+
+        ufsc_mark_affiliation_paid( 1, '2025' );
+        $this->assertNotEmpty( $wpdb->clubs[1]['date_affiliation'] );
+
+        ufsc_mark_licence_paid( 1, '2025' );
+        $this->assertEquals( 'en_attente', $wpdb->licences[1]['statut'] );
+        $this->assertEquals( 0, $wpdb->licences[1]['is_included'] );
+        $this->assertEquals( '2025', $wpdb->licences[1]['paid_season'] );
     }
 }


### PR DESCRIPTION
## Summary
- Add database-backed club lookup and payment tracking helpers
- Enhance license payment flagging with season and date metadata
- Test club quota evaluation and payment update flows

## Testing
- `phpunit tests/test-core.php` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7eceda040832baebad0edba741df9