### PR TITLE
Use ufsc_error query key and clean error URLs

### DIFF
--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -783,7 +783,7 @@ class UFSC_Unified_Handlers {
 
     private static function redirect_with_error( $message, $licence_id = null ) {
         $redirect_url = wp_get_referer() ?: home_url();
-        $args = array( 'error' => urlencode( $message ) );
+        $args         = array( 'ufsc_error' => urlencode( $message ) );
         if ( $licence_id ) {
             $args['licence_id'] = $licence_id;
         }

--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -518,10 +518,11 @@ class UFSC_CL_Club_Form {
             $message = sanitize_text_field( $_GET['ufsc_success'] );
             echo '<div class="ufsc-alert success">' . esc_html( $message ) . '</div>';
         }
-        
+
         if ( isset( $_GET['ufsc_error'] ) ) {
             $message = sanitize_text_field( $_GET['ufsc_error'] );
             echo '<div class="ufsc-alert error">' . esc_html( $message ) . '</div>';
+            echo '<script>if(window.history.replaceState){const url=new URL(window.location);url.searchParams.delete("ufsc_error");window.history.replaceState({},document.title,url.pathname+url.search+url.hash);}</script>';
         }
     }
 }

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -251,6 +251,7 @@ class UFSC_Frontend_Shortcodes {
                     <div class="ufsc-message ufsc-success"><?php echo esc_html( $_GET['ufsc_message'] ); ?></div>
                 <?php elseif ( isset( $_GET['ufsc_error'] ) ) : ?>
                     <div class="ufsc-message ufsc-error"><?php echo esc_html( $_GET['ufsc_error'] ); ?></div>
+                    <script>if(window.history.replaceState){const url=new URL(window.location);url.searchParams.delete('ufsc_error');window.history.replaceState({},document.title,url.pathname+url.search+url.hash);}</script>
                 <?php endif; ?>
             </div>
             <div class="ufsc-section-header">


### PR DESCRIPTION
## Summary
- switch unified handler redirect to `ufsc_error` query key
- clean `ufsc_error` from frontend URLs after displaying messages

## Testing
- `php -l includes/core/class-unified-handlers.php`
- `php -l includes/frontend/class-club-form.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99b328f1c832ba93f1762b8e53f55