### PR TITLE
Fix club name retrieval when club name is missing

### DIFF
--- a/inc/woocommerce/cart-integration.php
+++ b/inc/woocommerce/cart-integration.php
@@ -180,9 +180,7 @@ function ufsc_get_club_name( $club_id ) {
     );
 
 
-    return $club_name !== null ? $club_name : false;
-
-    return $club_name ? $club_name : false;
+    return ! empty( $club_name ) ? $club_name : false;
 
 }
 


### PR DESCRIPTION
## Summary
- remove duplicated return in `ufsc_get_club_name`
- return `false` when club name query yields null or empty result

## Testing
- `php -l inc/woocommerce/cart-integration.php`
- `php tests/test-core.php` (fails: Parse error: syntax error, unexpected token "===", expecting end of file)
- `php tests/test-affiliation-redirect.php` (fails: Class "PHPUnit\\Framework\\TestCase" not found)


------
https://chatgpt.com/codex/tasks/task_e_68b9c88f51bc832bb700e35d6743f51f