### PR TITLE
Use ufsc_error query parameter and clean URL

### DIFF
--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -785,10 +785,13 @@ class UFSC_Unified_Handlers {
 
     private static function redirect_with_error( $message, $licence_id = null ) {
         $redirect_url = wp_get_referer() ?: home_url();
-        $args         = array( 'ufsc_error' => urlencode( $message ) );
+        $redirect_url = remove_query_arg( 'ufsc_error', $redirect_url );
+
+        $args = array( 'ufsc_error' => rawurlencode( $message ) );
         if ( $licence_id ) {
             $args['licence_id'] = $licence_id;
         }
+
         wp_safe_redirect( add_query_arg( $args, $redirect_url ) );
         exit;
     }

--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -520,9 +520,11 @@ class UFSC_CL_Club_Form {
         }
 
         if ( isset( $_GET['ufsc_error'] ) ) {
-            $message = sanitize_text_field( $_GET['ufsc_error'] );
+            $message   = sanitize_text_field( $_GET['ufsc_error'] );
+            $clean_url = esc_url( remove_query_arg( 'ufsc_error' ) );
+
             echo '<div class="ufsc-alert error">' . esc_html( $message ) . '</div>';
-            echo '<script>if(window.history.replaceState){const url=new URL(window.location);url.searchParams.delete("ufsc_error");window.history.replaceState({},document.title,url.pathname+url.search+url.hash);}</script>';
+            echo '<script>if(window.history.replaceState){window.history.replaceState({},document.title,\'' . $clean_url . '\');}</script>';
         }
     }
 }

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -251,7 +251,12 @@ class UFSC_Frontend_Shortcodes {
                     <div class="ufsc-message ufsc-success"><?php echo esc_html( $_GET['ufsc_message'] ); ?></div>
                 <?php elseif ( isset( $_GET['ufsc_error'] ) ) : ?>
                     <div class="ufsc-message ufsc-error"><?php echo esc_html( $_GET['ufsc_error'] ); ?></div>
-                    <script>if(window.history.replaceState){const url=new URL(window.location);url.searchParams.delete('ufsc_error');window.history.replaceState({},document.title,url.pathname+url.search+url.hash);}</script>
+                    <?php $clean_url = esc_url( remove_query_arg( 'ufsc_error' ) ); ?>
+                    <script>
+                        if ( window.history.replaceState ) {
+                            window.history.replaceState( {}, document.title, '<?php echo $clean_url; ?>' );
+                        }
+                    </script>
                 <?php endif; ?>
             </div>
             <div class="ufsc-section-header">


### PR DESCRIPTION
## Summary
- Redirect with error now uses `ufsc_error` query key and clears any previous error parameter before redirecting
- Frontend components remove `ufsc_error` from the URL after displaying messages for cleaner addresses

## Testing
- `php -l includes/core/class-unified-handlers.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l includes/frontend/class-club-form.php`
- `phpunit tests/test-core.php` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a842bda4832ba4ef0d06143501e6