### PR TITLE
chore: bump version to 1.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # UFSC Clubs & Licences Plugin - Changelog
 
+## Version 1.5.7 - Mise à jour mineure (Septembre 2025)
+
+- Mise à jour du numéro de version du plugin.
+- Harmonisation de la constante `UFSC_CL_VERSION`.
+
 ## Version 1.5.3ff - Refactoring Majeur (Septembre 2024)
 
 ### 🎯 Objectifs

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -2,13 +2,13 @@
 /**
  * Plugin Name: UFSC – Clubs & Licences (SQL)
  * Description: Gestion Clubs/Licences connectée aux tables SQL existantes (mapping complet), formulaires complets (admin & front), documents PDF/JPG/PNG, exports CSV, badges colorés, mini-dashboard, shortcodes.
- * Version: 1.5.4
+ * Version: 1.5.7
  * Author: Davy – Studio REACTIV (pour l'UFSC)
  * Text Domain: ufsc-clubs
  */
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-define( 'UFSC_CL_VERSION', '1.5.4' );
+define( 'UFSC_CL_VERSION', '1.5.7' );
 define( 'UFSC_CL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UFSC_CL_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
## Summary
- bump plugin version header to 1.5.7
- align UFSC_CL_VERSION constant with new version
- document version 1.5.7 in changelog

## Testing
- `php -l ufsc-clubs-licences-sql.php`
- `php -l tests/test-core.php` *(fails: Parse error: syntax error, unexpected token "===", expecting end of file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04bff794832bb66403f4ce1d18ab