### PR TITLE
fix: remove redundant name_col assignment

### DIFF
--- a/includes/core/class-import-export.php
+++ b/includes/core/class-import-export.php
@@ -559,9 +559,6 @@ class UFSC_Import_Export {
 
         $name_col = function_exists( 'ufsc_club_col' ) ? ufsc_club_col( 'name' ) : 'nom';
 
-        $name_col    = ufsc_club_col( 'name' );
-
-
         $name = $wpdb->get_var( $wpdb->prepare(
             "SELECT {$name_col} FROM {$clubs_table} WHERE id = %d",
             $club_id


### PR DESCRIPTION
## Summary
- simplify get_club_name() by assigning `$name_col` once with helper fallback

## Testing
- `vendor/bin/phpunit tests` *(fails: No such file or directory)*
- `php -l includes/core/class-import-export.php` *(fails: Parse error: syntax error, unexpected token "*" in includes/core/class-import-export.php on line 482)*

------
https://chatgpt.com/codex/tasks/task_e_68b804bb6a5c832b9988eab8813c9ce0