### PR TITLE
Add redirect notice helper and display template

### DIFF
--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -91,7 +91,9 @@ class UFSC_CL_Admin_Menu {
         $t_lics  = isset($opts['table_licences']) ? $opts['table_licences'] : 'licences';
         
         echo '<div class="wrap">';
-        
+
+        include UFSC_CL_DIR . 'templates/partials/notice.php';
+
         // Header moderne
         echo '<div class="ufsc-header">';
         echo '<div style="display: flex; justify-content: space-between; align-items: center;">';

--- a/includes/common/functions.php
+++ b/includes/common/functions.php
@@ -1,0 +1,6 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+function ufsc_redirect_with_notice( $url, $notice_slug ) {
+    return add_query_arg( 'ufsc_notice', sanitize_key( $notice_slug ), $url );
+}

--- a/includes/frontend/class-affiliation-form.php
+++ b/includes/frontend/class-affiliation-form.php
@@ -294,7 +294,7 @@ class UFSC_Affiliation_Form {
 
         // Check if user already has a club
         if ( self::user_has_club( $user_id ) ) {
-            wp_safe_redirect( add_query_arg( 'error', urlencode( __( 'Vous avez déjà un club associé.', 'ufsc-clubs' ) ), $redirect_url ) );
+            wp_safe_redirect( ufsc_redirect_with_notice( $redirect_url, 'club_exists' ) );
             exit;
         }
 
@@ -302,7 +302,7 @@ class UFSC_Affiliation_Form {
         $club_data = self::validate_and_sanitize_input( $_POST );
         
         if ( is_wp_error( $club_data ) ) {
-            wp_safe_redirect( add_query_arg( 'error', urlencode( $club_data->get_error_message() ), $redirect_url ) );
+            wp_safe_redirect( ufsc_redirect_with_notice( $redirect_url, 'club_error' ) );
             exit;
         }
 
@@ -313,9 +313,9 @@ class UFSC_Affiliation_Form {
 
         if ( $result ) {
             $success_url = ! empty( $_POST['redirect_to'] ) ? $_POST['redirect_to'] : $redirect_url;
-            wp_safe_redirect( add_query_arg( 'created', '1', $success_url ) );
+            wp_safe_redirect( ufsc_redirect_with_notice( $success_url, 'club_created' ) );
         } else {
-            wp_safe_redirect( add_query_arg( 'error', urlencode( __( 'Erreur lors de la création du club. Veuillez réessayer.', 'ufsc-clubs' ) ), $redirect_url ) );
+            wp_safe_redirect( ufsc_redirect_with_notice( $redirect_url, 'club_creation_error' ) );
         }
         exit;
     }

--- a/includes/frontend/class-club-form-handler.php
+++ b/includes/frontend/class-club-form-handler.php
@@ -153,7 +153,7 @@ class UFSC_CL_Club_Form_Handler {
         $redirect_url = apply_filters( 'ufsc_club_affiliation_redirect_url', $redirect_url, $club_id, $affiliation );
 
         if ( $redirect_url ) {
-            wp_safe_redirect( $redirect_url );
+            wp_safe_redirect( ufsc_redirect_with_notice( $redirect_url, 'affiliation_added' ) );
             exit;
         }
     }

--- a/templates/frontend/licence-form.php
+++ b/templates/frontend/licence-form.php
@@ -1,5 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
+include UFSC_CL_DIR . 'templates/partials/notice.php';
 ?>
 <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-licence-form">
     <input type="hidden" name="action" value="ufsc_save_licence" />

--- a/templates/partials/notice.php
+++ b/templates/partials/notice.php
@@ -1,0 +1,5 @@
+<?php if ( ! empty( $_GET['ufsc_notice'] ) ): ?>
+  <div class="notice notice-info ufsc-notice">
+    <?php echo esc_html( ucfirst( str_replace( '_', ' ', $_GET['ufsc_notice'] ) ) ); ?>
+  </div>
+<?php endif; ?>

--- a/tests/test-affiliation-redirect.php
+++ b/tests/test-affiliation-redirect.php
@@ -7,7 +7,8 @@ use PHPUnit\Framework\TestCase;
 class UFSC_Affiliation_Redirect_Test extends TestCase {
 
     public function setUp(): void {
-        // Load class file
+        // Load required files
+        require_once __DIR__ . '/../includes/common/functions.php';
         require_once __DIR__ . '/../includes/frontend/class-club-form-handler.php';
 
         if ( ! function_exists( 'ufsc_add_affiliation_to_cart' ) ) {
@@ -34,6 +35,18 @@ class UFSC_Affiliation_Redirect_Test extends TestCase {
                 return $value;
             }
         }
+
+        if ( ! function_exists( 'add_query_arg' ) ) {
+            function add_query_arg( $key, $value, $url ) {
+                return $url . '?' . urlencode( $key ) . '=' . urlencode( $value );
+            }
+        }
+
+        if ( ! function_exists( 'sanitize_key' ) ) {
+            function sanitize_key( $key ) {
+                return preg_replace( '/[^a-z0-9_]/', '', strtolower( $key ) );
+            }
+        }
     }
 
     public function test_redirects_to_cart_with_product() {
@@ -51,6 +64,6 @@ class UFSC_Affiliation_Redirect_Test extends TestCase {
         }
 
         $this->assertSame( array( 42 ), $GLOBALS['ufsc_cart'] );
-        $this->assertSame( 'https://example.com/cart', $GLOBALS['redirect_url'] );
+        $this->assertSame( 'https://example.com/cart?ufsc_notice=affiliation_added', $GLOBALS['redirect_url'] );
     }
 }

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -30,6 +30,7 @@ require_once UFSC_CL_DIR.'includes/core/class-cache-manager.php';
 
 // New UFSC Gestion enhancement classes
 require_once UFSC_CL_DIR.'includes/common/class-ufsc-utils.php';
+require_once UFSC_CL_DIR.'includes/common/functions.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-transaction.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-db-migrations.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-affiliation-form.php';


### PR DESCRIPTION
## Summary
- Add `ufsc_redirect_with_notice` helper to build URLs with notice slugs
- Show notice banner on front-end licence form and admin dashboard
- Replace select redirects to attach notice parameter and update tests

## Testing
- `php -l includes/common/functions.php`
- `php -l templates/partials/notice.php`
- `php -l templates/frontend/licence-form.php`
- `php -l includes/admin/class-admin-menu.php`
- `php -l includes/frontend/class-club-form-handler.php`
- `php -l includes/frontend/class-affiliation-form.php`
- `php -l tests/test-affiliation-redirect.php`
- `phpunit tests/test-affiliation-redirect.php` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04b6c484832bb4c5c8af390b5359