### PR TITLE
style: improve validated badge contrast

### DIFF
--- a/assets/frontend/css/frontend.css
+++ b/assets/frontend/css/frontend.css
@@ -250,8 +250,9 @@
 }
 
 .ufsc-badge.-ok {
-    background: #d4edda;
-    color: #155724;
+    background: #28a745;
+    color: #ffffff;
+    padding: 0.35rem 0.65rem;
 }
 
 .ufsc-badge.-rejected {

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1509,14 +1509,14 @@ class UFSC_Frontend_Shortcodes {
      */
     private static function get_licence_status_badge_class( $status ) {
         $classes = array(
-            'brouillon' => 'ufsc-badge-info',
-            'paid'      => 'ufsc-badge-warning',
-            'validated' => 'ufsc-badge-success',
-            'applied'   => 'ufsc-badge-success',
-            'rejected'  => 'ufsc-badge-danger',
+            'brouillon' => '-draft',
+            'paid'      => '-pending',
+            'validated' => '-ok',
+            'applied'   => '-ok',
+            'rejected'  => '-rejected',
         );
 
-        return $classes[ $status ] ?? 'ufsc-badge-info';
+        return $classes[ $status ] ?? '-draft';
     }
 
     /**


### PR DESCRIPTION
## Summary
- enhance `.ufsc-badge.-ok` with green background, white text, larger padding
- map validated licence status to `-ok` badge class

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `phpunit -c tests/test-frontend.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a0c0df8832b8e7b61fc05cc7956