### PR TITLE
Fix UFSC REST API init and remove duplicates

### DIFF
--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -6,6 +6,7 @@ class UFSC_REST_API {
 
     public static function init() {
         add_action( 'rest_api_init', array( __CLASS__, 'register_routes' ) );
+    }
 
     /**
      * Register REST API routes
@@ -737,26 +738,9 @@ class UFSC_REST_API {
 
     }
 
-    public static function register_routes() {
-        register_rest_route( 'ufsc/v1', '/stats', array(
-            'methods'  => 'GET',
-            'callback' => array( __CLASS__, 'get_stats' ),
-        ) );
-
-        register_rest_route( 'ufsc/v1', '/licences', array(
-            'methods'  => 'GET',
-            'callback' => array( __CLASS__, 'get_licences' ),
-        ) );
-
-        register_rest_route( 'ufsc/v1', '/clubs/(?P<id>\\d+)', array(
-            'methods'  => 'GET',
-            'callback' => array( __CLASS__, 'get_club' ),
-        ) );
-    }
-
-
     public static function get_stats( $request ) {
         return rest_ensure_response( array( 'stats' => array() ) );
+    }
 
     private static function create_payment_order( $club_id, $licence_ids ) {
         if ( ! function_exists( 'ufsc_is_woocommerce_active' ) || ! ufsc_is_woocommerce_active() ) {
@@ -807,16 +791,7 @@ class UFSC_REST_API {
 
     }
 
-    public static function get_licences( $request ) {
-        return rest_ensure_response( array( 'licences' => array() ) );
-    }
-
-    public static function get_club( $request ) {
-        $id = (int) $request['id'];
-        return rest_ensure_response( array( 'club_id' => $id ) );
-    }
 }
-
 
 UFSC_REST_API::init();
 


### PR DESCRIPTION
## Summary
- Close `UFSC_REST_API::init` with a proper brace and spacing
- Remove duplicate route registrations and placeholder methods to resolve syntax errors

## Testing
- `php -l includes/api/class-rest-api.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba0f1df004832b8b5d8c2614d83f2b