### PR TITLE
Link dashboard actions to functional URLs

### DIFF
--- a/assets/js/frontend-dashboard.js
+++ b/assets/js/frontend-dashboard.js
@@ -631,15 +631,15 @@
 
         // // UFSC: New action handlers
         handleAddLicence: function() {
-            window.location.href = '?add_licence=1';
+            window.location.href = $('#btn-ajouter-licence').attr('href');
         },
 
         handleUpdateClub: function() {
-            window.location.href = '?edit_club=1';
+            window.location.href = $('#btn-mettre-a-jour-club').attr('href');
         },
 
         handleUploadDocument: function() {
-            window.location.href = '?upload_documents=1';
+            window.location.href = $('#btn-televerser-document').attr('href');
         },
 
         // // UFSC: CSV Export with filters

--- a/templates/frontend/club-dashboard.php
+++ b/templates/frontend/club-dashboard.php
@@ -195,19 +195,19 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
         <h2><?php echo esc_html__( 'Actions rapides', 'ufsc-clubs' ); ?></h2>
         <div class="ufsc-grid ufsc-actions-grid">
             <div class="ufsc-card">
-                <a href="#" class="ufsc-btn ufsc-btn-primary" id="btn-ajouter-licence">
+                <a href="<?php echo esc_url( add_query_arg( 'add_licence', '1' ) ); ?>" class="ufsc-btn ufsc-btn-primary" id="btn-ajouter-licence">
                     <span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
                     <?php echo esc_html__( 'Ajouter une licence', 'ufsc-clubs' ); ?>
                 </a>
             </div>
             <div class="ufsc-card">
-                <a href="#" class="ufsc-btn ufsc-btn-secondary" id="btn-mettre-a-jour-club">
+                <a href="<?php echo esc_url( add_query_arg( 'edit_club', '1' ) ); ?>" class="ufsc-btn ufsc-btn-secondary" id="btn-mettre-a-jour-club">
                     <span class="dashicons dashicons-admin-settings" aria-hidden="true"></span>
                     <?php echo esc_html__( 'Mettre à jour infos club', 'ufsc-clubs' ); ?>
                 </a>
             </div>
             <div class="ufsc-card">
-                <a href="#" class="ufsc-btn ufsc-btn-secondary" id="btn-televerser-document">
+                <a href="<?php echo esc_url( add_query_arg( 'upload_documents', '1' ) ); ?>" class="ufsc-btn ufsc-btn-secondary" id="btn-televerser-document">
                     <span class="dashicons dashicons-upload" aria-hidden="true"></span>
                     <?php echo esc_html__( 'Téléverser un document', 'ufsc-clubs' ); ?>
                 </a>


### PR DESCRIPTION
## Summary
- wire up dashboard action buttons with real query-based URLs for adding licences, editing club info and uploading documents
- update JavaScript handlers to redirect using each button's href

## Testing
- `php -l templates/frontend/club-dashboard.php`
- `node --check assets/js/frontend-dashboard.js`
- `node` (simulated button clicks verifying redirections)
- `apt-get update` (fails: repository not signed)
- `apt-get install -y phpunit` (fails: unable to locate package)

------
https://chatgpt.com/codex/tasks/task_e_68b9c5d054dc832b92f8b16baa967f14