### PR TITLE
Use dedicated nonce field for club profile update

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -541,7 +541,7 @@ class UFSC_Frontend_Shortcodes {
             <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-club-form ufsc-club-profile">
                 <div class="ufsc-notices" aria-live="polite"></div>
                 <input type="hidden" name="action" value="ufsc_save_club">
-                <?php wp_nonce_field( 'ufsc_save_club', '_wpnonce' ); ?>
+                <?php wp_nonce_field( 'ufsc_save_club', 'ufsc_club_nonce' ); ?>
                 
                 <div class="ufsc-grid">
                     <!-- // UFSC: Identité du club -->


### PR DESCRIPTION
## Summary
- replace generic _wpnonce field with ufsc_club_nonce in club profile form

## Testing
- `vendor/bin/phpunit tests/` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b84ce9724c832bbd52bae8934cb5dc