### PR TITLE
fix: define self before updating recent licences

### DIFF
--- a/assets/js/frontend-dashboard.js
+++ b/assets/js/frontend-dashboard.js
@@ -241,6 +241,7 @@
 
         // // UFSC: Update recent licenses display
         updateRecentLicences: function(licences) {
+            var self = this;
             var container = $('#ufsc-recent-licences');
             
             if (!licences || licences.length === 0) {


### PR DESCRIPTION
## Summary
- Avoid `self` being undefined by assigning `var self = this` at the start of `updateRecentLicences`

## Testing
- `node - <<'NODE' ... NODE` *(renders recent licences table without errors)*
- `phpunit --version` *(fails: command not found)*
- `composer global require phpunit/phpunit` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9957c204c832b9d14a6372e041089