### PR TITLE
Prefix UFSC cart metadata keys

### DIFF
--- a/inc/woocommerce/cart-integration.php
+++ b/inc/woocommerce/cart-integration.php
@@ -115,6 +115,11 @@ function ufsc_transfer_cart_meta_to_order( $item, $cart_item_key, $values, $orde
         $item->add_meta_data( '_ufsc_club_id', $values['ufsc_club_id'] );
     }
 
+    // Transfer single licence ID
+    if ( isset( $values['ufsc_licence_id'] ) ) {
+        $item->add_meta_data( '_ufsc_licence_id', absint( $values['ufsc_licence_id'] ) );
+    }
+
     // Transfer license IDs
     if ( isset( $values['ufsc_license_ids'] ) && is_array( $values['ufsc_license_ids'] ) ) {
         $item->add_meta_data( '_ufsc_licence_ids', $values['ufsc_license_ids'] );
@@ -159,6 +164,14 @@ function ufsc_display_cart_item_data( $item_data, $cart_item ) {
         $item_data[] = array(
             'key'   => __( 'Licences', 'ufsc-clubs' ),
             'value' => sprintf( __( '%d licence(s) spécifique(s)', 'ufsc-clubs' ), $license_count ),
+        );
+    }
+
+    // Display single licence ID
+    if ( isset( $cart_item['ufsc_licence_id'] ) ) {
+        $item_data[] = array(
+            'key'   => __( 'Licence', 'ufsc-clubs' ),
+            'value' => '#' . intval( $cart_item['ufsc_licence_id'] ),
         );
     }
 

--- a/inc/woocommerce/hooks.php
+++ b/inc/woocommerce/hooks.php
@@ -142,6 +142,13 @@ function ufsc_handle_additional_license_payment( $order, $item, $quantity ) {
     // Check if specific license IDs are attached to this line item
     $license_ids = $item->get_meta( '_ufsc_licence_ids' );
 
+    if ( empty( $license_ids ) ) {
+        $single_id = $item->get_meta( '_ufsc_licence_id' );
+        if ( $single_id ) {
+            $license_ids = array( $single_id );
+        }
+    }
+
     if ( ! empty( $license_ids ) && is_array( $license_ids ) ) {
         // Mark specific licenses as paid
         foreach ( $license_ids as $license_id ) {

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -432,7 +432,7 @@ class UFSC_Unified_Handlers {
         $added = false;
         if ( function_exists( 'WC' ) ) {
             function_exists( 'wc_load_cart' ) && wc_load_cart();
-            $added = WC()->cart->add_to_cart( 4823, 1, 0, array(), array( 'club_id' => $club_id ) );
+            $added = WC()->cart->add_to_cart( 4823, 1, 0, array(), array( 'ufsc_club_id' => $club_id ) );
         }
 
         if ( $added ) {
@@ -521,10 +521,10 @@ class UFSC_Unified_Handlers {
             function_exists( 'wc_load_cart' ) && wc_load_cart();
             $product_id     = $wc_settings['product_license_id'];
             $cart_item_data = array(
-                'licence_id' => $new_id,
-                'club_id'    => $club_id,
-                'season'     => $wc_settings['season'],
-                'category'   => isset( $data['categorie'] ) ? sanitize_text_field( $data['categorie'] ) : '',
+                'ufsc_licence_id' => $new_id,
+                'ufsc_club_id'    => $club_id,
+                'season'          => $wc_settings['season'],
+                'category'        => isset( $data['categorie'] ) ? sanitize_text_field( $data['categorie'] ) : '',
             );
             $added = WC()->cart->add_to_cart( $product_id, 1, 0, array(), $cart_item_data );
 
@@ -550,7 +550,7 @@ class UFSC_Unified_Handlers {
 
             if ( function_exists( 'WC' ) ) {
                 function_exists( 'wc_load_cart' ) && wc_load_cart();
-                $added = WC()->cart->add_to_cart( $product_id, 1, 0, array(), array( 'licence_id' => $new_id, 'club_id' => $club_id ) );
+                $added = WC()->cart->add_to_cart( $product_id, 1, 0, array(), array( 'ufsc_licence_id' => $new_id, 'ufsc_club_id' => $club_id ) );
             }
 
             if ( ! $added ) {
@@ -559,10 +559,10 @@ class UFSC_Unified_Handlers {
 
             if ( function_exists( 'WC' ) && defined( 'PRODUCT_ID_LICENCE' ) ) {
                 $cart_item_data = array(
-                    'licence_id'         => $new_id,
-                    'club_id'            => $club_id,
-                    'ufsc_nom'           => sanitize_text_field( $data['nom'] ),
-                    'ufsc_prenom'        => sanitize_text_field( $data['prenom'] ),
+                    'ufsc_licence_id'     => $new_id,
+                    'ufsc_club_id'        => $club_id,
+                    'ufsc_nom'            => sanitize_text_field( $data['nom'] ),
+                    'ufsc_prenom'         => sanitize_text_field( $data['prenom'] ),
                     'ufsc_date_naissance' => isset( $data['date_naissance'] ) ? sanitize_text_field( $data['date_naissance'] ) : '',
                 );
                 WC()->cart->add_to_cart( PRODUCT_ID_LICENCE, 1, 0, array(), $cart_item_data );


### PR DESCRIPTION
## Summary
- prefix cart metadata for club and licence IDs when adding to cart
- handle new metadata during cart-to-order transfer and cart display
- honour single licence metadata when processing additional licence payments

## Testing
- `php -l includes/core/class-unified-handlers.php`
- `php -l inc/woocommerce/cart-integration.php`
- `php -l inc/woocommerce/hooks.php`
- `rg "\bclub_id\b" -n | head -n 20`
- `rg "\blicence_id\b" -n | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ba04a92c0c832bbdb8d3cdfd4db25d