### PR TITLE
Switch licence handlers to WordPress nonce field

### DIFF
--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -59,7 +59,7 @@ class UFSC_Unified_Handlers {
      * Handle licence creation.
      */
     public static function handle_add_licence() {
-        if ( ! wp_verify_nonce( $_POST['ufsc_nonce'], 'ufsc_add_licence' ) ) {
+        if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_add_licence' ) ) {
             wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
         }
 
@@ -107,7 +107,7 @@ class UFSC_Unified_Handlers {
      * Handle licence update
      */
     public static function handle_update_licence() {
-        if ( ! wp_verify_nonce( $_POST['ufsc_nonce'], 'ufsc_update_licence' ) ) {
+        if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_update_licence' ) ) {
             wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
         }
 
@@ -195,7 +195,7 @@ class UFSC_Unified_Handlers {
      * Handle licence deletion
      */
     public static function handle_delete_licence() {
-        if ( ! wp_verify_nonce( $_POST['ufsc_nonce'], 'ufsc_delete_licence' ) ) {
+        if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_delete_licence' ) ) {
             wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
         }
 
@@ -234,7 +234,7 @@ class UFSC_Unified_Handlers {
      * Handle licence status update
      */
     public static function handle_update_licence_status() {
-        if ( ! wp_verify_nonce( $_POST['ufsc_nonce'], 'ufsc_update_licence_status' ) ) {
+        if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_update_licence_status' ) ) {
             wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
         }
 

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -403,7 +403,7 @@ class UFSC_Frontend_Shortcodes {
                                                     </a>
                                                 <?php endif; ?>
                                                 <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-delete-licence-form" style="display:inline">
-                                                    <?php wp_nonce_field( 'ufsc_delete_licence', 'ufsc_delete_licence_nonce' ); ?>
+                                                    <?php wp_nonce_field( 'ufsc_delete_licence' ); ?>
                                                     <input type="hidden" name="action" value="ufsc_delete_licence">
                                                     <input type="hidden" name="licence_id" value="<?php echo esc_attr( $licence->id ?? 0 ); ?>">
                                                     <button type="submit" class="ufsc-btn ufsc-btn-small ufsc-btn-danger" aria-label="<?php esc_attr_e( 'Supprimer la licence', 'ufsc-clubs' ); ?>">
@@ -919,7 +919,7 @@ class UFSC_Frontend_Shortcodes {
 
 
         // Handle form submission
-        if ( isset( $_POST['ufsc_add_licence'] ) && wp_verify_nonce( $_POST['ufsc_nonce'], 'ufsc_add_licence' ) ) {
+        if ( isset( $_POST['ufsc_add_licence'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_add_licence' ) ) {
             $result = self::handle_licence_creation( $atts['club_id'], $_POST );
             if ( $result['success'] ) {
                 echo '<div class="ufsc-message ufsc-success">' . esc_html( $result['message'] ) . '</div>';

--- a/templates/frontend/licences-list.php
+++ b/templates/frontend/licences-list.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                                 <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-inline-form">
                                     <input type="hidden" name="action" value="ufsc_delete_licence" />
                                     <input type="hidden" name="licence_id" value="<?php echo intval( $licence->id ); ?>" />
-                                    <?php wp_nonce_field( 'ufsc_delete_licence_' . $licence->id ); ?>
+                                    <?php wp_nonce_field( 'ufsc_delete_licence' ); ?>
                                     <button type="submit" class="ufsc-action ufsc-delete">
                                         <?php esc_html_e( 'Supprimer', 'ufsc-clubs' ); ?>
                                     </button>

--- a/tests/test-frontend.php
+++ b/tests/test-frontend.php
@@ -211,7 +211,7 @@ class UFSC_Frontend_Test extends PHPUnit\Framework\TestCase {
         $output = $this->simulate_shortcode_output();
         
         $this->assertStringContainsString( 'wp_nonce_field', $output );
-        $this->assertStringContainsString( 'ufsc_nonce', $output );
+        $this->assertStringContainsString( '_wpnonce', $output );
     }
 
     /**
@@ -263,7 +263,7 @@ class UFSC_Frontend_Test extends PHPUnit\Framework\TestCase {
                     <form>
                         <label for="test">Test Field</label>
                         <input type="text" id="test" name="test">
-                        ' . wp_nonce_field( 'ufsc_nonce', 'ufsc_nonce', true, false ) . '
+                        ' . wp_nonce_field( 'ufsc_save_licence', '_wpnonce', true, false ) . '
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- verify `_wpnonce` instead of `ufsc_nonce` in licence handlers
- update frontend forms and tests to use standard `_wpnonce` field

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b9ac1568832bbee2399a28e0788c