### PR TITLE
Add save licence handler hooks and streamline licence form

### DIFF
--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -18,6 +18,8 @@ class UFSC_Unified_Handlers {
         add_action( 'admin_post_nopriv_ufsc_add_licence', array( __CLASS__, 'handle_add_licence' ) );
         add_action( 'admin_post_ufsc_update_licence', array( __CLASS__, 'handle_update_licence' ) );
         add_action( 'admin_post_nopriv_ufsc_update_licence', array( __CLASS__, 'handle_update_licence' ) );
+        add_action( 'admin_post_ufsc_save_licence', array( __CLASS__, 'handle_save_licence' ) );
+        add_action( 'admin_post_nopriv_ufsc_save_licence', array( __CLASS__, 'handle_save_licence' ) );
 
         add_action( 'admin_post_ufsc_delete_licence', array( __CLASS__, 'handle_delete_licence' ) );
         add_action( 'admin_post_nopriv_ufsc_delete_licence', array( __CLASS__, 'handle_delete_licence' ) );

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -931,21 +931,12 @@ class UFSC_Frontend_Shortcodes {
 
             <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-licence-form">
 
-
-                <input type="hidden" name="action" value="ufsc_add_licence">
-                <?php wp_nonce_field( 'ufsc_add_licence', 'ufsc_nonce' ); ?>
-
-
-                <input type="hidden" name="action" value="ufsc_add_licence">
+                <input type="hidden" name="action" value="ufsc_save_licence">
+                <?php wp_nonce_field( 'ufsc_save_licence' ); ?>
                 <input type="hidden" name="ufsc_submit_action" id="ufsc_submit_action" value="save">
 
-
                 <div class="ufsc-notices" aria-live="polite"></div>
-                <input type="hidden" name="action" value="ufsc_save_licence">
 
-                <?php wp_nonce_field( 'ufsc_save_licence', '_wpnonce' ); ?>
-
-                
                 <!-- // UFSC: Enhanced form structure with conditional fields -->
                 <div class="ufsc-grid">
                     <div class="ufsc-card ufsc-form-section">


### PR DESCRIPTION
## Summary
- register admin_post handlers for unified licence saving
- simplify add licence form to use single action and nonce

## Testing
- `php -l includes/core/class-unified-handlers.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99c90b4f0832bac0e08cf235360af