### PR TITLE
Use responsable_id for club dashboard lookups

### DIFF
--- a/includes/frontend/class-club-dashboard.php
+++ b/includes/frontend/class-club-dashboard.php
@@ -109,14 +109,14 @@ class UFSC_Club_Dashboard {
         $settings = UFSC_SQL::get_settings();
         $table = $settings['table_clubs'];
         
-        $manager_col = ufsc_club_col( 'manager_user_id' );
-        if ( ! $manager_col ) {
+        $responsable_col = ufsc_club_col( 'responsable_id' );
+        if ( ! $responsable_col ) {
             return null; // Fallback if column mapping not available
         }
-        
-        $club = $wpdb->get_row( $wpdb->prepare( 
-            "SELECT * FROM `{$table}` WHERE `{$manager_col}` = %d LIMIT 1", 
-            $user_id 
+
+        $club = $wpdb->get_row( $wpdb->prepare(
+            "SELECT * FROM `{$table}` WHERE `{$responsable_col}` = %d LIMIT 1",
+            $user_id
         ) );
         
         return $club;
@@ -147,15 +147,15 @@ class UFSC_Club_Dashboard {
         $settings = UFSC_SQL::get_settings();
         $table = $settings['table_clubs'];
         
-        $manager_col = ufsc_club_col( 'manager_user_id' );
-        if ( ! $manager_col ) {
+        $responsable_col = ufsc_club_col( 'responsable_id' );
+        if ( ! $responsable_col ) {
             return false; // Fallback if column mapping not available
         }
-        
-        $result = $wpdb->get_var( $wpdb->prepare( 
-            "SELECT id FROM `{$table}` WHERE id = %d AND `{$manager_col}` = %d", 
-            $club_id, 
-            $user_id 
+
+        $result = $wpdb->get_var( $wpdb->prepare(
+            "SELECT id FROM `{$table}` WHERE id = %d AND `{$responsable_col}` = %d",
+            $club_id,
+            $user_id
         ) );
         
         return ! is_null( $result );


### PR DESCRIPTION
## Summary
- Use `responsable_id` column instead of `manager_user_id` when retrieving a user's club and validating editing permissions

## Testing
- `php -r "define('ABSPATH', true); require 'includes/core/column-map.php'; var_dump(UFSC_Column_Map::get_default_clubs_columns()['responsable_id']);"`
- `php /tmp/test_dashboard.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8546b60d8832bb9753be9dd53ea90