### PR TITLE
Propagate licence identity fields to WooCommerce

### DIFF
--- a/inc/woocommerce/cart-integration.php
+++ b/inc/woocommerce/cart-integration.php
@@ -103,10 +103,21 @@ function ufsc_transfer_cart_meta_to_order( $item, $cart_item_key, $values, $orde
     if ( isset( $values['ufsc_club_id'] ) ) {
         $item->add_meta_data( '_ufsc_club_id', $values['ufsc_club_id'] );
     }
-    
+
     // Transfer license IDs
     if ( isset( $values['ufsc_license_ids'] ) && is_array( $values['ufsc_license_ids'] ) ) {
         $item->add_meta_data( '_ufsc_licence_ids', $values['ufsc_license_ids'] );
+    }
+
+    // Transfer personal data
+    if ( isset( $values['ufsc_nom'] ) ) {
+        $item->add_meta_data( '_ufsc_nom', sanitize_text_field( $values['ufsc_nom'] ) );
+    }
+    if ( isset( $values['ufsc_prenom'] ) ) {
+        $item->add_meta_data( '_ufsc_prenom', sanitize_text_field( $values['ufsc_prenom'] ) );
+    }
+    if ( isset( $values['ufsc_date_naissance'] ) ) {
+        $item->add_meta_data( '_ufsc_date_naissance', sanitize_text_field( $values['ufsc_date_naissance'] ) );
     }
 }
 
@@ -139,7 +150,27 @@ function ufsc_display_cart_item_data( $item_data, $cart_item ) {
             'value' => sprintf( __( '%d licence(s) spécifique(s)', 'ufsc-clubs' ), $license_count ),
         );
     }
-    
+
+    // Display personal data
+    if ( isset( $cart_item['ufsc_nom'] ) ) {
+        $item_data[] = array(
+            'key'   => __( 'Nom', 'ufsc-clubs' ),
+            'value' => sanitize_text_field( $cart_item['ufsc_nom'] ),
+        );
+    }
+    if ( isset( $cart_item['ufsc_prenom'] ) ) {
+        $item_data[] = array(
+            'key'   => __( 'Prénom', 'ufsc-clubs' ),
+            'value' => sanitize_text_field( $cart_item['ufsc_prenom'] ),
+        );
+    }
+    if ( isset( $cart_item['ufsc_date_naissance'] ) && $cart_item['ufsc_date_naissance'] ) {
+        $item_data[] = array(
+            'key'   => __( 'Date de naissance', 'ufsc-clubs' ),
+            'value' => sanitize_text_field( $cart_item['ufsc_date_naissance'] ),
+        );
+    }
+
     return $item_data;
 }
 

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -386,7 +386,14 @@ class UFSC_Unified_Handlers {
         $new_id = $result;
         if ( isset( $_POST['ufsc_submit_action'] ) && 'add_to_cart' === $_POST['ufsc_submit_action'] ) {
             if ( function_exists( 'WC' ) && defined( 'PRODUCT_ID_LICENCE' ) ) {
-                WC()->cart->add_to_cart( PRODUCT_ID_LICENCE, 1, 0, array(), array( 'licence_id' => $new_id, 'club_id' => $club_id ) );
+                $cart_item_data = array(
+                    'licence_id'         => $new_id,
+                    'club_id'            => $club_id,
+                    'ufsc_nom'           => sanitize_text_field( $data['nom'] ),
+                    'ufsc_prenom'        => sanitize_text_field( $data['prenom'] ),
+                    'ufsc_date_naissance' => isset( $data['date_naissance'] ) ? sanitize_text_field( $data['date_naissance'] ) : '',
+                );
+                WC()->cart->add_to_cart( PRODUCT_ID_LICENCE, 1, 0, array(), $cart_item_data );
             }
             self::update_licence_status_db( $new_id, 'pending' );
             if ( function_exists( 'wc_get_cart_url' ) ) {


### PR DESCRIPTION
## Summary
- Include member name and birthdate in cart item data when a licence is added to the WooCommerce cart
- Surface those personal fields in cart display and copy them to order line items for post‑checkout access

## Testing
- `php -l includes/core/class-unified-handlers.php`
- `php -l inc/woocommerce/cart-integration.php`
- `phpunit --version` *(fails: command not found)*
- `composer require --dev phpunit/phpunit` *(fails: curl error 56: CONNECT tunnel failed, response 403)*
- `php tests/test-core.php` *(fails: Parse error, unexpected token "===", expecting end of file)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c95ab1d0832b9cc29c8c5c2e65b6