### PR TITLE
Expose REST API URL to dashboard script

### DIFF
--- a/assets/js/frontend-dashboard.js
+++ b/assets/js/frontend-dashboard.js
@@ -30,6 +30,7 @@
             // Get club ID from dashboard configuration
             var dashboardConfig = window.ufsc_dashboard_vars || {};
             this.config.club_id = dashboardConfig.club_id || this.config.club_id;
+            this.config.rest_url = dashboardConfig.rest_url || this.config.rest_url;
             
             if (!this.config.club_id) {
                 console.warn('UFSC Dashboard: No club ID provided');

--- a/includes/frontend/class-club-dashboard.php
+++ b/includes/frontend/class-club-dashboard.php
@@ -218,8 +218,9 @@ class UFSC_Club_Dashboard {
         // Localize script for AJAX
         wp_localize_script( 'ufsc-dashboard', 'ufsc_dashboard_vars', array(
             'ajax_url' => admin_url( 'admin-ajax.php' ),
-            'nonce' => wp_create_nonce( 'ufsc_club_dashboard' ),
+            'nonce'   => wp_create_nonce( 'ufsc_club_dashboard' ),
             'club_id' => self::get_user_club_id( get_current_user_id() ),
+            'rest_url' => rest_url( 'ufsc/v1/' ),
             'strings' => array(
                 'loading' => __( 'Chargement...', 'ufsc-clubs' ),
                 'error' => __( 'Erreur lors du chargement', 'ufsc-clubs' ),


### PR DESCRIPTION
## Summary
- Pass REST API base URL to `ufsc-dashboard` script
- Initialize dashboard JS with REST API URL from localized variables

## Testing
- `php -l includes/frontend/class-club-dashboard.php`
- `node --check assets/js/frontend-dashboard.js`
- `phpunit tests/` *(fails: command not found)*
- `composer require --dev phpunit/phpunit` *(fails: curl error 56 CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b99583b7b8832b91bfa03257c7fba5