### PR TITLE
Add configurable UFSC settings and WooCommerce integration options

### DIFF
--- a/inc/woocommerce/settings-woocommerce.php
+++ b/inc/woocommerce/settings-woocommerce.php
@@ -16,7 +16,9 @@ function ufsc_get_default_woocommerce_settings() {
         'product_affiliation_id' => 4823,
         'product_license_id' => 2934,
         'included_licenses' => 10,
-        'season' => '2025-2026'
+        'season' => '2025-2026',
+        'max_profile_photo_size' => 2,
+        'auto_consume_included' => 1,
     );
 }
 
@@ -53,9 +55,17 @@ function ufsc_save_woocommerce_settings( $settings ) {
     if ( isset( $settings['included_licenses'] ) ) {
         $sanitized['included_licenses'] = absint( $settings['included_licenses'] );
     }
-    
+
     if ( isset( $settings['season'] ) ) {
         $sanitized['season'] = sanitize_text_field( $settings['season'] );
+    }
+
+    if ( isset( $settings['max_profile_photo_size'] ) ) {
+        $sanitized['max_profile_photo_size'] = absint( $settings['max_profile_photo_size'] );
+    }
+
+    if ( isset( $settings['auto_consume_included'] ) ) {
+        $sanitized['auto_consume_included'] = ! empty( $settings['auto_consume_included'] ) ? 1 : 0;
     }
     
     return update_option( 'ufsc_woocommerce_settings', $sanitized );

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -51,13 +51,13 @@ class UFSC_CL_Admin_Menu {
             array( 'UFSC_SQL_Admin', 'render_exports' ) 
         );
         
-        add_submenu_page( 
-            'ufsc-dashboard', 
-            __('Paramètres','ufsc-clubs'), 
-            __('Paramètres','ufsc-clubs'), 
-            'manage_options', 
-            'ufsc-settings', 
-            array( 'UFSC_SQL_Admin', 'render_settings' ) 
+        add_submenu_page(
+            'ufsc-dashboard',
+            __('Paramètres','ufsc-clubs'),
+            __('Paramètres','ufsc-clubs'),
+            'manage_options',
+            'ufsc-settings',
+            array( 'UFSC_Settings_Page', 'render' )
         );
         
         add_submenu_page( 

--- a/includes/admin/class-ufsc-settings-page.php
+++ b/includes/admin/class-ufsc-settings-page.php
@@ -1,0 +1,74 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+class UFSC_Settings_Page {
+    const OPTION_KEY = 'ufsc_woocommerce_settings';
+
+    public static function get_default_settings() {
+        return array(
+            'product_license_id'     => 2934,
+            'product_affiliation_id' => 4823,
+            'included_licenses'      => 10,
+            'max_profile_photo_size' => 2,
+            'auto_consume_included'  => 1,
+        );
+    }
+
+    public static function get_settings() {
+        $defaults = self::get_default_settings();
+        $saved    = get_option( self::OPTION_KEY, array() );
+        return wp_parse_args( $saved, $defaults );
+    }
+
+    public static function save_settings( $input ) {
+        $sanitized = array();
+        if ( isset( $input['product_license_id'] ) ) {
+            $sanitized['product_license_id'] = absint( $input['product_license_id'] );
+        }
+        if ( isset( $input['product_affiliation_id'] ) ) {
+            $sanitized['product_affiliation_id'] = absint( $input['product_affiliation_id'] );
+        }
+        if ( isset( $input['included_licenses'] ) ) {
+            $sanitized['included_licenses'] = absint( $input['included_licenses'] );
+        }
+        if ( isset( $input['max_profile_photo_size'] ) ) {
+            $sanitized['max_profile_photo_size'] = absint( $input['max_profile_photo_size'] );
+        }
+        $sanitized['auto_consume_included'] = ! empty( $input['auto_consume_included'] ) ? 1 : 0;
+
+        $existing = get_option( self::OPTION_KEY, array() );
+        $sanitized = array_merge( $existing, $sanitized );
+        update_option( self::OPTION_KEY, $sanitized );
+    }
+
+    public static function render() {
+        if ( isset( $_POST['ufsc_settings_save'] ) && check_admin_referer( 'ufsc_settings' ) ) {
+            self::save_settings( wp_unslash( $_POST ) );
+            echo '<div class="updated"><p>' . esc_html__( 'Paramètres enregistrés.', 'ufsc-clubs' ) . '</p></div>';
+        }
+        $s = self::get_settings();
+        echo '<div class="wrap"><h1>' . esc_html__( 'Paramètres UFSC', 'ufsc-clubs' ) . '</h1>';
+        echo '<form method="post">';
+        wp_nonce_field( 'ufsc_settings' );
+        echo '<table class="form-table">';
+
+        echo '<tr><th scope="row"><label for="product_affiliation_id">' . esc_html__( 'ID du produit pack affiliation', 'ufsc-clubs' ) . '</label></th>';
+        echo '<td><input type="number" id="product_affiliation_id" name="product_affiliation_id" value="' . esc_attr( $s['product_affiliation_id'] ) . '" class="regular-text" /></td></tr>';
+
+        echo '<tr><th scope="row"><label for="product_license_id">' . esc_html__( 'ID du produit licence additionnelle', 'ufsc-clubs' ) . '</label></th>';
+        echo '<td><input type="number" id="product_license_id" name="product_license_id" value="' . esc_attr( $s['product_license_id'] ) . '" class="regular-text" /></td></tr>';
+
+        echo '<tr><th scope="row"><label for="included_licenses">' . esc_html__( 'Licences incluses par pack', 'ufsc-clubs' ) . '</label></th>';
+        echo '<td><input type="number" id="included_licenses" name="included_licenses" value="' . esc_attr( $s['included_licenses'] ) . '" class="regular-text" min="0" /></td></tr>';
+
+        echo '<tr><th scope="row"><label for="max_profile_photo_size">' . esc_html__( 'Taille max photo profil (Mo)', 'ufsc-clubs' ) . '</label></th>';
+        echo '<td><input type="number" id="max_profile_photo_size" name="max_profile_photo_size" value="' . esc_attr( $s['max_profile_photo_size'] ) . '" class="regular-text" min="1" /></td></tr>';
+
+        echo '<tr><th scope="row">' . esc_html__( 'Auto-consommer licences incluses', 'ufsc-clubs' ) . '</th>';
+        echo '<td><label><input type="checkbox" id="auto_consume_included" name="auto_consume_included" value="1" ' . checked( 1, $s['auto_consume_included'], false ) . ' /> ' . esc_html__( 'Activer', 'ufsc-clubs' ) . '</label></td></tr>';
+
+        echo '</table>';
+        submit_button( __( 'Enregistrer', 'ufsc-clubs' ), 'primary', 'ufsc_settings_save' );
+        echo '</form></div>';
+    }
+}

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -504,7 +504,8 @@ class UFSC_Unified_Handlers {
         $included_quota = isset( $wc_settings['included_licenses'] ) ? (int) $wc_settings['included_licenses'] : 10;
         $current_included = UFSC_SQL::count_included_licences( $club_id );
 
-        if ( $current_included < $included_quota ) {
+        $auto_consume = ! empty( $wc_settings['auto_consume_included'] );
+        if ( $auto_consume && $current_included < $included_quota ) {
             UFSC_SQL::mark_licence_as_included( $new_id );
             $redirect_url = esc_url_raw( add_query_arg(
                 array(

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -15,6 +15,7 @@ define( 'UFSC_CL_URL', plugin_dir_url( __FILE__ ) );
 require_once UFSC_CL_DIR.'includes/core/class-utils.php';
 require_once UFSC_CL_DIR.'includes/core/column-map.php';
 require_once UFSC_CL_DIR.'includes/admin/class-admin-menu.php';
+require_once UFSC_CL_DIR.'includes/admin/class-ufsc-settings-page.php';
 require_once UFSC_CL_DIR.'includes/core/class-sql.php';
 require_once UFSC_CL_DIR.'includes/admin/class-sql-admin.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-sql-shortcodes.php';


### PR DESCRIPTION
## Summary
- introduce dedicated UFSC settings page for product IDs, quota, photo size and auto-consume toggle
- expose settings via existing WooCommerce option and respect auto-consume in licence handling
- wire settings page into admin menu and bootstrap

## Testing
- `php -l includes/admin/class-ufsc-settings-page.php`
- `php -l inc/woocommerce/settings-woocommerce.php`
- `php -l includes/core/class-unified-handlers.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f5e00d4832b9fc3dd982af89cb0