### PR TITLE
Send multiple licence IDs individually for export

### DIFF
--- a/assets/frontend/js/frontend.js
+++ b/assets/frontend/js/frontend.js
@@ -313,7 +313,7 @@ jQuery(document).ready(function($) {
                 return $(this).val();
             }).get();
             if (selectedIds.length) {
-                url.searchParams.set('ids', selectedIds.join(','));
+                selectedIds.forEach(id => url.searchParams.append('ids[]', id));
             }
 
             // UI feedback


### PR DESCRIPTION
## Summary
- Send each selected licence ID as repeated `ids[]` params instead of comma-separated string to ensure backend receives all values

## Testing
- `php -r 'parse_str("ids[]=1&ids[]=2&ids[]=3", $_REQUEST); var_export(array_map("intval", (array) $_REQUEST["ids"]));'`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c283b50c832b80b48045551a4703