### PR TITLE
Refactor uploads to use WordPress media API

### DIFF
--- a/includes/core/class-uploads.php
+++ b/includes/core/class-uploads.php
@@ -2,236 +2,133 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 /**
- * Secure upload handling utility
+ * Upload handling using WordPress media_handle_upload
  */
-class UFSC_CL_Uploads {
-    
+class UFSC_Uploads {
+
     /**
-     * Safely handle file uploads with validation
-     * 
-     * @param array $file $_FILES array element
-     * @param array $allowed_mimes Allowed MIME types
-     * @param int $max_size_bytes Maximum file size in bytes
-     * @return array|WP_Error Upload result with 'url' and 'attachment_id' on success
-     */
-    public static function ufsc_safe_handle_upload( $file, $allowed_mimes = array(), $max_size_bytes = 5242880 ) {
-        // Default allowed MIME types for documents
-        if ( empty( $allowed_mimes ) ) {
-            $allowed_mimes = array(
-                'pdf' => 'application/pdf',
-                'jpg' => 'image/jpeg',
-                'jpeg' => 'image/jpeg',
-                'png' => 'image/png'
-            );
-        }
-        
-        // Check if file was uploaded
-        if ( empty( $file['name'] ) || empty( $file['tmp_name'] ) ) {
-            return new WP_Error( 'no_file', __( 'Aucun fichier fourni', 'ufsc-clubs' ) );
-        }
-        
-        // Check file size
-        if ( $file['size'] > $max_size_bytes ) {
-            $max_mb = $max_size_bytes / 1048576;
-            return new WP_Error( 'file_too_large', sprintf( 
-                __( 'Le fichier est trop volumineux. Taille maximum : %s MB', 'ufsc-clubs' ), 
-                $max_mb 
-            ) );
-        }
-        
-        // Validate file type using WordPress functions
-        $filetype = wp_check_filetype_and_ext( $file['tmp_name'], $file['name'] );
-        
-        if ( ! $filetype['type'] || ! in_array( $filetype['type'], $allowed_mimes ) ) {
-            return new WP_Error( 'invalid_file_type', __( 'Type de fichier non autorisé', 'ufsc-clubs' ) );
-        }
-        
-        // Include required WordPress upload functions
-        if ( ! function_exists( 'wp_handle_upload' ) ) {
-            require_once ABSPATH . 'wp-admin/includes/file.php';
-        }
-        if ( ! function_exists( 'media_handle_sideload' ) ) {
-            require_once ABSPATH . 'wp-admin/includes/media.php';
-        }
-        if ( ! function_exists( 'download_url' ) ) {
-            require_once ABSPATH . 'wp-admin/includes/image.php';
-        }
-        
-        // Handle upload with custom filename sanitization
-        $upload_overrides = array(
-            'test_form' => false,
-            'unique_filename_callback' => function( $dir, $name, $ext ) {
-                $name = remove_accents( $name );
-                $name = sanitize_file_name( $name );
-                $hash = substr( md5( uniqid( '', true ) ), 0, 8 );
-                return $name . '-' . $hash . $ext;
-            },
-        );
-        $uploaded_file = wp_handle_upload( $file, $upload_overrides );
-        
-        if ( isset( $uploaded_file['error'] ) ) {
-            return new WP_Error( 'upload_error', $uploaded_file['error'] );
-        }
-        
-        // Create attachment
-        $attachment = array(
-            'post_mime_type' => $uploaded_file['type'],
-            'post_title'     => sanitize_file_name( $file['name'] ),
-            'post_content'   => '',
-            'post_status'    => 'inherit'
-        );
-        
-        $attachment_id = wp_insert_attachment( $attachment, $uploaded_file['file'] );
-        
-        if ( is_wp_error( $attachment_id ) ) {
-            return $attachment_id;
-        }
-        
-        // Generate attachment metadata
-        $attachment_data = wp_generate_attachment_metadata( $attachment_id, $uploaded_file['file'] );
-        wp_update_attachment_metadata( $attachment_id, $attachment_data );
-        
-        return array(
-            'url' => $uploaded_file['url'],
-            'attachment_id' => $attachment_id,
-            'file_path' => $uploaded_file['file']
-        );
-    }
-    
-    /**
-     * Get allowed MIME types for logo uploads
-     * 
-     * @return array Allowed MIME types for logos
+     * Allowed MIME types for logos.
+     *
+     * @return array
      */
     public static function get_logo_mime_types() {
         return array(
-            'jpg' => 'image/jpeg',
+            'jpg'  => 'image/jpeg',
             'jpeg' => 'image/jpeg',
-            'png' => 'image/png',
-            'gif' => 'image/gif'
+            'png'  => 'image/png',
+            'gif'  => 'image/gif',
         );
     }
-    
+
     /**
-     * Get allowed MIME types for document uploads
-     * 
-     * @return array Allowed MIME types for documents
+     * Allowed MIME types for documents.
+     *
+     * @return array
      */
     public static function get_document_mime_types() {
         return array(
-            'pdf' => 'application/pdf',
-            'jpg' => 'image/jpeg',
+            'pdf'  => 'application/pdf',
+            'jpg'  => 'image/jpeg',
             'jpeg' => 'image/jpeg',
-            'png' => 'image/png'
+            'png'  => 'image/png',
         );
     }
 
     /**
-     * Handle upload of required club documents
+     * Maximum logo file size in bytes.
      *
-     * Validates and stores uploaded files for statutory documents.
-     * Returns attachment IDs keyed by document field name.
-     *
-     * @param int $club_id Club identifier for meta association
-     * @return array|WP_Error Array of attachment IDs or WP_Error on failure
-     */
-    public static function handle_required_docs( int $club_id ) {
-        $allowed_mimes = self::get_document_mime_types();
-        $max_size      = self::get_document_max_size();
-
-        $document_fields = array(
-            'doc_statuts'        => 'statuts_upload',
-            'doc_recepisse'      => 'recepisse_upload',
-            'doc_jo'             => 'jo_upload',
-            'doc_pv_ag'          => 'pv_ag_upload',
-            'doc_cer'            => 'cer_upload',
-            'doc_attestation_cer'=> 'attestation_cer_upload',
-        );
-
-        $results = array();
-
-        foreach ( $document_fields as $db_field => $upload_field ) {
-            if ( empty( $_FILES[ $upload_field ]['name'] ) ) {
-                continue;
-            }
-
-            $upload = self::ufsc_safe_handle_upload(
-                $_FILES[ $upload_field ],
-                $allowed_mimes,
-                $max_size
-            );
-
-            if ( is_wp_error( $upload ) ) {
-                return $upload;
-            }
-
-            $attachment_id        = $upload['attachment_id'];
-            $results[ $db_field ] = $attachment_id;
-
-            if ( $club_id ) {
-                update_post_meta( $club_id, $db_field, $attachment_id );
-                update_post_meta( $club_id, $db_field . '_status', 'pending' );
-            }
-        }
-
-        return $results;
-    }
-    
-    /**
-     * Get maximum file size for logos (2MB)
-     * 
-     * @return int Maximum file size in bytes
+     * @return int
      */
     public static function get_logo_max_size() {
         return 2097152; // 2MB
     }
-    
+
     /**
-     * Get maximum file size for documents (5MB)
-     * 
-     * @return int Maximum file size in bytes
+     * Maximum document file size in bytes.
+     *
+     * @return int
      */
     public static function get_document_max_size() {
         return 5242880; // 5MB
     }
-}
-
-
-/**
- * Wrapper class providing required document handling
- */
-class UFSC_Uploads extends UFSC_CL_Uploads {
 
     /**
-     * Handle uploads for required club documents.
+     * Handle a single upload field using media_handle_upload.
      *
-     * Loops through known document fields and uploads any files present
-     * using the secure upload helper. Returns an associative array of
-     * field => URL pairs on success or WP_Error on failure.
-     *
-     * @param array $files $_FILES array
-     * @return array|WP_Error
+     * @param string $field        Field name in the $_FILES array.
+     * @param int    $post_id      Post ID to associate, 0 for none.
+     * @param array  $allowed_mimes Allowed MIME types.
+     * @param int    $max_size      Maximum file size in bytes.
+     * @return int|WP_Error Attachment ID on success.
      */
-    public static function handle_required_docs( $files ) {
-        $doc_fields    = array( 'doc_statuts', 'doc_recepisse', 'doc_jo', 'doc_pv_ag', 'doc_cer', 'doc_attestation_cer' );
-        $uploads       = array();
+    public static function handle_single_upload_field( $field, $post_id = 0, $allowed_mimes = array(), $max_size = 5242880 ) {
+        if ( empty( $_FILES[ $field ]['name'] ) ) {
+            return 0;
+        }
+
+        $file = $_FILES[ $field ];
+
+        if ( $file['size'] > $max_size ) {
+            $max_mb = $max_size / 1048576;
+            return new WP_Error( 'file_too_large', sprintf( __( 'Le fichier est trop volumineux. Taille maximum : %s MB', 'ufsc-clubs' ), $max_mb ) );
+        }
+
+        $filetype = wp_check_filetype_and_ext( $file['tmp_name'], $file['name'] );
+        if ( $allowed_mimes && ( ! $filetype['type'] || ! in_array( $filetype['type'], $allowed_mimes, true ) ) ) {
+            return new WP_Error( 'invalid_file_type', __( 'Type de fichier non autorisé', 'ufsc-clubs' ) );
+        }
+
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/media.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+
+        $overrides = array( 'test_form' => false );
+        if ( ! empty( $allowed_mimes ) ) {
+            $overrides['mimes'] = $allowed_mimes;
+        }
+
+        $attach_id = media_handle_upload( $field, $post_id, array(), $overrides );
+        if ( is_wp_error( $attach_id ) ) {
+            return $attach_id;
+        }
+
+        return (int) $attach_id;
+    }
+
+    /**
+     * Handle required club document uploads.
+     *
+     * @param int $post_id Post ID to associate, 0 for none.
+     * @return array|WP_Error Array of meta_key => attachment_id.
+     */
+    public static function handle_required_docs( $post_id = 0 ) {
         $allowed_mimes = self::get_document_mime_types();
         $max_size      = self::get_document_max_size();
 
-        foreach ( $doc_fields as $field ) {
-            if ( empty( $files[ $field ]['name'] ) ) {
+        $fields = array(
+            'doc_statuts'         => 'statuts_upload',
+            'doc_recepisse'       => 'recepisse_upload',
+            'doc_jo'              => 'jo_upload',
+            'doc_pv_ag'           => 'pv_ag_upload',
+            'doc_cer'             => 'cer_upload',
+            'doc_attestation_cer' => 'attestation_cer_upload',
+        );
+
+        $results = array();
+
+        foreach ( $fields as $meta_key => $field_name ) {
+            if ( empty( $_FILES[ $field_name ]['name'] ) ) {
                 continue;
             }
 
-            $result = self::ufsc_safe_handle_upload( $files[ $field ], $allowed_mimes, $max_size );
-            if ( is_wp_error( $result ) ) {
-                return $result;
+            $attach_id = self::handle_single_upload_field( $field_name, $post_id, $allowed_mimes, $max_size );
+            if ( is_wp_error( $attach_id ) ) {
+                return $attach_id;
             }
 
-            $uploads[ $field ] = $result['url'];
+            $results[ $meta_key ] = (int) $attach_id;
         }
 
-        return $uploads;
+        return $results;
     }
 }
-

--- a/tests/integration-test.php
+++ b/tests/integration-test.php
@@ -68,14 +68,14 @@ class UFSC_Club_Form_Integration_Test {
      * Test upload utility
      */
     public static function test_upload_utility() {
-        if (!class_exists('UFSC_CL_Uploads')) {
-            echo "✗ UFSC_CL_Uploads class not available\n";
+        if (!class_exists('UFSC_Uploads')) {
+            echo "✗ UFSC_Uploads class not available\n";
             return false;
         }
         
         // Test MIME type configurations
-        $logo_types = UFSC_CL_Uploads::get_logo_mime_types();
-        $doc_types = UFSC_CL_Uploads::get_document_mime_types();
+        $logo_types = UFSC_Uploads::get_logo_mime_types();
+        $doc_types = UFSC_Uploads::get_document_mime_types();
         
         if (isset($logo_types['jpg']) && isset($doc_types['pdf'])) {
             echo "✓ Upload utility MIME types configured\n";


### PR DESCRIPTION
## Summary
- Replace custom UFSC_CL_Uploads with UFSC_Uploads using `media_handle_upload`
- Add `handle_single_upload_field` and `handle_required_docs` returning attachment IDs
- Update club handlers and REST API to store upload IDs in post meta

## Testing
- `php -l includes/core/class-uploads.php`
- `php -l includes/frontend/class-club-form-handler.php`
- `php -l includes/core/class-unified-handlers.php`
- `php -l includes/api/class-rest-api.php`
- `php -l tests/integration-test.php`
- `for f in tests/*.php; do php "$f"; done` *(fails: Call to undefined function ufsc_get_woocommerce_settings(), PHPUnit\Framework\TestCase not found, syntax error in tests/test-core.php)*

------
https://chatgpt.com/codex/tasks/task_e_68ba048ce550832b8de7f64ecd45c28c