### PR TITLE
Use secure admin-post endpoint for cart additions

### DIFF
--- a/UFSC_GESTION_IMPLEMENTATION.md
+++ b/UFSC_GESTION_IMPLEMENTATION.md
@@ -86,7 +86,7 @@ This document outlines the implementation of the UFSC Gestion plugin enhancement
   - `ufsc_quota_add_paid()`
 
 #### Cart Integration (`inc/woocommerce/cart-integration.php`)
-- URL-based add to cart: `?ufsc_add_to_cart=product_id&ufsc_club_id=123&ufsc_license_ids=1,2,3`
+- Add to cart via secure form posting to `admin-post.php` with action `ufsc_add_to_cart`
 - Meta data transfer from cart to order
 - Cart item display enhancements
 - `ufsc_add_affiliation_to_cart()` function for programmatic use

--- a/inc/woocommerce/cart-integration.php
+++ b/inc/woocommerce/cart-integration.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 /**
  * WooCommerce cart integration for UFSC Gestion
- * Handles add-to-cart by URL and meta transfer to orders
+ * Handles secure add-to-cart and meta transfer to orders
  */
 
 /**
@@ -14,91 +14,86 @@ function ufsc_init_cart_integration() {
         return;
     }
     
-    // Handle add to cart via URL parameters
-    add_action( 'init', 'ufsc_handle_add_to_cart_url' );
+    // Handle secure add to cart requests
+    add_action( 'admin_post_ufsc_add_to_cart', 'ufsc_handle_add_to_cart_secure' );
+    add_action( 'admin_post_nopriv_ufsc_add_to_cart', 'ufsc_handle_add_to_cart_secure' );
     
     // Transfer meta data from cart to order
     add_action( 'woocommerce_checkout_create_order_line_item', 'ufsc_transfer_cart_meta_to_order', 10, 4 );
 }
 
 /**
- * Handle add to cart via URL parameters
- * Supports URLs like: ?ufsc_add_to_cart=product_id&ufsc_club_id=123&ufsc_license_ids=1,2,3
+ * Handle secure add to cart requests posted via admin-post.php
  */
-function ufsc_handle_add_to_cart_url() {
-    if ( ! isset( $_GET['ufsc_add_to_cart'] ) ) {
-        return;
-    }
-
-    $product_id = absint( $_GET['ufsc_add_to_cart'] );
-    if ( ! $product_id ) {
-        return;
-    }
-
-    $nonce = isset( $_GET['_ufsc_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['_ufsc_nonce'] ) ) : '';
-    if ( ! $nonce || ! wp_verify_nonce( $nonce, 'ufsc_add_to_cart' ) ) {
+function ufsc_handle_add_to_cart_secure() {
+    // Verify nonce
+    $nonce = isset( $_POST['_ufsc_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_ufsc_nonce'] ) ) : '';
+    if ( ! $nonce || ! wp_verify_nonce( $nonce, 'ufsc_add_to_cart_action' ) ) {
         wc_add_notice( __( 'Action non autorisée', 'ufsc-clubs' ), 'error' );
-        return;
+        wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
+        exit;
     }
 
     if ( ! is_user_logged_in() || ! current_user_can( 'read' ) ) {
         wc_add_notice( __( 'Vous devez être connecté pour effectuer cette action', 'ufsc-clubs' ), 'error' );
-        return;
+        wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
+        exit;
     }
 
-    // Verify product exists
+    $product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+    if ( ! $product_id ) {
+        wc_add_notice( __( 'Produit non trouvé', 'ufsc-clubs' ), 'error' );
+        wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
+        exit;
+    }
+
     $product = wc_get_product( $product_id );
     if ( ! $product || ! $product->exists() ) {
         wc_add_notice( __( 'Produit non trouvé', 'ufsc-clubs' ), 'error' );
-        return;
+        wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
+        exit;
     }
-    
-    $quantity = isset( $_GET['quantity'] ) ? absint( $_GET['quantity'] ) : 1;
+
+    $quantity       = isset( $_POST['quantity'] ) ? absint( $_POST['quantity'] ) : 1;
     $cart_item_data = array();
-    
+
     // Add club ID if provided
-    if ( isset( $_GET['ufsc_club_id'] ) ) {
-        $club_id = absint( $_GET['ufsc_club_id'] );
+    if ( isset( $_POST['ufsc_club_id'] ) ) {
+        $club_id = absint( $_POST['ufsc_club_id'] );
         if ( $club_id > 0 ) {
             $cart_item_data['ufsc_club_id'] = $club_id;
         }
     }
-    
+
     // Add license IDs if provided
-    if ( isset( $_GET['ufsc_license_ids'] ) ) {
-        $license_ids_string = sanitize_text_field( $_GET['ufsc_license_ids'] );
-        $license_ids = array_filter( array_map( 'absint', explode( ',', $license_ids_string ) ) );
-        
+    if ( isset( $_POST['ufsc_license_ids'] ) ) {
+        $license_ids_string = sanitize_text_field( wp_unslash( $_POST['ufsc_license_ids'] ) );
+        $license_ids        = array_filter( array_map( 'absint', explode( ',', $license_ids_string ) ) );
+
         if ( ! empty( $license_ids ) ) {
             $cart_item_data['ufsc_license_ids'] = $license_ids;
-            $quantity = count( $license_ids ); // Override quantity to match license count
+            $quantity                           = count( $license_ids ); // Override quantity to match license count
         }
     }
-    
+
     // Add to cart
+    if ( function_exists( 'wc_load_cart' ) ) {
+        wc_load_cart();
+    }
     $cart_item_key = WC()->cart->add_to_cart( $product_id, $quantity, 0, array(), $cart_item_data );
-    
+
     if ( $cart_item_key ) {
-        wc_add_notice( 
-            sprintf( __( '%s ajouté au panier', 'ufsc-clubs' ), $product->get_name() ), 
-            'success' 
+        wc_add_notice(
+            sprintf( __( '%s ajouté au panier', 'ufsc-clubs' ), $product->get_name() ),
+            'success'
         );
-        
-        // Redirect to cart or checkout if specified
-        $redirect = isset( $_GET['ufsc_redirect'] ) ? sanitize_text_field( $_GET['ufsc_redirect'] ) : '';
-        
-        switch ( $redirect ) {
-            case 'cart':
-                wp_safe_redirect( wc_get_cart_url() );
-                exit;
-                
-            case 'checkout':
-                wp_safe_redirect( wc_get_checkout_url() );
-                exit;
-        }
     } else {
         wc_add_notice( __( 'Erreur lors de l\'ajout au panier', 'ufsc-clubs' ), 'error' );
     }
+
+    // Redirect back to the referring page
+    wp_safe_redirect( wp_get_referer() ? wp_get_referer() : wc_get_cart_url() );
+    exit;
 }
 
 /**

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -396,14 +396,15 @@ class UFSC_Frontend_Shortcodes {
                                             if ( in_array( $licence_status, array( 'brouillon', 'non_payee' ), true ) ) :
                                                 if ( 'brouillon' === $licence_status ) :
                                                     ?>
-                                                    <a href="<?php echo esc_url( add_query_arg( array(
-                                                        'ufsc_add_to_cart' => $wc_settings['product_license_id'],
-                                                        'ufsc_license_ids' => $licence->id ?? 0,
-                                                    ), '' ) ); ?>"
-                                                       class="ufsc-btn ufsc-btn-small"
-                                                       aria-label="<?php esc_attr_e( 'Envoyer la licence au panier', 'ufsc-clubs' ); ?>">
-                                                        <?php esc_html_e( 'Envoyer au panier', 'ufsc-clubs' ); ?>
-                                                    </a>
+                                                    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline">
+                                                        <?php wp_nonce_field( 'ufsc_add_to_cart_action', '_ufsc_nonce' ); ?>
+                                                        <input type="hidden" name="action" value="ufsc_add_to_cart">
+                                                        <input type="hidden" name="product_id" value="<?php echo esc_attr( $wc_settings['product_license_id'] ); ?>">
+                                                        <input type="hidden" name="ufsc_license_ids" value="<?php echo esc_attr( $licence->id ?? 0 ); ?>">
+                                                        <button type="submit" class="ufsc-btn ufsc-btn-small" aria-label="<?php esc_attr_e( 'Envoyer la licence au panier', 'ufsc-clubs' ); ?>">
+                                                            <?php esc_html_e( 'Envoyer au panier', 'ufsc-clubs' ); ?>
+                                                        </button>
+                                                    </form>
                                                     <a href="<?php echo esc_url( add_query_arg( 'edit_licence', $licence->id ?? 0 ) ); ?>"
                                                        class="ufsc-btn ufsc-btn-small"
                                                        aria-label="<?php esc_attr_e( 'Modifier la licence', 'ufsc-clubs' ); ?>">
@@ -540,12 +541,15 @@ class UFSC_Frontend_Shortcodes {
                 $licence_status = $licence->statut ?? '';
                 if ( 'non_payee' === $licence_status ) :
                     ?>
-                    <a href="<?php echo esc_url( add_query_arg( array(
-                        'ufsc_add_to_cart' => $wc_settings['product_license_id'],
-                        'ufsc_license_ids' => $licence->id ?? 0,
-                    ), '' ) ); ?>" class="ufsc-btn ufsc-btn-small">
-                        <?php esc_html_e( 'Payer la licence', 'ufsc-clubs' ); ?>
-                    </a>
+                    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline">
+                        <?php wp_nonce_field( 'ufsc_add_to_cart_action', '_ufsc_nonce' ); ?>
+                        <input type="hidden" name="action" value="ufsc_add_to_cart">
+                        <input type="hidden" name="product_id" value="<?php echo esc_attr( $wc_settings['product_license_id'] ); ?>">
+                        <input type="hidden" name="ufsc_license_ids" value="<?php echo esc_attr( $licence->id ?? 0 ); ?>">
+                        <button type="submit" class="ufsc-btn ufsc-btn-small">
+                            <?php esc_html_e( 'Payer la licence', 'ufsc-clubs' ); ?>
+                        </button>
+                    </form>
                 <?php endif; ?>
 
                 <?php if ( in_array( $licence_status, array( 'brouillon', 'non_payee' ), true ) ) : ?>


### PR DESCRIPTION
## Summary
- replace URL parameter add-to-cart handler with secure `admin_post` actions and nonce/capability checks
- update frontend licence actions to submit forms with nonces to the new endpoint
- document new form-based cart addition flow

## Testing
- `php -l inc/woocommerce/cart-integration.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `rg ufsc_add_to_cart -n`


------
https://chatgpt.com/codex/tasks/task_e_68ba0491057c832ba0ed6849558baaf2