### PR TITLE
Streamline document status handling

### DIFF
--- a/assets/js/frontend-dashboard.js
+++ b/assets/js/frontend-dashboard.js
@@ -335,13 +335,13 @@
             
             docTypes.forEach(function(docType) {
                 var item = $('.ufsc-document-item[data-doc="' + docType + '"]');
-                var status = item.find('.ufsc-document-status');
-                
+                var status = item.children('.ufsc-document-status');
+
                 if (documents && documents[docType]) {
-                    status.text('✅');
+                    status.removeClass('-pending').addClass('-transmitted').text('✅');
                     item.addClass('-transmitted');
                 } else {
-                    status.text('⏳');
+                    status.removeClass('-transmitted').addClass('-pending').text('⏳');
                     item.removeClass('-transmitted');
                 }
             });

--- a/templates/frontend/club-dashboard.php
+++ b/templates/frontend/club-dashboard.php
@@ -130,60 +130,48 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'Statuts', 'ufsc-clubs' ); ?></span>
 
-                    <span class="ufsc-badge ufsc-document-status">⏳</span>
+                    <span class="ufsc-badge ufsc-document-status -pending">⏳</span>
                     <div class="ufsc-row-actions"></div>
-
-                    <span class="ufsc-badge ufsc-document-status -pending"><span aria-hidden="true">⏳</span> <?php echo esc_html__( 'En attente', 'ufsc-clubs' ); ?></span>
 
                 </div>
                 <div class="ufsc-document-item" data-doc="recepisse">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'Récépissé', 'ufsc-clubs' ); ?></span>
 
-                    <span class="ufsc-badge ufsc-document-status">⏳</span>
+                    <span class="ufsc-badge ufsc-document-status -pending">⏳</span>
                     <div class="ufsc-row-actions"></div>
-
-                    <span class="ufsc-badge ufsc-document-status -pending"><span aria-hidden="true">⏳</span> <?php echo esc_html__( 'En attente', 'ufsc-clubs' ); ?></span>
 
                 </div>
                 <div class="ufsc-document-item" data-doc="jo">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'Journal Officiel', 'ufsc-clubs' ); ?></span>
 
-                    <span class="ufsc-badge ufsc-document-status">⏳</span>
+                    <span class="ufsc-badge ufsc-document-status -pending">⏳</span>
                     <div class="ufsc-row-actions"></div>
-
-                    <span class="ufsc-badge ufsc-document-status -pending"><span aria-hidden="true">⏳</span> <?php echo esc_html__( 'En attente', 'ufsc-clubs' ); ?></span>
 
                 </div>
                 <div class="ufsc-document-item" data-doc="pv_ag">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'PV Assemblée Générale', 'ufsc-clubs' ); ?></span>
 
-                    <span class="ufsc-badge ufsc-document-status">⏳</span>
+                    <span class="ufsc-badge ufsc-document-status -pending">⏳</span>
                     <div class="ufsc-row-actions"></div>
-
-                    <span class="ufsc-badge ufsc-document-status -pending"><span aria-hidden="true">⏳</span> <?php echo esc_html__( 'En attente', 'ufsc-clubs' ); ?></span>
 
                 </div>
                 <div class="ufsc-document-item" data-doc="cer">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'CER', 'ufsc-clubs' ); ?></span>
 
-                    <span class="ufsc-badge ufsc-document-status">⏳</span>
+                    <span class="ufsc-badge ufsc-document-status -pending">⏳</span>
                     <div class="ufsc-row-actions"></div>
-
-                    <span class="ufsc-badge ufsc-document-status -pending"><span aria-hidden="true">⏳</span> <?php echo esc_html__( 'En attente', 'ufsc-clubs' ); ?></span>
 
                 </div>
                 <div class="ufsc-document-item" data-doc="attestation_cer">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'Attestation CER', 'ufsc-clubs' ); ?></span>
 
-                    <span class="ufsc-badge ufsc-document-status">⏳</span>
+                    <span class="ufsc-badge ufsc-document-status -pending">⏳</span>
                     <div class="ufsc-row-actions"></div>
-
-                    <span class="ufsc-badge ufsc-document-status -pending"><span aria-hidden="true">⏳</span> <?php echo esc_html__( 'En attente', 'ufsc-clubs' ); ?></span>
 
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Remove duplicated status badges in club dashboard markup
- Update dashboard script to toggle a single document status element for all documents

## Testing
- `vendor/bin/phpunit tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c5c62814832b9c3bf9d26e16696f