### PR TITLE
Improve dashboard accessibility and responsive grids

### DIFF
--- a/assets/css/ufsc-front.css
+++ b/assets/css/ufsc-front.css
@@ -6,11 +6,11 @@
 :root {
     --ufsc-primary: #2271b1;      /* Bleu UFSC */
     --ufsc-secondary: #135e96;    /* Bleu foncé */
-    --ufsc-success: #059669;      /* Vert validation */
-    --ufsc-warning: #f59e0b;      /* Orange attention */
-    --ufsc-danger: #ef4444;       /* Rouge erreur */
-    --ufsc-info: #3b82f6;         /* Bleu information */
-    --ufsc-neutral: #6b7280;      /* Gris neutre */
+    --ufsc-success: #047857;      /* Vert validation */
+    --ufsc-warning: #b45309;      /* Orange attention */
+    --ufsc-danger: #b91c1c;       /* Rouge erreur */
+    --ufsc-info: #1d4ed8;         /* Bleu information */
+    --ufsc-neutral: #374151;      /* Gris neutre */
 
     --ufsc-spacing-xs: 8px;
     --ufsc-spacing-sm: 16px;
@@ -49,6 +49,35 @@
     }
 }
 
+/* Licence cards grid */
+.ufsc-licence-cards {
+    display: grid;
+    gap: var(--ufsc-spacing-md);
+    grid-template-columns: 1fr;
+}
+@media (min-width: var(--tablet)) {
+    .ufsc-licence-cards {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+/* Documents status grid */
+.ufsc-documents-status {
+    display: grid;
+    gap: var(--ufsc-spacing-md);
+    grid-template-columns: 1fr;
+}
+@media (min-width: var(--tablet)) {
+    .ufsc-documents-status {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+@media (min-width: var(--desktop)) {
+    .ufsc-documents-status {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
 /* Card */
 .ufsc-card {
     background: #ffffff;
@@ -61,6 +90,14 @@
 .ufsc-card:hover {
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     transform: translateY(-2px);
+}
+
+.ufsc-card:focus,
+.ufsc-card:focus-within,
+.ufsc-licence-card:focus,
+.ufsc-document-item:focus {
+    outline: 3px solid var(--ufsc-info);
+    outline-offset: 2px;
 }
 
 /* Club profile grids */

--- a/templates/frontend/club-dashboard.php
+++ b/templates/frontend/club-dashboard.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 ?>
 
 <div class="ufsc-club-dashboard" id="ufsc-club-dashboard">
-    <div class="ufsc-feedback" id="ufsc-feedback" aria-live="polite"></div>
+    <div class="ufsc-feedback" id="ufsc-feedback" aria-live="polite" role="status" tabindex="-1"></div>
     
     <!-- 1. En-tête Club -->
     <div class="ufsc-dashboard-header">
@@ -81,7 +81,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
         </div>
 
         <!-- // UFSC: KPIs selon les exigences (Validées, Payées, En attente, Refusées) -->
-        <div class="ufsc-grid ufsc-kpi-grid" id="ufsc-kpi-grid" aria-live="polite">
+        <div class="ufsc-grid ufsc-kpi-grid" id="ufsc-kpi-grid" aria-live="polite" role="region" aria-label="<?php echo esc_attr__( 'Statistiques des licences', 'ufsc-clubs' ); ?>">
             <div class="ufsc-card ufsc-kpi-card -validees">
                 <div class="ufsc-kpi-value" id="kpi-licences-validees" aria-live="polite">
                     <div class="ufsc-loading"><?php echo esc_html__( 'Chargement...', 'ufsc-clubs' ); ?></div>
@@ -113,7 +113,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
     <div class="ufsc-dashboard-section ufsc-recent-licences-section">
         <h2><?php echo esc_html__( 'Licences récentes', 'ufsc-clubs' ); ?></h2>
         <div class="ufsc-card">
-            <div class="ufsc-recent-licences" id="ufsc-recent-licences" aria-live="polite">
+            <div class="ufsc-recent-licences" id="ufsc-recent-licences" aria-live="polite" role="region" aria-label="<?php echo esc_attr__( 'Licences récentes', 'ufsc-clubs' ); ?>">
                 <!-- // UFSC: Section populated via JavaScript -->
                 <div class="ufsc-loading"><?php echo esc_html__( 'Chargement...', 'ufsc-clubs' ); ?></div>
             </div>
@@ -124,9 +124,9 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
     <div class="ufsc-dashboard-section ufsc-documents-section">
         <h2><?php echo esc_html__( 'Documents du club', 'ufsc-clubs' ); ?></h2>
         <div class="ufsc-card">
-            <div class="ufsc-grid ufsc-documents-status" id="ufsc-documents-status" aria-live="polite">
+            <div class="ufsc-grid ufsc-documents-status" id="ufsc-documents-status" aria-live="polite" role="region" aria-label="<?php echo esc_attr__( 'Documents du club', 'ufsc-clubs' ); ?>">
                 <!-- // UFSC: Documents obligatoires avec statut visuel -->
-                <div class="ufsc-document-item" data-doc="statuts">
+                <div class="ufsc-document-item" data-doc="statuts" tabindex="0">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'Statuts', 'ufsc-clubs' ); ?></span>
 
@@ -134,7 +134,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                     <div class="ufsc-row-actions"></div>
 
                 </div>
-                <div class="ufsc-document-item" data-doc="recepisse">
+                <div class="ufsc-document-item" data-doc="recepisse" tabindex="0">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'Récépissé', 'ufsc-clubs' ); ?></span>
 
@@ -142,7 +142,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                     <div class="ufsc-row-actions"></div>
 
                 </div>
-                <div class="ufsc-document-item" data-doc="jo">
+                <div class="ufsc-document-item" data-doc="jo" tabindex="0">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'Journal Officiel', 'ufsc-clubs' ); ?></span>
 
@@ -150,7 +150,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                     <div class="ufsc-row-actions"></div>
 
                 </div>
-                <div class="ufsc-document-item" data-doc="pv_ag">
+                <div class="ufsc-document-item" data-doc="pv_ag" tabindex="0">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'PV Assemblée Générale', 'ufsc-clubs' ); ?></span>
 
@@ -158,7 +158,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                     <div class="ufsc-row-actions"></div>
 
                 </div>
-                <div class="ufsc-document-item" data-doc="cer">
+                <div class="ufsc-document-item" data-doc="cer" tabindex="0">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'CER', 'ufsc-clubs' ); ?></span>
 
@@ -166,7 +166,7 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                     <div class="ufsc-row-actions"></div>
 
                 </div>
-                <div class="ufsc-document-item" data-doc="attestation_cer">
+                <div class="ufsc-document-item" data-doc="attestation_cer" tabindex="0">
                     <span class="ufsc-document-icon" aria-hidden="true">📄</span>
                     <span class="ufsc-document-name"><?php echo esc_html__( 'Attestation CER', 'ufsc-clubs' ); ?></span>
 


### PR DESCRIPTION
## Summary
- enhance color tokens for WCAG AA contrast and add focus outlines
- add responsive grids for licence and document cards
- expose dashboard sections as ARIA regions with focusable document items

## Testing
- `php -l templates/frontend/club-dashboard.php`
- `php tests/test-frontend.php` *(fails: PHPUnit\Framework\TestCase not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f8f521c832b89debeb797c1b962