### PR TITLE
Ensure notifications use DB data and fix dashboard URL

### DIFF
--- a/includes/core/class-email-notifications.php
+++ b/includes/core/class-email-notifications.php
@@ -662,36 +662,35 @@ class UFSC_Email_Notifications {
             'responsable_id' => function_exists( 'ufsc_club_col' ) ? ufsc_club_col( 'responsable_id' ) : 'responsable_id',
         );
 
-        $select = array();
-        foreach ( $columns as $alias => $col ) {
-            $select[] = "`{$col}` AS {$alias}";
-        }
+        $responsable_col = $columns['responsable_id'];
+        $users_table     = $wpdb->users;
 
-        $id_col = $columns['id'];
-        $row    = $wpdb->get_row(
-            $wpdb->prepare(
-                'SELECT ' . implode( ', ', $select ) . " FROM `{$table}` WHERE `{$id_col}` = %d LIMIT 1",
-                (int) $club_id
-            ),
-            ARRAY_A
+        $sql = $wpdb->prepare(
+            "SELECT c.`{$columns['id']}` AS id,
+                    c.`{$columns['nom']}` AS nom,
+                    c.`{$columns['email']}` AS email,
+                    c.`{$responsable_col}` AS responsable_id,
+                    u.user_email AS responsable_email
+             FROM `{$table}` c
+             LEFT JOIN {$users_table} u ON u.ID = c.`{$responsable_col}`
+             WHERE c.`{$columns['id']}` = %d
+             LIMIT 1",
+            (int) $club_id
         );
+
+        $row = $wpdb->get_row( $sql, ARRAY_A );
 
         return $row ?: null;
     }
 
     private static function get_club_responsible_email( $club_id ) {
         $club = self::get_club_data( $club_id );
-        if ( ! $club || empty( $club['responsable_id'] ) ) {
-            return '';
-        }
-
-        $user = get_userdata( (int) $club['responsable_id'] );
-        return $user ? $user->user_email : '';
+        return $club['responsable_email'] ?? '';
     }
 
     private static function get_dashboard_url() {
         $dashboard_page = get_option( 'ufsc_dashboard_page' );
-        return $dashboard_page ? get_permalink( $dashboard_page ) : home_url( '/tableau-de-bord/' );
+        return $dashboard_page ? get_permalink( $dashboard_page ) : home_url( '/club-dashboard/' );
     }
 }
 

--- a/includes/frontend/class-affiliation-form.php
+++ b/includes/frontend/class-affiliation-form.php
@@ -505,6 +505,6 @@ class UFSC_Affiliation_Form {
      */
     private static function get_dashboard_url() {
         $dashboard_page = get_option( 'ufsc_dashboard_page' );
-        return $dashboard_page ? get_permalink( $dashboard_page ) : null;
+        return $dashboard_page ? get_permalink( $dashboard_page ) : home_url( '/club-dashboard/' );
     }
 }


### PR DESCRIPTION
## Summary
- Query club data with responsible email directly from the database for notifications
- Return proper frontend dashboard URL when no setting is found

## Testing
- `php -l includes/core/class-email-notifications.php`
- `php -l includes/frontend/class-affiliation-form.php`
- `phpunit --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ecf39230832badb857b9edc12eba