### PR TITLE
Limiter l'édition aux licences brouillon

### DIFF
--- a/FRONTEND_LAYER_README.md
+++ b/FRONTEND_LAYER_README.md
@@ -38,6 +38,8 @@ Une fois validés par l'admin:
 - **Licences**: Non modifiables (lecture seule)
 - **Clubs**: Seuls email et téléphone éditables
 
+Seules les licences en statut `brouillon` peuvent être modifiées depuis le tableau de bord.
+
 **Fonctions de contrôle:**
 ```php
 ufsc_is_validated_club($club_id)      // Vérifie si club validé

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -360,7 +360,7 @@ class UFSC_Frontend_Shortcodes {
                                                aria-label="<?php esc_attr_e( 'Consulter la licence', 'ufsc-clubs' ); ?>">
                                                 <?php esc_html_e( 'Consulter', 'ufsc-clubs' ); ?>
                                             </a>
-                                            <?php if ( in_array( $licence->statut ?? '', array( 'brouillon', 'non_payee', 'refusee' ), true ) ) : ?>
+                                            <?php if ( in_array( $licence->statut ?? '', array( 'brouillon' ), true ) ) : ?>
                                                 <a href="<?php echo esc_url( add_query_arg( 'edit_licence', $licence->id ?? 0 ) ); ?>"
                                                    class="ufsc-btn ufsc-btn-small"
                                                    aria-label="<?php esc_attr_e( 'Modifier la licence', 'ufsc-clubs' ); ?>">


### PR DESCRIPTION
## Summary
- Restrict licence modification to `brouillon` status only
- Clarify documentation: only draft licences are editable

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a033b48832bb0cab06ade91d797