### PR TITLE
Use cart URL when adding licence to cart

### DIFF
--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -379,8 +379,8 @@ class UFSC_Unified_Handlers {
                 WC()->cart->add_to_cart( PRODUCT_ID_LICENCE, 1, 0, array(), array( 'licence_id' => $new_id, 'club_id' => $club_id ) );
             }
             self::update_licence_status_db( $new_id, 'pending' );
-            if ( function_exists( 'wc_get_checkout_url' ) ) {
-                wp_safe_redirect( wc_get_checkout_url() );
+            if ( function_exists( 'wc_get_cart_url' ) ) {
+                wp_safe_redirect( wc_get_cart_url() );
                 exit;
             }
         }


### PR DESCRIPTION
## Summary
- Redirect to cart page instead of checkout when adding a licence to the WooCommerce cart

## Testing
- `php -l includes/core/class-unified-handlers.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ce93560832b84eb2c182f05f696