### PR TITLE
Add DB indexes and optimize stats queries

### DIFF
--- a/includes/core/class-ufsc-db-migrations.php
+++ b/includes/core/class-ufsc-db-migrations.php
@@ -10,7 +10,7 @@ class UFSC_DB_Migrations {
     /**
      * Current migration version
      */
-    const MIGRATION_VERSION = '1.0.0';
+    const MIGRATION_VERSION = '1.1.0';
 
     /**
      * Option key for tracking migration version
@@ -75,25 +75,39 @@ class UFSC_DB_Migrations {
         
         // Licences table indexes
         $licences_indexes = array(
-            'idx_licences_statut' => 'statut',
-            'idx_licences_payment_status' => 'payment_status',
-            'idx_licences_date_creation' => 'date_creation',
-            'idx_licences_nom_licence' => 'nom_licence',
-            'idx_licences_club_id' => 'club_id',
-            'idx_licences_numero_licence_delegataire' => 'numero_licence_delegataire'
+            'idx_licences_statut'                   => 'statut',
+            'idx_licences_payment_status'          => 'payment_status',
+            'idx_licences_date_creation'           => 'date_creation',
+            'idx_licences_nom_licence'             => 'nom_licence',
+            'idx_licences_club_id'                 => 'club_id',
+            'idx_licences_numero_licence_delegataire' => 'numero_licence_delegataire',
+            // New indexes for performant stats queries
+            'idx_licences_status'                  => 'status',
+            'idx_licences_paid'                    => 'paid',
+            'idx_licences_gender'                  => 'gender',
+            'idx_licences_practice'                => 'practice',
+            'idx_licences_birthdate'               => 'birthdate',
         );
 
         self::create_table_indexes( $settings['table_licences'], $licences_indexes );
 
         // Clubs table indexes
         $clubs_indexes = array(
-            'idx_clubs_statut' => 'statut',
-            'idx_clubs_region' => 'region',
+            'idx_clubs_statut'        => 'statut',
+            'idx_clubs_region'        => 'region',
             'idx_clubs_date_creation' => 'date_creation',
-            'idx_clubs_responsable_id' => 'responsable_id'
+            'idx_clubs_responsable_id'=> 'responsable_id'
         );
 
         self::create_table_indexes( $settings['table_clubs'], $clubs_indexes );
+
+        // Club documents table indexes
+        $club_docs_table   = $wpdb->prefix . 'ufsc_club_docs';
+        $club_docs_indexes = array(
+            'idx_club_docs_club_id' => 'club_id',
+        );
+
+        self::create_table_indexes( $club_docs_table, $club_docs_indexes );
     }
 
     /**

--- a/includes/front/class-ufsc-stats.php
+++ b/includes/front/class-ufsc-stats.php
@@ -1,0 +1,93 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class UFSC_Stats {
+    /**
+     * Get aggregated statistics for a club's licences.
+     * Utilises indexed columns and GROUP BY queries for performance.
+     *
+     * @param int      $club_id Club identifier.
+     * @param null|int $season  Optional season filter.
+     * @return array  Aggregated statistics.
+     */
+    public static function get_club_stats( $club_id, $season = null ) {
+        global $wpdb;
+
+        if ( function_exists( 'ufsc_get_licences_table' ) ) {
+            $table = ufsc_get_licences_table();
+        } else {
+            $table = $wpdb->prefix . 'ufsc_licences';
+        }
+
+        $where = $wpdb->prepare( 'club_id = %d', $club_id );
+        if ( null !== $season ) {
+            // Season column optional; only add if exists.
+            $columns = $wpdb->get_col( "DESCRIBE `{$table}`" );
+            if ( in_array( 'season', $columns, true ) ) {
+                $where .= $wpdb->prepare( ' AND season = %d', $season );
+            }
+        }
+
+        // Status distribution
+        $status_rows = $wpdb->get_results( "SELECT status, COUNT(*) AS count FROM `{$table}` WHERE {$where} GROUP BY status" );
+        $status_counts = array();
+        $total_licences = 0;
+        foreach ( $status_rows as $row ) {
+            $status_counts[ $row->status ] = (int) $row->count;
+            $total_licences += (int) $row->count;
+        }
+
+        // Paid distribution
+        $paid_rows = $wpdb->get_results( "SELECT paid, COUNT(*) AS count FROM `{$table}` WHERE {$where} GROUP BY paid" );
+        $paid_counts = array();
+        $paid_licences = 0;
+        foreach ( $paid_rows as $row ) {
+            $paid_counts[ $row->paid ] = (int) $row->count;
+            if ( '1' == $row->paid || 1 === (int) $row->paid ) {
+                $paid_licences = (int) $row->count;
+            }
+        }
+
+        // Gender distribution
+        $gender_rows = $wpdb->get_results( "SELECT gender, COUNT(*) AS count FROM `{$table}` WHERE {$where} GROUP BY gender" );
+        $gender_counts = array();
+        foreach ( $gender_rows as $row ) {
+            $gender_counts[ $row->gender ] = (int) $row->count;
+        }
+
+        // Practice distribution
+        $practice_rows = $wpdb->get_results( "SELECT practice, COUNT(*) AS count FROM `{$table}` WHERE {$where} GROUP BY practice" );
+        $practice_counts = array();
+        foreach ( $practice_rows as $row ) {
+            $practice_counts[ $row->practice ] = (int) $row->count;
+        }
+
+        // Birth year distribution
+        $birth_rows = $wpdb->get_results( "SELECT YEAR(birthdate) AS year, COUNT(*) AS count FROM `{$table}` WHERE {$where} GROUP BY YEAR(birthdate)" );
+        $birth_year_counts = array();
+        foreach ( $birth_rows as $row ) {
+            $birth_year_counts[ $row->year ] = (int) $row->count;
+        }
+
+        // Determine validated licences based on status
+        $validated_statuses = array( 'validated', 'valide', 'validée', 'validé', 'approved' );
+        $validated_licences = 0;
+        foreach ( $validated_statuses as $status ) {
+            if ( isset( $status_counts[ $status ] ) ) {
+                $validated_licences += $status_counts[ $status ];
+            }
+        }
+
+        return array(
+            'total_licences'     => $total_licences,
+            'paid_licences'      => $paid_licences,
+            'validated_licences' => $validated_licences,
+            'quota_remaining'    => max( 0, 50 - $total_licences ),
+            'by_status'          => $status_counts,
+            'by_paid'            => $paid_counts,
+            'by_gender'          => $gender_counts,
+            'by_practice'        => $practice_counts,
+            'by_birth_year'      => $birth_year_counts,
+        );
+    }
+}

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1529,70 +1529,18 @@ class UFSC_Frontend_Shortcodes {
      */
     private static function get_club_stats( $club_id, $season ) {
         $cache_key = "ufsc_stats_{$club_id}_{$season}";
-        $stats = get_transient( $cache_key );
-        
-        if ( false === $stats ) {
-            global $wpdb;
+        $stats     = get_transient( $cache_key );
 
-            if ( ! function_exists( 'ufsc_get_licences_table' ) ) {
-                $stats = array( 'total_licences' => 0, 'paid_licences' => 0, 'validated_licences' => 0, 'quota_remaining' => 10 );
+        if ( false === $stats ) {
+            if ( class_exists( 'UFSC_Stats' ) ) {
+                $stats = UFSC_Stats::get_club_stats( $club_id, $season );
             } else {
-                $licences_table = ufsc_get_licences_table();
-                
-                // Get table columns for dynamic detection
-                $columns = $wpdb->get_col( "DESCRIBE `{$licences_table}`" );
-                
-                // Total licences
-                $total_licences = (int) $wpdb->get_var( $wpdb->prepare(
-                    "SELECT COUNT(*) FROM `{$licences_table}` WHERE club_id = %d",
-                    $club_id
-                ) );
-                
-                // Paid licences with dynamic column detection
-                $paid_licences = 0;
-                $paid_where = array();
-                
-                if ( in_array( 'paid_season', $columns ) ) {
-                    $paid_where[] = $wpdb->prepare( "paid_season = %s", $season );
-                }
-                if ( in_array( 'is_paid', $columns ) ) {
-                    $paid_where[] = "is_paid = 1";
-                }
-                
-                if ( ! empty( $paid_where ) ) {
-                    $paid_query = "SELECT COUNT(*) FROM `{$licences_table}` WHERE club_id = %d AND (" . implode( ' OR ', $paid_where ) . ")";
-                    $paid_licences = (int) $wpdb->get_var( $wpdb->prepare( $paid_query, $club_id ) );
-                }
-                
-                // Validated licences with dynamic column detection
-                $validated_licences = 0;
-                $status_column = null;
-                foreach ( ['status', 'statut'] as $col ) {
-                    if ( in_array( $col, $columns ) ) {
-                        $status_column = $col;
-                        break;
-                    }
-                }
-                
-                if ( $status_column ) {
-                    $validated_statuses = ['valide', 'validée', 'validé', 'validated', 'approved'];
-                    $status_placeholders = implode( ',', array_fill( 0, count( $validated_statuses ), '%s' ) );
-                    $validated_query = "SELECT COUNT(*) FROM `{$licences_table}` WHERE club_id = %d AND `{$status_column}` IN ({$status_placeholders})";
-                    $validated_licences = (int) $wpdb->get_var( $wpdb->prepare( $validated_query, array_merge( [$club_id], $validated_statuses ) ) );
-                }
-                
-                $stats = array(
-                    'total_licences' => $total_licences,
-                    'paid_licences' => $paid_licences,
-                    'validated_licences' => $validated_licences,
-                    'quota_remaining' => max( 0, 50 - $total_licences ) // Default quota of 50
-                );
+                $stats = array( 'total_licences' => 0, 'paid_licences' => 0, 'validated_licences' => 0, 'quota_remaining' => 10 );
             }
-            
-            // Cache for 1 hour
+
             set_transient( $cache_key, $stats, HOUR_IN_SECONDS );
         }
-        
+
         return $stats;
     }
 

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -36,6 +36,7 @@ require_once UFSC_CL_DIR.'includes/core/class-ufsc-db-migrations.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-affiliation-form.php';
 require_once UFSC_CL_DIR.'includes/admin/list-tables/class-ufsc-licences-list-table.php';
 require_once UFSC_CL_DIR.'includes/admin/list-tables/class-ufsc-clubs-list-table.php';
+require_once UFSC_CL_DIR.'includes/front/class-ufsc-stats.php';
 
 // New frontend layer components
 require_once UFSC_CL_DIR.'includes/frontend/class-frontend-shortcodes.php';
@@ -107,7 +108,10 @@ final class UFSC_CL_Bootstrap {
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
         add_action( 'wp_enqueue_scripts', array( $this, 'localize_frontend_scripts' ) );
     }
-    public function on_activate(){ flush_rewrite_rules(); }
+    public function on_activate(){
+        UFSC_DB_Migrations::run_migrations();
+        flush_rewrite_rules();
+    }
     public function on_deactivate(){ flush_rewrite_rules(); }
 
     /**


### PR DESCRIPTION
## Summary
- add database indexes for club and licence stats queries
- refactor stats aggregation to use GROUP BY and cached helper class

## Testing
- `php -l includes/core/class-ufsc-db-migrations.php`
- `php -l ufsc-clubs-licences-sql.php`
- `php -l includes/front/class-ufsc-stats.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php tests/test-core.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f89ff94832b8749c19e00b86cde