### PR TITLE
Fix missing closing brace in licence handler

### DIFF
--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -397,6 +397,7 @@ class UFSC_Unified_Handlers {
 
             if ( ! $added ) {
                 self::store_form_and_redirect( $_POST, array( __( 'Impossible d\'ajouter le produit au panier', 'ufsc-clubs' ) ), $new_id );
+            }
 
             if ( function_exists( 'WC' ) && defined( 'PRODUCT_ID_LICENCE' ) ) {
                 $cart_item_data = array(


### PR DESCRIPTION
## Summary
- Close conditional block in `process_licence_request` to prevent subsequent statements from being included inadvertently

## Testing
- `php tests/test-core.php` *(fails: Parse error, requires PHPUnit)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e1eab094832bad8dce904120edf2