### PR TITLE
feat: add quick access to licence creation form

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -257,6 +257,10 @@ class UFSC_Frontend_Shortcodes {
             <div class="ufsc-section-header">
                 <h3><?php printf( 'Mes Licences – %s', esc_html( $club_name ) ); ?></h3>
                 <div class="ufsc-section-actions">
+                    <a href="<?php echo esc_url( add_query_arg( 'edit_licence', 0 ) ); ?>"
+                       class="ufsc-btn ufsc-btn-primary">
+                        <?php esc_html_e( 'Ajouter une licence', 'ufsc-clubs' ); ?>
+                    </a>
                     <a href="<?php echo esc_url( add_query_arg( 'ufsc_export', 'csv' ) ); ?>"
                        class="ufsc-btn ufsc-btn-secondary">
                         <?php esc_html_e( 'Exporter CSV', 'ufsc-clubs' ); ?>


### PR DESCRIPTION
## Summary
- add "Ajouter une licence" button in club licences section for easy access to creation form

## Testing
- `phpunit tests/test-frontend.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a80197c8832b9c83cc640035086a