### PR TITLE
Add manager_user_id mapping for clubs

### DIFF
--- a/includes/core/column-map.php
+++ b/includes/core/column-map.php
@@ -59,6 +59,7 @@ class UFSC_Column_Map {
             'statut'                     => 'statut',
             'date_creation'              => 'date_creation',
             'responsable_id'             => 'responsable_id',
+            'manager_user_id'            => 'responsable_id',
             'doc_statuts'                => 'doc_statuts',
             'doc_recepisse'              => 'doc_recepisse',
             'doc_jo'                     => 'doc_jo',


### PR DESCRIPTION
## Summary
- add `manager_user_id` alias for `responsable_id` in default club column mapping

## Testing
- `php -l includes/core/column-map.php`
- `phpunit tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8485d18c8832b9dd78de6693a3052