### PR TITLE
Implement club info and quota payment sync

### DIFF
--- a/inc/woocommerce/cart-integration.php
+++ b/inc/woocommerce/cart-integration.php
@@ -144,30 +144,31 @@ function ufsc_display_cart_item_data( $item_data, $cart_item ) {
 }
 
 /**
- * Get club name by ID
- * TODO: Implement according to existing database schema
- * 
- * @param int $club_id Club ID
- * @return string|false Club name or false if not found
+ * Get club name by ID.
+ *
+ * Reads the configured clubs table and returns the `nom` column for the
+ * requested club. If the club doesn't exist an empty value is returned.
+ *
+ * @param int $club_id Club ID.
+ * @return string|false Club name or false if not found.
  */
 function ufsc_get_club_name( $club_id ) {
     global $wpdb;
 
-    // Retrieve club name from configured clubs table
+    if ( ! function_exists( 'ufsc_get_clubs_table' ) ) {
+        return false;
+    }
+
     $clubs_table = ufsc_get_clubs_table();
-    $club_name   = $wpdb->get_var(
+
+    $club_name = $wpdb->get_var(
         $wpdb->prepare(
             "SELECT nom FROM {$clubs_table} WHERE id = %d",
             $club_id
         )
     );
 
-    // Return false if club not found
-    if ( null === $club_name ) {
-        return false;
-    }
-
-    return $club_name;
+    return $club_name ? $club_name : false;
 }
 
 /**

--- a/inc/woocommerce/hooks.php
+++ b/inc/woocommerce/hooks.php
@@ -163,16 +163,22 @@ if ( ! function_exists( 'ufsc_mark_affiliation_paid' ) ) {
     function ufsc_mark_affiliation_paid( $club_id, $season ) {
         global $wpdb;
 
+        if ( ! function_exists( 'ufsc_get_clubs_table' ) ) {
+            return false;
+        }
+
         $clubs_table = ufsc_get_clubs_table();
 
         // Update affiliation date to mark payment
-        $wpdb->update(
+        $updated = $wpdb->update(
             $clubs_table,
             array( 'date_affiliation' => current_time( 'mysql' ) ),
             array( 'id' => $club_id ),
             array( '%s' ),
             array( '%d' )
         );
+
+        return false !== $updated;
     }
 }
 
@@ -186,14 +192,20 @@ if ( ! function_exists( 'ufsc_mark_licence_paid' ) ) {
     function ufsc_mark_licence_paid( $license_id, $season ) {
         global $wpdb;
 
+        if ( ! function_exists( 'ufsc_get_licences_table' ) ) {
+            return false;
+        }
+
         $licences_table = ufsc_get_licences_table();
-        $wpdb->update(
+        $updated        = $wpdb->update(
             $licences_table,
             array( 'statut' => 'en_attente', 'is_included' => 0 ),
             array( 'id' => $license_id ),
             array( '%s', '%d' ),
             array( '%d' )
         );
+
+        return false !== $updated;
     }
 }
 
@@ -207,14 +219,20 @@ if ( ! function_exists( 'ufsc_mark_licence_paid' ) ) {
 function ufsc_quota_add_included( $club_id, $quantity, $season ) {
     global $wpdb;
 
+    if ( ! function_exists( 'ufsc_get_clubs_table' ) ) {
+        return false;
+    }
+
     $clubs_table = ufsc_get_clubs_table();
-    $wpdb->query(
+    $updated     = $wpdb->query(
         $wpdb->prepare(
             "UPDATE {$clubs_table} SET quota_licences = COALESCE(quota_licences,0) + %d WHERE id = %d",
             $quantity,
             $club_id
         )
     );
+
+    return false !== $updated;
 }
 
 /**
@@ -227,12 +245,18 @@ function ufsc_quota_add_included( $club_id, $quantity, $season ) {
 function ufsc_quota_add_paid( $club_id, $quantity, $season ) {
     global $wpdb;
 
+    if ( ! function_exists( 'ufsc_get_clubs_table' ) ) {
+        return false;
+    }
+
     $clubs_table = ufsc_get_clubs_table();
-    $wpdb->query(
+    $updated     = $wpdb->query(
         $wpdb->prepare(
             "UPDATE {$clubs_table} SET quota_licences = COALESCE(quota_licences,0) + %d WHERE id = %d",
             $quantity,
             $club_id
         )
     );
+
+    return false !== $updated;
 }


### PR DESCRIPTION
## Summary
- Add database-backed `ufsc_get_club_name` helper
- Implement quota checks and responsible user lookup for licence payments
- Sync quota and payment helpers with clubs/licences tables

## Testing
- `php -l inc/woocommerce/cart-integration.php`
- `php -l inc/woocommerce/admin-actions.php`
- `php -l inc/woocommerce/hooks.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f96c797c832b90dcd14392d8389d