### PR TITLE
Start docblock for licence payment method

### DIFF
--- a/includes/core/class-sql.php
+++ b/includes/core/class-sql.php
@@ -177,7 +177,9 @@ class UFSC_SQL {
             array( '%d' ),
             array( '%d' )
         );
+    }
 
+    /**
      * Mark a licence as paid and validated.
      *
      * @param int    $licence_id Licence ID.


### PR DESCRIPTION
## Summary
- start docblock for licence payment routine and close preceding helper method

## Testing
- `php -l includes/core/class-sql.php`
- `for f in tests/*.php; do echo "Running $f"; php $f >/tmp/output.txt 2>&1; tail -n 20 /tmp/output.txt; done` *(fails: Call to undefined function ufsc_get_woocommerce_settings, PHPUnit\Framework\TestCase not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba0ca66104832b9c6de7440b99c684