### PR TITLE
Simplifie l'affichage des dirigeants du formulaire club

### DIFF
--- a/assets/frontend/css/ufsc-club-form.css
+++ b/assets/frontend/css/ufsc-club-form.css
@@ -145,9 +145,19 @@
     text-decoration: underline;
 }
 
+/* Dirigeants layout */
+.ufsc-dirigeants {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.ufsc-dirigeants .ufsc-field input {
+    width: 100%;
+}
+
 /* Dirigeants Sections */
 .ufsc-dirigeant-section {
-    margin-bottom: 30px;
     padding: 15px;
     background: #fff;
     border: 1px solid #e0e0e0;

--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -334,42 +334,44 @@ class UFSC_CL_Club_Form {
                 </fieldset>
                 
                 <!-- Dirigeants Section -->
-                <fieldset class="ufsc-form-section ufsc-grid">
+                <fieldset class="ufsc-form-section ufsc-dirigeants">
                     <legend><?php esc_html_e( 'Dirigeants', 'ufsc-clubs' ); ?></legend>
-                    
-                    <?php 
+
+                    <?php
                     $dirigeants_info = array(
-                        'president' => array( 'label' => __( 'Président', 'ufsc-clubs' ), 'required' => true ),
+                        'president'  => array( 'label' => __( 'Président', 'ufsc-clubs' ),  'required' => true ),
                         'secretaire' => array( 'label' => __( 'Secrétaire', 'ufsc-clubs' ), 'required' => true ),
-                        'tresorier' => array( 'label' => __( 'Trésorier', 'ufsc-clubs' ), 'required' => true ),
+                        'tresorier'  => array( 'label' => __( 'Trésorier', 'ufsc-clubs' ),  'required' => true ),
                         'entraineur' => array( 'label' => __( 'Entraîneur', 'ufsc-clubs' ), 'required' => false )
                     );
-                    
-                    foreach ( $dirigeants_info as $dirigeant => $info ):
+
+                    foreach ( $dirigeants_info as $dirigeant => $info ) :
                     ?>
                         <div class="ufsc-dirigeant-section">
                             <h4><?php echo esc_html( $info['label'] ); ?> <?php echo $info['required'] ? '<span class="required">*</span>' : ''; ?></h4>
-                            
-                            <div class="ufsc-grid">
-                                <div class="ufsc-field">
-                                    <label for="<?php echo esc_attr( $dirigeant ); ?>_prenom" class="ufsc-label <?php echo $info['required'] ? 'required' : ''; ?>"><?php esc_html_e( 'Prénom', 'ufsc-clubs' ); ?></label>
-                                    <input type="text" id="<?php echo esc_attr( $dirigeant ); ?>_prenom" name="<?php echo esc_attr( $dirigeant ); ?>_prenom" value="<?php echo esc_attr( $club_data[$dirigeant . '_prenom'] ?? '' ); ?>" <?php echo $info['required'] ? 'required' : ''; ?> />
-                                <div class="ufsc-field-error" aria-live="polite"></div></div>
-                                <div class="ufsc-field">
-                                    <label for="<?php echo esc_attr( $dirigeant ); ?>_nom" class="ufsc-label <?php echo $info['required'] ? 'required' : ''; ?>"><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></label>
-                                    <input type="text" id="<?php echo esc_attr( $dirigeant ); ?>_nom" name="<?php echo esc_attr( $dirigeant ); ?>_nom" value="<?php echo esc_attr( $club_data[$dirigeant . '_nom'] ?? '' ); ?>" <?php echo $info['required'] ? 'required' : ''; ?> />
-                                <div class="ufsc-field-error" aria-live="polite"></div></div>
+
+                            <div class="ufsc-field">
+                                <label for="<?php echo esc_attr( $dirigeant ); ?>_prenom" class="ufsc-label <?php echo $info['required'] ? 'required' : ''; ?>"><?php esc_html_e( 'Prénom', 'ufsc-clubs' ); ?></label>
+                                <input type="text" id="<?php echo esc_attr( $dirigeant ); ?>_prenom" name="<?php echo esc_attr( $dirigeant ); ?>_prenom" value="<?php echo esc_attr( $club_data[ $dirigeant . '_prenom' ] ?? '' ); ?>" <?php echo $info['required'] ? 'required' : ''; ?> />
+                                <div class="ufsc-field-error" aria-live="polite"></div>
                             </div>
-                            
-                            <div class="ufsc-grid">
-                                <div class="ufsc-field">
-                                    <label for="<?php echo esc_attr( $dirigeant ); ?>_email" class="ufsc-label <?php echo $info['required'] ? 'required' : ''; ?>"><?php esc_html_e( 'Email', 'ufsc-clubs' ); ?></label>
-                                    <input type="email" id="<?php echo esc_attr( $dirigeant ); ?>_email" name="<?php echo esc_attr( $dirigeant ); ?>_email" value="<?php echo esc_attr( $club_data[$dirigeant . '_email'] ?? '' ); ?>" <?php echo $info['required'] ? 'required' : ''; ?> />
-                                <div class="ufsc-field-error" aria-live="polite"></div></div>
-                                <div class="ufsc-field">
-                                    <label for="<?php echo esc_attr( $dirigeant ); ?>_tel" class="ufsc-label <?php echo $info['required'] ? 'required' : ''; ?>"><?php esc_html_e( 'Téléphone', 'ufsc-clubs' ); ?></label>
-                                    <input type="tel" id="<?php echo esc_attr( $dirigeant ); ?>_tel" name="<?php echo esc_attr( $dirigeant ); ?>_tel" value="<?php echo esc_attr( $club_data[$dirigeant . '_tel'] ?? '' ); ?>" <?php echo $info['required'] ? 'required' : ''; ?> />
-                                <div class="ufsc-field-error" aria-live="polite"></div></div>
+
+                            <div class="ufsc-field">
+                                <label for="<?php echo esc_attr( $dirigeant ); ?>_nom" class="ufsc-label <?php echo $info['required'] ? 'required' : ''; ?>"><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></label>
+                                <input type="text" id="<?php echo esc_attr( $dirigeant ); ?>_nom" name="<?php echo esc_attr( $dirigeant ); ?>_nom" value="<?php echo esc_attr( $club_data[ $dirigeant . '_nom' ] ?? '' ); ?>" <?php echo $info['required'] ? 'required' : ''; ?> />
+                                <div class="ufsc-field-error" aria-live="polite"></div>
+                            </div>
+
+                            <div class="ufsc-field">
+                                <label for="<?php echo esc_attr( $dirigeant ); ?>_email" class="ufsc-label <?php echo $info['required'] ? 'required' : ''; ?>"><?php esc_html_e( 'Email', 'ufsc-clubs' ); ?></label>
+                                <input type="email" id="<?php echo esc_attr( $dirigeant ); ?>_email" name="<?php echo esc_attr( $dirigeant ); ?>_email" value="<?php echo esc_attr( $club_data[ $dirigeant . '_email' ] ?? '' ); ?>" <?php echo $info['required'] ? 'required' : ''; ?> />
+                                <div class="ufsc-field-error" aria-live="polite"></div>
+                            </div>
+
+                            <div class="ufsc-field">
+                                <label for="<?php echo esc_attr( $dirigeant ); ?>_tel" class="ufsc-label <?php echo $info['required'] ? 'required' : ''; ?>"><?php esc_html_e( 'Téléphone', 'ufsc-clubs' ); ?></label>
+                                <input type="tel" id="<?php echo esc_attr( $dirigeant ); ?>_tel" name="<?php echo esc_attr( $dirigeant ); ?>_tel" value="<?php echo esc_attr( $club_data[ $dirigeant . '_tel' ] ?? '' ); ?>" <?php echo $info['required'] ? 'required' : ''; ?> />
+                                <div class="ufsc-field-error" aria-live="polite"></div>
                             </div>
                         </div>
                     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- restructure la section Dirigeants pour afficher chaque rôle sur une seule colonne
- ajoute la classe `.ufsc-dirigeants` pour un affichage vertical et pleine largeur des champs

## Testing
- `php -l includes/frontend/class-club-form.php`
- `phpunit --version` *(fails: command not found)*
- `php tests/test-frontend.php` *(fails: PHPUnit\Framework\TestCase not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84a66c8fc832b9bc5d9383d95ef6e