### PR TITLE
Fix actions column layout in licences table

### DIFF
--- a/assets/admin/css/admin.css
+++ b/assets/admin/css/admin.css
@@ -67,6 +67,19 @@
 }
 
 /* Table improvements */
+.wrap {
+    overflow-x: auto;
+}
+
+.wp-list-table {
+    table-layout: fixed;
+}
+
+.wp-list-table th,
+.wp-list-table td {
+    word-break: break-word;
+}
+
 .wp-list-table.ufsc-enhanced {
     border-collapse: collapse;
     width: 100%;
@@ -99,19 +112,15 @@
 
 /* Actions column improvements */
 .wp-list-table .column-actions {
-    width: 150px;
-    white-space: nowrap;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
 }
 
 .wp-list-table .column-actions .button {
-    margin-right: 4px;
     padding: 4px 8px;
     font-size: 12px;
     line-height: 1.2;
-}
-
-.wp-list-table .column-actions .button:last-child {
-    margin-right: 0;
 }
 
 /* Quick status dropdown styling */

--- a/includes/admin/list-tables/class-ufsc-licences-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-licences-list-table.php
@@ -340,7 +340,7 @@ class UFSC_Licences_List_Table {
         echo '<th>' . esc_html__( 'Paiement', 'ufsc-clubs' ) . '</th>';
         echo '<th>' . esc_html__( 'Médical', 'ufsc-clubs' ) . '</th>';
         echo '<th>' . self::get_sortable_header( 'date_creation', __( 'Créé le', 'ufsc-clubs' ), $sorting ) . '</th>';
-        echo '<th>' . esc_html__( 'Actions', 'ufsc-clubs' ) . '</th>';
+        echo '<th class="column-actions">' . esc_html__( 'Actions', 'ufsc-clubs' ) . '</th>';
         echo '</tr>';
         echo '</thead>';
         echo '<tbody>';
@@ -405,7 +405,7 @@ class UFSC_Licences_List_Table {
         echo '<td>' . esc_html( mysql2date( 'd/m/Y', $licence->date_creation ) ) . '</td>';
         
         // Actions
-        echo '<td>';
+        echo '<td class="column-actions">';
         $view_url = admin_url( 'admin.php?page=ufsc-sql-licences&action=view&id=' . $licence->id );
         $edit_url = admin_url( 'admin.php?page=ufsc-sql-licences&action=edit&id=' . $licence->id );
         echo '<a href="' . esc_url( $view_url ) . '" class="button button-small">' . esc_html__( 'Consulter', 'ufsc-clubs' ) . '</a> ';


### PR DESCRIPTION
## Summary
- ensure actions column markup uses `column-actions` for styling
- allow admin table to wrap and flex action buttons for better layout
- prevent excessive widths with fixed table layout and word breaking

## Testing
- `php -l includes/admin/list-tables/class-ufsc-licences-list-table.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a8f54288832bb9909eb52b51bd17