### PR TITLE
Move licence actions below rows

### DIFF
--- a/assets/frontend/css/frontend.css
+++ b/assets/frontend/css/frontend.css
@@ -265,6 +265,10 @@
     gap: 0.5rem;
 }
 
+.ufsc-row-actions-row .ufsc-row-actions {
+    justify-content: flex-start;
+}
+
 @media (max-width: 767px) {
     .ufsc-row-actions {
         flex-direction: column;

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -337,7 +337,6 @@ class UFSC_Frontend_Shortcodes {
                                 <th scope="col" class="ufsc-hide-mobile"><?php esc_html_e( 'Email', 'ufsc-clubs' ); ?></th>
                                 <th scope="col"><?php esc_html_e( 'Statut', 'ufsc-clubs' ); ?></th>
                                 <th scope="col" class="ufsc-hide-mobile"><?php esc_html_e( 'Date création', 'ufsc-clubs' ); ?></th>
-                                <th scope="col"><?php esc_html_e( 'Actions', 'ufsc-clubs' ); ?></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -353,7 +352,10 @@ class UFSC_Frontend_Shortcodes {
                                         </span>
                                     </td>
                                     <td class="ufsc-hide-mobile"><?php echo esc_html( $licence->date_creation ?? '' ); ?></td>
-                                    <td class="ufsc-actions" aria-label="<?php esc_attr_e( 'Actions', 'ufsc-clubs' ); ?>">
+                                </tr>
+                                <tr class="ufsc-row-actions-row">
+                                    <td></td>
+                                    <td colspan="5">
                                         <div class="ufsc-row-actions">
                                             <a href="<?php echo esc_url( add_query_arg( 'view_licence', $licence->id ?? 0 ) ); ?>"
                                                class="ufsc-btn ufsc-btn-small"
@@ -367,7 +369,7 @@ class UFSC_Frontend_Shortcodes {
                                                     <?php esc_html_e( 'Modifier', 'ufsc-clubs' ); ?>
                                                 </a>
                                             <?php endif; ?>
-                                            <?php if ( in_array( $licence->statut ?? '', array( 'brouillon', 'non_payee' ), true ) ) : ?>
+        <?php if ( in_array( $licence->statut ?? '', array( 'brouillon', 'non_payee' ), true ) ) : ?>
                                                 <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-delete-licence-form" style="display:inline">
                                                     <?php wp_nonce_field( 'ufsc_delete_licence', 'ufsc_delete_licence_nonce' ); ?>
                                                     <input type="hidden" name="action" value="ufsc_delete_licence">


### PR DESCRIPTION
## Summary
- drop Actions column from licence list and show action buttons on dedicated row
- ensure row actions align to the left on mobile

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `vendor/bin/phpunit tests/` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a09fe84832bac98794fb6eb7704