### PR TITLE
Simplify licence actions visibility

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -374,31 +374,25 @@ class UFSC_Frontend_Shortcodes {
                                                 <?php esc_html_e( 'Consulter', 'ufsc-clubs' ); ?>
                                             </a>
 
-                                            <?php if ( in_array( $licence->statut ?? '', array( 'brouillon', 'non_payee', 'rejected' ), true ) ) : ?>
-
-
-                                            <?php if ( 'brouillon' === ( $licence->statut ?? '' ) ) : ?>
-                                                <a href="<?php echo esc_url( add_query_arg( array(
-                                                    'ufsc_add_to_cart' => $wc_settings['product_license_id'],
-                                                    'ufsc_license_ids' => $licence->id ?? 0,
-                                                ), '' ) ); ?>"
-                                                   class="ufsc-btn ufsc-btn-small"
-                                                   aria-label="<?php esc_attr_e( 'Envoyer la licence au panier', 'ufsc-clubs' ); ?>">
-                                                    <?php esc_html_e( 'Envoyer au panier', 'ufsc-clubs' ); ?>
-                                                </a>
-                                            <?php endif; ?>
-                                            <?php if ( in_array( $licence->statut ?? '', array( 'brouillon', 'non_payee', 'refusee' ), true ) ) : ?>
-
-                                            <?php if ( in_array( $licence->statut ?? '', array( 'brouillon' ), true ) ) : ?>
-
-
-                                                <a href="<?php echo esc_url( add_query_arg( 'edit_licence', $licence->id ?? 0 ) ); ?>"
-                                                   class="ufsc-btn ufsc-btn-small"
-                                                   aria-label="<?php esc_attr_e( 'Modifier la licence', 'ufsc-clubs' ); ?>">
-                                                    <?php esc_html_e( 'Modifier', 'ufsc-clubs' ); ?>
-                                                </a>
-                                            <?php endif; ?>
-        <?php if ( in_array( $licence->statut ?? '', array( 'brouillon', 'non_payee' ), true ) ) : ?>
+                                            <?php
+                                            $licence_status = $licence->statut ?? '';
+                                            if ( in_array( $licence_status, array( 'brouillon', 'non_payee' ), true ) ) :
+                                                if ( 'brouillon' === $licence_status ) :
+                                                    ?>
+                                                    <a href="<?php echo esc_url( add_query_arg( array(
+                                                        'ufsc_add_to_cart' => $wc_settings['product_license_id'],
+                                                        'ufsc_license_ids' => $licence->id ?? 0,
+                                                    ), '' ) ); ?>"
+                                                       class="ufsc-btn ufsc-btn-small"
+                                                       aria-label="<?php esc_attr_e( 'Envoyer la licence au panier', 'ufsc-clubs' ); ?>">
+                                                        <?php esc_html_e( 'Envoyer au panier', 'ufsc-clubs' ); ?>
+                                                    </a>
+                                                    <a href="<?php echo esc_url( add_query_arg( 'edit_licence', $licence->id ?? 0 ) ); ?>"
+                                                       class="ufsc-btn ufsc-btn-small"
+                                                       aria-label="<?php esc_attr_e( 'Modifier la licence', 'ufsc-clubs' ); ?>">
+                                                        <?php esc_html_e( 'Modifier', 'ufsc-clubs' ); ?>
+                                                    </a>
+                                                <?php endif; ?>
                                                 <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-delete-licence-form" style="display:inline">
                                                     <?php wp_nonce_field( 'ufsc_delete_licence', 'ufsc_delete_licence_nonce' ); ?>
                                                     <input type="hidden" name="action" value="ufsc_delete_licence">
@@ -407,8 +401,6 @@ class UFSC_Frontend_Shortcodes {
                                                         <?php esc_html_e( 'Supprimer', 'ufsc-clubs' ); ?>
                                                     </button>
                                                 </form>
-                                            <?php endif; ?>
-                                            <?php endif; ?>
                                             <?php endif; ?>
                                         </div>
                                     </td>


### PR DESCRIPTION
## Summary
- streamline licence actions display logic and ensure draft/unpaid statuses show edit and delete options

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php /tmp/test_licence_actions.php`
- `phpunit tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a805fe18832b9fd1ab8105060a83