### PR TITLE
Add REST nonce to frontend requests

### DIFF
--- a/assets/js/frontend-dashboard.js
+++ b/assets/js/frontend-dashboard.js
@@ -802,7 +802,8 @@
                 url: url,
                 type: 'GET',
                 beforeSend: function(xhr) {
-                    xhr.setRequestHeader('X-WP-Nonce', window.ufsc_frontend_vars ? window.ufsc_frontend_vars.nonce : '');
+                    var nonce = window.ufsc_frontend_vars && window.ufsc_frontend_vars.rest_nonce ? window.ufsc_frontend_vars.rest_nonce : '';
+                    xhr.setRequestHeader('X-WP-Nonce', nonce);
                 },
                 success: function(response) {
                     successCallback(response);
@@ -823,7 +824,8 @@
                 url: this.config.rest_url + endpoint,
                 type: 'DELETE',
                 beforeSend: function(xhr) {
-                    xhr.setRequestHeader('X-WP-Nonce', window.ufsc_frontend_vars ? window.ufsc_frontend_vars.nonce : '');
+                    var nonce = window.ufsc_frontend_vars && window.ufsc_frontend_vars.rest_nonce ? window.ufsc_frontend_vars.rest_nonce : '';
+                    xhr.setRequestHeader('X-WP-Nonce', nonce);
                 },
                 success: function(response) {
                     successCallback(response);

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -147,6 +147,7 @@ final class UFSC_CL_Bootstrap {
                 'ajax_url' => admin_url( 'admin-ajax.php' ),
                 'rest_url' => rest_url( 'ufsc/v1/' ),
                 'nonce' => wp_create_nonce( 'ufsc_frontend_nonce' ),
+                'rest_nonce' => wp_create_nonce( 'wp_rest' ),
                 'strings' => array(
                     'saving' => __( 'Enregistrement...', 'ufsc-clubs' ),
                     'loading' => __( 'Chargement...', 'ufsc-clubs' ),


### PR DESCRIPTION
## Summary
- Add `rest_nonce` to localized frontend vars using `wp_create_nonce('wp_rest')`
- Pass `rest_nonce` via `X-WP-Nonce` header in dashboard REST requests

## Testing
- `php -l ufsc-clubs-licences-sql.php`
- `node --check assets/js/frontend-dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68b995763504832baec6716f839552e1