### PR TITLE
Affiche tous les champs de la licence

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -471,16 +471,48 @@ class UFSC_Frontend_Shortcodes {
             <table class="ufsc-table ufsc-licence-info">
                 <tbody>
                     <tr>
-                        <th><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></th>
-                        <td><?php echo esc_html( $licence->nom ?? '' ); ?></td>
-                    </tr>
-                    <tr>
                         <th><?php esc_html_e( 'Prénom', 'ufsc-clubs' ); ?></th>
                         <td><?php echo esc_html( $licence->prenom ?? '' ); ?></td>
                     </tr>
                     <tr>
+                        <th><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></th>
+                        <td><?php echo esc_html( $licence->nom ?? '' ); ?></td>
+                    </tr>
+                    <tr>
                         <th>Email</th>
                         <td><?php echo esc_html( $licence->email ?? '' ); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Date de naissance', 'ufsc-clubs' ); ?></th>
+                        <td><?php echo esc_html( $licence->date_naissance ?? '' ); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Rôle', 'ufsc-clubs' ); ?></th>
+                        <td><?php echo esc_html( $licence->role ?? '' ); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Réduction postier', 'ufsc-clubs' ); ?></th>
+                        <td><?php echo $licence->reduction_postier ? esc_html__( 'Oui', 'ufsc-clubs' ) : esc_html__( 'Non', 'ufsc-clubs' ); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Identifiant La Poste', 'ufsc-clubs' ); ?></th>
+                        <td><?php echo esc_html( $licence->identifiant_laposte ?? '' ); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Réduction bénévole', 'ufsc-clubs' ); ?></th>
+                        <td><?php echo $licence->reduction_benevole ? esc_html__( 'Oui', 'ufsc-clubs' ) : esc_html__( 'Non', 'ufsc-clubs' ); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Licence délégataire', 'ufsc-clubs' ); ?></th>
+                        <td><?php echo $licence->licence_delegataire ? esc_html__( 'Oui', 'ufsc-clubs' ) : esc_html__( 'Non', 'ufsc-clubs' ); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Numéro de licence délégataire', 'ufsc-clubs' ); ?></th>
+                        <td><?php echo esc_html( $licence->numero_licence_delegataire ?? '' ); ?></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Note', 'ufsc-clubs' ); ?></th>
+                        <td><?php echo esc_html( $licence->note ?? '' ); ?></td>
                     </tr>
                     <tr>
                         <th><?php esc_html_e( 'Statut', 'ufsc-clubs' ); ?></th>


### PR DESCRIPTION
## Summary
- Display all licence fields in the single licence view.

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php /tmp/test_render_single_licence.php > /tmp/test_output.html && tail -n 20 /tmp/test_output.html`
- `composer global require phpunit/phpunit:^9` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a7fc0bf0832b8bbdb24ad9595e97