### PR TITLE
feat: unify Chart.js version

### DIFF
--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -342,8 +342,8 @@ class UFSC_CL_Admin_Menu {
      * Enqueue dashboard scripts and data
      */
     private static function enqueue_dashboard_scripts($dashboard_data) {
-        // Enqueue Chart.js from CDN
-        wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js', array(), '3.9.1', true);
+        // Enqueue Chart.js from CDN (unified version 4.4.0)
+        wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js', array(), '4.4.0', true);
         
         // Enqueue our dashboard script
         wp_add_inline_script('chartjs', self::get_dashboard_js($dashboard_data));

--- a/includes/frontend/class-club-dashboard.php
+++ b/includes/frontend/class-club-dashboard.php
@@ -206,8 +206,8 @@ class UFSC_Club_Dashboard {
      * Enqueue dashboard assets
      */
     private static function enqueue_dashboard_assets() {
-        // Enqueue Chart.js from CDN or local
-        wp_enqueue_script( 'chart-js', 'https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js', array(), '3.9.1', true );
+        // Enqueue Chart.js from CDN (unified version 4.4.0)
+        wp_enqueue_script( 'chart-js', 'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js', array(), '4.4.0', true );
         
         // Enqueue custom dashboard CSS
         wp_enqueue_style( 'ufsc-dashboard', UFSC_CL_URL . 'assets/css/frontend-dashboard.css', array(), UFSC_CL_VERSION );


### PR DESCRIPTION
## Summary
- use Chart.js 4.4.0 across admin and frontend dashboards

## Testing
- `php -l includes/admin/class-admin-menu.php`
- `php -l includes/frontend/class-club-dashboard.php`
- `node /tmp/chart-test/run.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9c5df8e38832bafe7f67d3b409531