### PR TITLE
Fix cache data retrieval for notifications and audit log

### DIFF
--- a/assets/js/frontend-dashboard.js
+++ b/assets/js/frontend-dashboard.js
@@ -353,7 +353,7 @@
             var cacheKey = 'notifications_' + this.config.club_id;
 
             if (this.isCacheValid(cacheKey)) {
-                this.updateNotifications(this.cache[cacheKey]);
+                this.updateNotifications(this.cache[cacheKey].data);
                 return;
             }
 
@@ -395,7 +395,7 @@
             var cacheKey = 'audit_' + this.config.club_id;
 
             if (this.isCacheValid(cacheKey)) {
-                this.updateAuditLog(this.cache[cacheKey]);
+                this.updateAuditLog(this.cache[cacheKey].data);
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Use cached `.data` for notifications and audit log updates to avoid passing metadata objects

## Testing
- `node --check assets/js/frontend-dashboard.js && echo "Syntax OK"`
- `php tests/test-frontend.php` *(fails: Class "PHPUnit\\Framework\\TestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c5d6da80832b84b4da851bec3517