### PR TITLE
Add selective licence export via checkbox selection

### DIFF
--- a/assets/js/frontend-dashboard.js
+++ b/assets/js/frontend-dashboard.js
@@ -90,6 +90,10 @@
                 self.handleExportSelection();
             });
 
+            $(document).on('change', '#ufsc-select-all', function() {
+                $('.ufsc-licence-select').prop('checked', $(this).is(':checked'));
+            });
+
             $('#btn-generer-attestation').on('click', function(e) {
                 e.preventDefault();
                 self.handleGenerateAttestation();
@@ -565,8 +569,26 @@
         },
 
         handleExportSelection: function() {
-            // Placeholder - integrate with export
-            this.showToast('Export - fonctionnalité à venir', 'info');
+            var selectedIds = [];
+            $('.ufsc-licence-select:checked').each(function() {
+                selectedIds.push($(this).val());
+            });
+
+            if (selectedIds.length === 0) {
+                this.showToast('Veuillez sélectionner au moins une licence.', 'warning');
+                return;
+            }
+
+            var actionUrl = window.location.href.split('?')[0];
+            var form = $('<form method="get" action="' + actionUrl + '">');
+            form.append('<input type="hidden" name="ufsc_export" value="csv">');
+            selectedIds.forEach(function(id) {
+                form.append('<input type="hidden" name="ids[]" value="' + id + '">');
+            });
+
+            $('body').append(form);
+            form.submit();
+            form.remove();
         },
 
         handleGenerateAttestation: function() {

--- a/includes/core/class-import-export.php
+++ b/includes/core/class-import-export.php
@@ -11,7 +11,7 @@ class UFSC_Import_Export {
      * Export licences to CSV
      *
      * @param int   $club_id Club ID
-     * @param array $filters Optional filters
+     * @param array $filters Optional filters (status, season, ids)
      * @return array Result with success status and file info
      */
     public static function export_licences_csv( $club_id, $filters = array() ) {
@@ -113,7 +113,7 @@ class UFSC_Import_Export {
      * Export licences to Excel (XLSX)
      *
      * @param int   $club_id Club ID
-     * @param array $filters Optional filters
+     * @param array $filters Optional filters (status, season, ids)
      * @return array Result with success status and file info
      */
     public static function export_licences_xlsx( $club_id, $filters = array() ) {
@@ -487,6 +487,15 @@ class UFSC_Import_Export {
             }
         }
 
+        if ( ! empty( $filters['ids'] ) && is_array( $filters['ids'] ) ) {
+            $ids = array_filter( array_map( 'intval', $filters['ids'] ) );
+            if ( ! empty( $ids ) ) {
+                $placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+                $where[]      = "id IN ({$placeholders})";
+                $values       = array_merge( $values, $ids );
+            }
+        }
+
         $sql = "SELECT id, nom, prenom, email, telephone, date_naissance, sexe, adresse, ville, code_postal, statut, date_creation, date_validation
                 FROM {$licences_table}
                 WHERE " . implode( ' AND ', $where );
@@ -621,6 +630,7 @@ function ufsc_handle_export_request() {
     $filters = array(
         'season' => isset( $_GET['season'] ) ? sanitize_text_field( wp_unslash( $_GET['season'] ) ) : null,
         'status' => isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : null,
+        'ids'    => isset( $_REQUEST['ids'] ) ? array_map( 'intval', (array) $_REQUEST['ids'] ) : array(),
     );
 
     switch ( $format ) {

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -250,10 +250,13 @@ class UFSC_Frontend_Shortcodes {
                        class="ufsc-btn ufsc-btn-secondary">
                         <?php esc_html_e( 'Exporter CSV', 'ufsc-clubs' ); ?>
                     </a>
-                    <a href="<?php echo esc_url( add_query_arg( 'ufsc_export', 'xlsx' ) ); ?>" 
+                    <a href="<?php echo esc_url( add_query_arg( 'ufsc_export', 'xlsx' ) ); ?>"
                        class="ufsc-btn ufsc-btn-secondary">
                         <?php esc_html_e( 'Exporter Excel', 'ufsc-clubs' ); ?>
                     </a>
+                    <button id="btn-exporter-selection" class="ufsc-btn ufsc-btn-secondary">
+                        <?php esc_html_e( 'Exporter sélection', 'ufsc-clubs' ); ?>
+                    </button>
                     <button class="ufsc-btn ufsc-btn-secondary" onclick="document.getElementById('ufsc-import-modal').style.display='block'">
                         <?php esc_html_e( 'Importer CSV', 'ufsc-clubs' ); ?>
                     </button>
@@ -328,6 +331,7 @@ class UFSC_Frontend_Shortcodes {
                     <table class="ufsc-table">
                         <thead>
                             <tr>
+                                <th scope="col"><input type="checkbox" id="ufsc-select-all"></th>
                                 <th scope="col"><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></th>
                                 <th scope="col"><?php esc_html_e( 'Prénom', 'ufsc-clubs' ); ?></th>
                                 <th scope="col" class="ufsc-hide-mobile"><?php esc_html_e( 'Email', 'ufsc-clubs' ); ?></th>
@@ -339,6 +343,7 @@ class UFSC_Frontend_Shortcodes {
                         <tbody>
                             <?php foreach ( $licences as $licence ): ?>
                                 <tr>
+                                    <td><input type="checkbox" class="ufsc-licence-select" value="<?php echo esc_attr( $licence->id ?? 0 ); ?>"></td>
                                     <th scope="row"><?php echo esc_html( $licence->nom ?? '' ); ?></th>
                                     <td><?php echo esc_html( $licence->prenom ?? '' ); ?></td>
                                     <td class="ufsc-hide-mobile"><?php echo esc_html( $licence->email ?? '' ); ?></td>


### PR DESCRIPTION
## Summary
- add selection checkboxes and export button to club licence table
- implement frontend JS to send selected licence IDs for export
- extend export handler to filter licences by provided ID list

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l includes/core/class-import-export.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b85b97454c832b858b131b586a5931