### PR TITLE
feat: add draft filter and badge styling

### DIFF
--- a/assets/frontend/css/frontend.css
+++ b/assets/frontend/css/frontend.css
@@ -179,10 +179,26 @@
     font-size: 0.9rem;
 }
 
+.ufsc-filter-checkbox-label {
+    display: flex;
+    align-items: center;
+    font-size: 0.9rem;
+}
+
+.ufsc-filter-checkbox-label input {
+    margin-right: 0.25rem;
+}
+
 /* // UFSC: Recent Licenses Table */
 .ufsc-recent-licences table {
     width: 100%;
     border-collapse: collapse;
+}
+
+.ufsc-table-note {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: #6c757d;
 }
 
 .ufsc-recent-licences th,
@@ -240,8 +256,9 @@
 }
 
 .ufsc-badge.-draft {
-    background: #f8f9fa;
-    color: #6c757d;
+    background: #fff9c4;
+    color: #856404;
+    border: 1px dotted #d39e00;
 }
 
 .ufsc-badge.-pending {

--- a/assets/js/frontend-dashboard.js
+++ b/assets/js/frontend-dashboard.js
@@ -63,7 +63,7 @@
             });
 
             // // UFSC: Filters
-            $('.ufsc-filter').on('change', function() {
+            $('.ufsc-filter, .ufsc-filter-checkbox').on('change', function() {
                 self.applyFilters();
             });
 
@@ -217,6 +217,7 @@
         loadRecentLicences: function() {
             var self = this;
             var filters = this.getCurrentFilters();
+            filters.drafts_only = $('#filter-drafts').is(':checked') ? 1 : 0;
             var cacheKey = 'recent_licences_' + this.config.club_id + '_' + JSON.stringify(filters);
 
             if (this.isCacheValid(cacheKey)) {
@@ -259,8 +260,9 @@
                 html += '<td>' + self.renderLicenceActions(licence) + '</td>';
                 html += '</tr>';
             });
-            
+
             html += '</tbody></table>';
+            html += '<p class="ufsc-table-note">Utilisez le filtre « Afficher seulement les brouillons » pour ne voir que ces licences.</p>';
             container.html(html);
         },
 

--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -799,6 +799,10 @@ class UFSC_REST_API {
             $where_conditions[] = "role = %s";
             $where_values[] = sanitize_text_field( $filters['role'] );
         }
+
+        if ( ! empty( $filters['drafts_only'] ) ) {
+            $where_conditions[] = "statut = 'brouillon'";
+        }
         
         if ( isset( $filters['competition'] ) && $filters['competition'] !== '' ) {
             $where_conditions[] = "competition = %d";

--- a/templates/frontend/club-dashboard.php
+++ b/templates/frontend/club-dashboard.php
@@ -69,6 +69,10 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                     <option value="1"><?php echo esc_html__( 'Compétition', 'ufsc-clubs' ); ?></option>
                     <option value="0"><?php echo esc_html__( 'Loisir', 'ufsc-clubs' ); ?></option>
                 </select>
+                <label class="ufsc-filter-checkbox-label">
+                    <input type="checkbox" id="filter-drafts" class="ufsc-filter-checkbox" />
+                    <?php echo esc_html__( 'Afficher seulement les brouillons', 'ufsc-clubs' ); ?>
+                </label>
                 <button id="btn-export-csv" class="ufsc-btn ufsc-btn-secondary">
                     <span class="dashicons dashicons-download" aria-hidden="true"></span>
                     <?php echo esc_html__( 'Export CSV', 'ufsc-clubs' ); ?>


### PR DESCRIPTION
## Summary
- strengthen `-draft` badge with pale yellow background and dotted border
- add checkbox to filter licences to drafts only and show an explanatory note
- support `drafts_only` filter in recent licences API

## Testing
- `php -l includes/api/class-rest-api.php`
- `php -l templates/frontend/club-dashboard.php`
- `php tests/test-frontend.php` *(fails: Class "PHPUnit\Framework\TestCase" not found)*
- `apt-get update` *(fails: 403  Forbidden)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a0dcf30832bafb40f5084ca9141