### PR TITLE
Register WooCommerce endpoint for club dashboard

### DIFF
--- a/includes/frontend/class-club-dashboard.php
+++ b/includes/frontend/class-club-dashboard.php
@@ -15,6 +15,11 @@ class UFSC_Club_Dashboard {
         
         // WooCommerce integration
         if ( self::is_woocommerce_active() ) {
+            add_rewrite_endpoint( 'ufsc-tableau-de-bord', EP_ROOT | EP_PAGES );
+            add_filter( 'woocommerce_get_query_vars', function( $vars ) {
+                $vars['ufsc-tableau-de-bord'] = 'ufsc-tableau-de-bord';
+                return $vars;
+            } );
             add_action( 'woocommerce_account_ufsc-tableau-de-bord_endpoint', array( __CLASS__, 'render_woocommerce_dashboard' ) );
             add_filter( 'woocommerce_account_menu_items', array( __CLASS__, 'add_woocommerce_menu_item' ) );
         }


### PR DESCRIPTION
## Summary
- Register `ufsc-tableau-de-bord` rewrite endpoint and query var for WooCommerce integration
- Ensure dashboard endpoint hooks register after query vars

## Testing
- `php -l includes/frontend/class-club-dashboard.php`
- `vendor/bin/phpunit tests/` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68b81db0dcf0832ba39f53b244239e41