### PR TITLE
Add capability and nonce checks to admin_post handlers

### DIFF
--- a/inc/woocommerce/admin-actions.php
+++ b/inc/woocommerce/admin-actions.php
@@ -225,6 +225,10 @@ L\'équipe UFSC', 'ufsc-clubs' ),
  * This function should be called from admin interface
  */
 function ufsc_handle_admin_send_to_payment() {
+    if ( ! current_user_can( 'read' ) ) {
+        wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+    }
+
     // Verify nonce and capabilities
     if ( ! check_admin_referer( 'ufsc_send_to_payment' ) || ! current_user_can( 'manage_options' ) ) {
         wp_die( __( 'Erreur de sécurité', 'ufsc-clubs' ) );

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -368,6 +368,10 @@ class UFSC_SQL_Admin {
     }
 
     public static function handle_save_club(){
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
         check_admin_referer('ufsc_sql_save_club');
 
         $user_id = get_current_user_id();
@@ -674,6 +678,9 @@ class UFSC_SQL_Admin {
     }
 
     public static function handle_delete_club(){
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
         if ( ! current_user_can('manage_options') ) wp_die('Accès refusé');
         check_admin_referer('ufsc_sql_delete_club');
 
@@ -1173,6 +1180,10 @@ class UFSC_SQL_Admin {
     }
 
     public static function handle_save_licence(){
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
         check_admin_referer('ufsc_sql_save_licence');
 
         $user_id   = get_current_user_id();
@@ -1269,8 +1280,11 @@ class UFSC_SQL_Admin {
      * Handle sending license to payment
      */
     public static function handle_send_license_payment(){
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
         if ( ! current_user_can('manage_options') ) wp_die('Accès refusé');
-        
+
         $license_id = isset($_GET['license_id']) ? (int) $_GET['license_id'] : 0;
         check_admin_referer('ufsc_send_license_payment_'.$license_id);
 
@@ -1496,6 +1510,10 @@ class UFSC_SQL_Admin {
     }
 
     public static function handle_delete_licence(){
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
         check_admin_referer('ufsc_sql_delete_licence');
 
         global $wpdb;
@@ -1704,6 +1722,9 @@ class UFSC_SQL_Admin {
      * Handle export data request
      */
     public static function handle_export_data() {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
         if (!current_user_can('manage_options')) {
             wp_die('Accès refusé');
         }

--- a/includes/admin/class-user-club-admin.php
+++ b/includes/admin/class-user-club-admin.php
@@ -435,7 +435,13 @@ class UFSC_User_Club_Admin {
      * Handle user-club association
      */
     public static function handle_user_club_association() {
-        if ( ! current_user_can( 'manage_options' ) || ! wp_verify_nonce( $_POST['ufsc_nonce'], 'ufsc_associate_user_club' ) ) {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
+        check_admin_referer( 'ufsc_associate_user_club', 'ufsc_nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
             wp_die( __( 'Sécurité échouée', 'ufsc-clubs' ) );
         }
 
@@ -461,7 +467,13 @@ class UFSC_User_Club_Admin {
      * Handle club region update
      */
     public static function handle_club_region_update() {
-        if ( ! current_user_can( 'manage_options' ) || ! wp_verify_nonce( $_POST['ufsc_nonce'], 'ufsc_update_club_region' ) ) {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
+        check_admin_referer( 'ufsc_update_club_region', 'ufsc_nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
             wp_die( __( 'Sécurité échouée', 'ufsc-clubs' ) );
         }
 

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -52,6 +52,12 @@ class UFSC_Unified_Handlers {
      * Handle licence save (create or update based on presence of licence_id).
      */
     public static function handle_save_licence() {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
+        check_admin_referer( 'ufsc_save_licence' );
+
         $licence_id = isset( $_POST['licence_id'] ) ? intval( $_POST['licence_id'] ) : 0;
 
         self::process_licence_request( $licence_id );
@@ -61,9 +67,11 @@ class UFSC_Unified_Handlers {
      * Handle licence creation.
      */
     public static function handle_add_licence() {
-        if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_add_licence' ) ) {
-            wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
+
+        check_admin_referer( 'ufsc_add_licence' );
 
         if ( ! is_user_logged_in() ) {
             self::redirect_with_error( 'Vous devez être connecté' );
@@ -109,9 +117,11 @@ class UFSC_Unified_Handlers {
      * Handle licence update
      */
     public static function handle_update_licence() {
-        if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_update_licence' ) ) {
-            wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
+
+        check_admin_referer( 'ufsc_update_licence' );
 
         $licence_id = isset( $_POST['licence_id'] ) ? intval( $_POST['licence_id'] ) : 0;
 
@@ -197,9 +207,11 @@ class UFSC_Unified_Handlers {
      * Handle licence deletion
      */
     public static function handle_delete_licence() {
-        if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_delete_licence' ) ) {
-            wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
+
+        check_admin_referer( 'ufsc_delete_licence' );
 
         if ( ! is_user_logged_in() ) {
             self::redirect_with_error( 'Vous devez être connecté' );
@@ -236,9 +248,11 @@ class UFSC_Unified_Handlers {
      * Handle licence status update
      */
     public static function handle_update_licence_status() {
-        if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_update_licence_status' ) ) {
-            wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
+
+        check_admin_referer( 'ufsc_update_licence_status' );
 
         if ( ! is_user_logged_in() ) {
             self::redirect_with_error( 'Vous devez être connecté' );
@@ -284,17 +298,14 @@ class UFSC_Unified_Handlers {
      * // UFSC: Handle club save (profile/documents)
      */
     public static function handle_save_club() {
-        // Verify nonce - accept custom or default nonce field
-        $has_valid_nonce = false;
-        if ( isset( $_POST['ufsc_club_nonce'] ) ) {
-            $has_valid_nonce = wp_verify_nonce( $_POST['ufsc_club_nonce'], 'ufsc_save_club' );
-        }
-        if ( ! $has_valid_nonce && isset( $_POST['_wpnonce'] ) ) {
-            $has_valid_nonce = wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_save_club' );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
 
-        if ( ! $has_valid_nonce ) {
-            wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
+        if ( isset( $_POST['ufsc_club_nonce'] ) ) {
+            check_admin_referer( 'ufsc_save_club', 'ufsc_club_nonce' );
+        } else {
+            check_admin_referer( 'ufsc_save_club' );
         }
 
         // Basic authentication check
@@ -353,9 +364,11 @@ class UFSC_Unified_Handlers {
      * checkout with appropriate notices.
      */
     public static function handle_club_affiliation_submit() {
-        if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_club_affiliation_submit' ) ) {
-            wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
+
+        check_admin_referer( 'ufsc_club_affiliation_submit' );
 
         if ( ! is_user_logged_in() ) {
             self::redirect_with_error( __( 'Vous devez être connecté', 'ufsc-clubs' ) );
@@ -620,15 +633,11 @@ class UFSC_Unified_Handlers {
      * // UFSC: Handle CSV export
      */
     public static function handle_export_stats() {
-        // Verify nonce
-        if ( ! isset( $_POST['nonce'] ) ) {
-            wp_die( __( 'Missing nonce', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
 
-        $nonce = sanitize_text_field( wp_unslash( $_POST['nonce'] ) );
-        if ( ! wp_verify_nonce( $nonce, 'ufsc_frontend_nonce' ) ) {
-            wp_die( __( 'Nonce verification failed', 'ufsc-clubs' ) );
-        }
+        check_admin_referer( 'ufsc_frontend_nonce', 'nonce' );
 
         if ( ! is_user_logged_in() ) {
             wp_die( __( 'Vous devez être connecté', 'ufsc-clubs' ) );

--- a/includes/frontend/class-affiliation-form.php
+++ b/includes/frontend/class-affiliation-form.php
@@ -259,9 +259,11 @@ class UFSC_Affiliation_Form {
      * Handle non-AJAX affiliation payment form
      */
     public static function handle_affiliation_pay() {
-        if ( ! isset( $_POST['ufsc_affiliation_nonce'] ) || ! wp_verify_nonce( $_POST['ufsc_affiliation_nonce'], 'ufsc_affiliation_pay' ) ) {
-            wp_die( esc_html__( 'Erreur de sécurité. Veuillez réessayer.', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( esc_html__( 'Accès refusé.', 'ufsc-clubs' ) );
         }
+
+        check_admin_referer( 'ufsc_affiliation_pay', 'ufsc_affiliation_nonce' );
 
         if ( function_exists( 'ufsc_is_woocommerce_active' ) && ufsc_is_woocommerce_active() ) {
             $settings   = ufsc_get_woocommerce_settings();
@@ -280,10 +282,11 @@ class UFSC_Affiliation_Form {
      * Handle form submission
      */
     public static function handle_form_submission() {
-        // Verify nonce
-        if ( ! wp_verify_nonce( $_POST['ufsc_nonce'], 'ufsc_create_club' ) ) {
-            wp_die( esc_html__( 'Erreur de sécurité. Veuillez réessayer.', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( esc_html__( 'Accès refusé.', 'ufsc-clubs' ) );
         }
+
+        check_admin_referer( 'ufsc_create_club', 'ufsc_nonce' );
 
         if ( ! is_user_logged_in() ) {
             wp_die( esc_html__( 'Vous devez être connecté pour créer un club.', 'ufsc-clubs' ) );

--- a/includes/frontend/class-club-form-handler.php
+++ b/includes/frontend/class-club-form-handler.php
@@ -18,10 +18,11 @@ class UFSC_CL_Club_Form_Handler {
      * Handle club form submission
      */
     public static function handle_save_club() {
-        // Verify nonce
-        if ( ! wp_verify_nonce( $_POST['ufsc_club_nonce'] ?? '', 'ufsc_save_club' ) ) {
-            wp_die( __( 'Erreur de sécurité. Veuillez réessayer.', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
+
+        check_admin_referer( 'ufsc_save_club', 'ufsc_club_nonce' );
         
         $club_id = (int) ( $_POST['club_id'] ?? 0 );
         $affiliation = (bool) ( $_POST['affiliation'] ?? false );


### PR DESCRIPTION
## Summary
- protect all `admin_post_*` handlers with `current_user_can('read')`
- switch to `check_admin_referer` for nonce verification across handlers
- ensure SQL admin and unified handlers check capabilities before processing

## Testing
- `php -l includes/admin/class-user-club-admin.php`
- `php -l inc/woocommerce/admin-actions.php`
- `php -l includes/frontend/class-club-form-handler.php`
- `php -l includes/frontend/class-affiliation-form.php`
- `php -l includes/admin/class-sql-admin.php`
- `php -l includes/core/class-unified-handlers.php`
- `phpunit --version` *(fails: command not found)*
- `composer global require phpunit/phpunit` *(fails: curl error 56)*

------
https://chatgpt.com/codex/tasks/task_e_68ba04b03c84832b9a4448e2a6aeae89