### PR TITLE
Add uninstall script to clean plugin options

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Fired when the plugin is uninstalled.
+ *
+ * @package UFSC Gestion
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+// Remove stored options.
+$option_names = [
+    'ufsc_gestion_settings',
+    'ufsc_woocommerce_settings',
+    'ufsc_sql_settings',
+    'ufsc_db_migration_version',
+    'ufsc_license_pricing_rules',
+    'ufsc_dashboard_page',
+];
+
+foreach ( $option_names as $option ) {
+    delete_option( $option );
+}
+
+// Remove dynamically created options.
+global $wpdb;
+$like_patterns = [
+    'ufsc_club_logo_%',
+    'ufsc_club_doc_%',
+];
+
+foreach ( $like_patterns as $pattern ) {
+    $wpdb->query(
+        $wpdb->prepare(
+            "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+            $pattern
+        )
+    );
+}
+


### PR DESCRIPTION
## Summary
- add uninstall handler to remove plugin options and dynamic option patterns on uninstall

## Testing
- `php -l uninstall.php`
- `phpunit tests/test-core.php tests/test-frontend.php tests/test-club-save.php tests/test-affiliation-redirect.php tests/integration-test.php` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f801914832babf280dee92376fd