### PR TITLE
Add daily cron for licence expiry and reminders

### DIFF
--- a/includes/common/class-ufsc-cron.php
+++ b/includes/common/class-ufsc-cron.php
@@ -1,0 +1,66 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Cron tasks for UFSC Gestion
+ */
+class UFSC_Cron {
+
+    /**
+     * Register hooks.
+     */
+    public static function init() {
+        add_action( 'ufsc_daily', array( __CLASS__, 'process_licences' ) );
+    }
+
+    /**
+     * Process licence expirations and send reminders.
+     */
+    public static function process_licences() {
+        global $wpdb;
+
+        $settings       = UFSC_SQL::get_settings();
+        $licences_table = $settings['table_licences'];
+        $clubs_table    = $settings['table_clubs'];
+
+        // Expire licences past their expiration date.
+        $expired_ids = $wpdb->get_col(
+            "SELECT id FROM {$licences_table} WHERE expires_at IS NOT NULL AND expires_at < NOW() AND statut <> 'expired'"
+        );
+
+        foreach ( $expired_ids as $licence_id ) {
+            $wpdb->update(
+                $licences_table,
+                array( 'statut' => 'expired' ),
+                array( 'id' => $licence_id ),
+                array( '%s' ),
+                array( '%d' )
+            );
+        }
+
+        // Send reminders 30 days before expiry.
+        $reminder_date = gmdate( 'Y-m-d', strtotime( '+30 days' ) );
+        $reminders     = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT l.id, l.email, l.expires_at, c.email AS club_email FROM {$licences_table} l LEFT JOIN {$clubs_table} c ON l.club_id = c.id WHERE DATE(l.expires_at) = %s",
+                $reminder_date
+            )
+        );
+
+        foreach ( $reminders as $row ) {
+            $to = $row->email ? $row->email : $row->club_email;
+            if ( ! $to ) {
+                continue;
+            }
+
+            $subject = __( 'UFSC Licence expiring soon', 'ufsc-clubs' );
+            $message = sprintf(
+                __( 'Your licence will expire on %s.', 'ufsc-clubs' ),
+                date_i18n( get_option( 'date_format' ), strtotime( $row->expires_at ) )
+            );
+
+            wp_mail( $to, $subject, $message );
+        }
+    }
+}
+UFSC_Cron::init();

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -31,6 +31,7 @@ require_once UFSC_CL_DIR.'includes/core/class-cache-manager.php';
 // New UFSC Gestion enhancement classes
 require_once UFSC_CL_DIR.'includes/common/class-ufsc-utils.php';
 require_once UFSC_CL_DIR.'includes/common/functions.php';
+require_once UFSC_CL_DIR.'includes/common/class-ufsc-cron.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-transaction.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-db-migrations.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-affiliation-form.php';
@@ -107,8 +108,19 @@ final class UFSC_CL_Bootstrap {
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
         add_action( 'wp_enqueue_scripts', array( $this, 'localize_frontend_scripts' ) );
     }
-    public function on_activate(){ flush_rewrite_rules(); }
-    public function on_deactivate(){ flush_rewrite_rules(); }
+    public function on_activate(){
+        if ( ! wp_next_scheduled( 'ufsc_daily' ) ) {
+            wp_schedule_event( time(), 'daily', 'ufsc_daily' );
+        }
+        flush_rewrite_rules();
+    }
+    public function on_deactivate(){
+        $timestamp = wp_next_scheduled( 'ufsc_daily' );
+        if ( $timestamp ) {
+            wp_unschedule_event( $timestamp, 'ufsc_daily' );
+        }
+        flush_rewrite_rules();
+    }
 
     /**
      * Enqueue frontend assets


### PR DESCRIPTION
## Summary
- Register `ufsc_daily` cron event on activation and unschedule on deactivation
- Add `UFSC_Cron` class to expire old licences and email reminders 30 days before expiry

## Testing
- `php -l includes/common/class-ufsc-cron.php`
- `php -l ufsc-clubs-licences-sql.php`
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f5a2de0832b84c111eb6c555068