### PR TITLE
Display server-provided export error details

### DIFF
--- a/assets/frontend/js/frontend.js
+++ b/assets/frontend/js/frontend.js
@@ -351,7 +351,18 @@ jQuery(document).ready(function($) {
                     document.body.removeChild(a);
                     URL.revokeObjectURL(downloadUrl);
                 } else {
-                    alert(ufsc_frontend_vars.strings.ajax_error);
+                    if (xhr.response && typeof xhr.response.text === 'function') {
+                        xhr.response
+                            .text()
+                            .then(function(text) {
+                                alert(text);
+                            })
+                            .catch(function() {
+                                alert(ufsc_frontend_vars.strings.ajax_error);
+                            });
+                    } else {
+                        alert(xhr.responseText || xhr.response || ufsc_frontend_vars.strings.ajax_error);
+                    }
                 }
 
                 $btn.removeClass('ufsc-loading').prop('disabled', false);


### PR DESCRIPTION
## Summary
- show detailed server response when export request fails

## Testing
- `node --check assets/frontend/js/frontend.js`
- `node - <<'NODE'
const blob = new Blob(['Detailed error']);
blob.text().then(t => console.log('Simulated alert:', t));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b9c284e1a8832ba3c80cdd446294a5