### PR TITLE
feat: improve club profile layout

### DIFF
--- a/assets/css/ufsc-front.css
+++ b/assets/css/ufsc-front.css
@@ -74,6 +74,8 @@
 .ufsc-club-profile .ufsc-card h4,
 .ufsc-club-profile fieldset legend {
     font-size: 1.1rem;
+    font-weight: 600;
+    line-height: 1.4;
     margin-bottom: var(--ufsc-spacing-sm);
     color: var(--ufsc-secondary);
 }
@@ -81,13 +83,14 @@
 .ufsc-club-profile fieldset {
     margin-bottom: var(--ufsc-spacing-lg);
     padding: var(--ufsc-spacing-md);
+    background: #ffffff;
     border: 1px solid #e1e5e9;
     border-radius: 8px;
 }
 
 /* Field */
-.ufsc-field {
-    margin-bottom: var(--ufsc-spacing-sm);
+.ufsc-club-profile .ufsc-field {
+    margin-bottom: var(--ufsc-spacing-md);
 }
 .ufsc-field label {
     display: block;

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -644,30 +644,28 @@ class UFSC_Frontend_Shortcodes {
                 <input type="hidden" name="action" value="ufsc_save_club">
                 <?php wp_nonce_field( 'ufsc_save_club', 'ufsc_club_nonce' ); ?>
                 
-                <div class="ufsc-grid">
-                    <!-- // UFSC: Identité du club -->
-                    <div class="ufsc-card ufsc-section">
-                        <h4><?php esc_html_e( 'Identité du club', 'ufsc-clubs' ); ?></h4>
+                <!-- // UFSC: Identité du club -->
+                <div class="ufsc-card ufsc-section">
+                    <h4><?php esc_html_e( 'Identité du club', 'ufsc-clubs' ); ?></h4>
 
-                        <div class="ufsc-grid">
-                            <?php self::render_field( 'nom', $club, __( 'Nom du club', 'ufsc-clubs' ), 'text', true, $is_admin ); ?>
-                            <?php self::render_field( 'region', $club, __( 'Région', 'ufsc-clubs' ), 'text', true, $is_admin ); ?>
-                            <?php self::render_field( 'num_affiliation', $club, __( 'N° d\'affiliation', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
-                            <?php self::render_field( 'statut', $club, __( 'Statut', 'ufsc-clubs' ), 'text', true, false ); ?>
-                        </div>
+                    <div class="ufsc-grid">
+                        <?php self::render_field( 'nom', $club, __( 'Nom du club', 'ufsc-clubs' ), 'text', true, $is_admin ); ?>
+                        <?php self::render_field( 'region', $club, __( 'Région', 'ufsc-clubs' ), 'text', true, $is_admin ); ?>
+                        <?php self::render_field( 'num_affiliation', $club, __( 'N° d\'affiliation', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
+                        <?php self::render_field( 'statut', $club, __( 'Statut', 'ufsc-clubs' ), 'text', true, false ); ?>
                     </div>
+                </div>
 
-                    <!-- // UFSC: Coordonnées -->
-                    <div class="ufsc-card ufsc-section">
-                        <h4><?php esc_html_e( 'Coordonnées', 'ufsc-clubs' ); ?></h4>
+                <!-- // UFSC: Coordonnées -->
+                <div class="ufsc-card ufsc-section">
+                    <h4><?php esc_html_e( 'Coordonnées', 'ufsc-clubs' ); ?></h4>
 
-                        <div class="ufsc-grid">
-                            <?php self::render_field( 'adresse', $club, __( 'Adresse', 'ufsc-clubs' ), 'textarea', false, $is_admin ); ?>
-                            <?php self::render_field( 'code_postal', $club, __( 'Code postal', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
-                            <?php self::render_field( 'ville', $club, __( 'Ville', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
-                            <?php self::render_field( 'email', $club, __( 'Email', 'ufsc-clubs' ), 'email', false, true ); ?>
-                            <?php self::render_field( 'telephone', $club, __( 'Téléphone', 'ufsc-clubs' ), 'tel', false, true ); ?>
-                        </div>
+                    <div class="ufsc-grid">
+                        <?php self::render_field( 'adresse', $club, __( 'Adresse', 'ufsc-clubs' ), 'textarea', false, $is_admin ); ?>
+                        <?php self::render_field( 'code_postal', $club, __( 'Code postal', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
+                        <?php self::render_field( 'ville', $club, __( 'Ville', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
+                        <?php self::render_field( 'email', $club, __( 'Email', 'ufsc-clubs' ), 'email', false, true ); ?>
+                        <?php self::render_field( 'telephone', $club, __( 'Téléphone', 'ufsc-clubs' ), 'tel', false, true ); ?>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- ensure club profile sections use dedicated grids for fields
- fine-tune typography and spacing for a cleaner look

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99c4359c4832b8b05a6e7bd656dae