### PR TITLE
Add cart button for draft licences

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -232,6 +232,7 @@ class UFSC_Frontend_Shortcodes {
         $licences = self::get_club_licences( $atts['club_id'], $atts );
         $total_count = self::get_club_licences_count( $atts['club_id'], $atts );
         $total_pages = ceil( $total_count / $atts['per_page'] );
+        $wc_settings = ufsc_get_woocommerce_settings();
 
         ob_start();
         ?>
@@ -360,6 +361,16 @@ class UFSC_Frontend_Shortcodes {
                                                aria-label="<?php esc_attr_e( 'Consulter la licence', 'ufsc-clubs' ); ?>">
                                                 <?php esc_html_e( 'Consulter', 'ufsc-clubs' ); ?>
                                             </a>
+                                            <?php if ( 'brouillon' === ( $licence->statut ?? '' ) ) : ?>
+                                                <a href="<?php echo esc_url( add_query_arg( array(
+                                                    'ufsc_add_to_cart' => $wc_settings['product_license_id'],
+                                                    'ufsc_license_ids' => $licence->id ?? 0,
+                                                ), '' ) ); ?>"
+                                                   class="ufsc-btn ufsc-btn-small"
+                                                   aria-label="<?php esc_attr_e( 'Envoyer la licence au panier', 'ufsc-clubs' ); ?>">
+                                                    <?php esc_html_e( 'Envoyer au panier', 'ufsc-clubs' ); ?>
+                                                </a>
+                                            <?php endif; ?>
                                             <?php if ( in_array( $licence->statut ?? '', array( 'brouillon', 'non_payee', 'refusee' ), true ) ) : ?>
                                                 <a href="<?php echo esc_url( add_query_arg( 'edit_licence', $licence->id ?? 0 ) ); ?>"
                                                    class="ufsc-btn ufsc-btn-small"


### PR DESCRIPTION
## Summary
- Show "Envoyer au panier" button in licence actions when status is brouillon
- Build WooCommerce add-to-cart URL with licence ID and product ID from settings

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `phpunit --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b86a06a3c8832bbf5ad6567f751c8a