### PR TITLE
Use color-coded badge classes for licence statuses

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1499,14 +1499,14 @@ class UFSC_Frontend_Shortcodes {
      */
     private static function get_licence_status_badge_class( $status ) {
         $classes = array(
-            'brouillon' => '-draft',
-            'paid' => '-pending',
-            'validated' => '-ok',
-            'applied' => '-ok',
-            'rejected' => '-rejected'
+            'brouillon' => 'ufsc-badge-info',
+            'paid'      => 'ufsc-badge-warning',
+            'validated' => 'ufsc-badge-success',
+            'applied'   => 'ufsc-badge-success',
+            'rejected'  => 'ufsc-badge-danger',
         );
 
-        return $classes[ $status ] ?? '-draft';
+        return $classes[ $status ] ?? 'ufsc-badge-info';
     }
 
     /**


### PR DESCRIPTION
## Summary
- Map licence status names to ufsc-badge-success, ufsc-badge-warning, etc.
- Ensure CSS already defines these ufsc-badge-* classes for all statuses

## Testing
- `php -r 'define("ABSPATH", "."); require "includes/frontend/class-frontend-shortcodes.php"; $ref=new ReflectionClass("UFSC_Frontend_Shortcodes"); $m=$ref->getMethod("get_licence_status_badge_class"); $m->setAccessible(true); echo $m->invoke(null, "validated")."\n";'`
- `wget -O phpunit.phar https://phar.phpunit.de/phpunit-9.6.phar` (fails: Proxy tunneling failed: Forbidden)
- `php tests/test-core.php` (fails: Parse error, unexpected token "===")


------
https://chatgpt.com/codex/tasks/task_e_68b85b90c788832bb9bd965907b87baa