### PR TITLE
Add club documents module and dashboard grid

### DIFF
--- a/includes/front/class-ufsc-documents.php
+++ b/includes/front/class-ufsc-documents.php
@@ -1,0 +1,138 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Manage club documents uploads and downloads.
+ */
+class UFSC_Documents {
+
+    /**
+     * Register hooks for document management.
+     */
+    public static function init() {
+        add_action( 'admin_post_ufsc_upload_document', array( __CLASS__, 'handle_upload' ) );
+        add_action( 'template_redirect', array( __CLASS__, 'maybe_download' ) );
+    }
+
+    /**
+     * Handle document uploads from club dashboard forms.
+     */
+    public static function handle_upload() {
+        if ( ! isset( $_POST['club_id'], $_POST['_wpnonce'] ) ) {
+            wp_die( __( 'Requête invalide.', 'ufsc-clubs' ) );
+        }
+
+        $club_id = (int) $_POST['club_id'];
+
+        if ( ! wp_verify_nonce( $_POST['_wpnonce'], 'ufsc_upload_document_' . $club_id ) ) {
+            wp_die( __( 'Nonce invalide.', 'ufsc-clubs' ) );
+        }
+
+        if ( ! UFSC_CL_Permissions::ufsc_user_can_edit_club( $club_id ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
+        if ( empty( $_FILES['ufsc_document']['name'] ) ) {
+            wp_die( __( 'Aucun fichier fourni.', 'ufsc-clubs' ) );
+        }
+
+        $file = wp_handle_upload( $_FILES['ufsc_document'], array( 'test_form' => false ) );
+
+        if ( isset( $file['error'] ) ) {
+            wp_die( esc_html( $file['error'] ) );
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'ufsc_club_docs';
+
+        $wpdb->insert(
+            $table,
+            array(
+                'club_id'     => $club_id,
+                'file_name'   => basename( $file['file'] ),
+                'file_path'   => $file['file'],
+                'file_url'    => $file['url'],
+                'mime_type'   => $file['type'],
+                'uploaded_at' => current_time( 'mysql' ),
+            ),
+            array( '%d', '%s', '%s', '%s', '%s', '%s' )
+        );
+
+        wp_safe_redirect( wp_get_referer() );
+        exit;
+    }
+
+    /**
+     * Provide secure download for documents.
+     */
+    public static function maybe_download() {
+        if ( empty( $_GET['ufsc_doc'] ) || empty( $_GET['nonce'] ) ) {
+            return;
+        }
+
+        $doc_id = (int) $_GET['ufsc_doc'];
+        $nonce  = sanitize_text_field( wp_unslash( $_GET['nonce'] ) );
+
+        if ( ! wp_verify_nonce( $nonce, 'ufsc_download_doc_' . $doc_id ) ) {
+            wp_die( __( 'Lien de téléchargement invalide.', 'ufsc-clubs' ) );
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'ufsc_club_docs';
+        $doc   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $doc_id ) );
+
+        if ( ! $doc ) {
+            wp_die( __( 'Document introuvable.', 'ufsc-clubs' ) );
+        }
+
+        if ( ! UFSC_CL_Permissions::ufsc_user_can_edit_club( (int) $doc->club_id ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
+        if ( ! file_exists( $doc->file_path ) ) {
+            wp_die( __( 'Fichier introuvable.', 'ufsc-clubs' ) );
+        }
+
+        header( 'Content-Type: ' . $doc->mime_type );
+        header( 'Content-Disposition: attachment; filename="' . basename( $doc->file_name ) . '"' );
+        readfile( $doc->file_path );
+        exit;
+    }
+
+    /**
+     * Get documents for a club.
+     *
+     * @param int $club_id Club ID.
+     * @return array
+     */
+    public static function get_club_documents( $club_id ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'ufsc_club_docs';
+
+        return $wpdb->get_results(
+            $wpdb->prepare( "SELECT * FROM {$table} WHERE club_id = %d ORDER BY uploaded_at DESC", $club_id )
+        );
+    }
+
+    /**
+     * Determine dashicon class for a mime type.
+     *
+     * @param string $mime Mime type.
+     * @return string
+     */
+    public static function get_file_icon( $mime ) {
+        if ( strpos( $mime, 'pdf' ) !== false ) {
+            return 'dashicons-media-document';
+        }
+        if ( strpos( $mime, 'image/' ) === 0 ) {
+            return 'dashicons-format-image';
+        }
+        if ( strpos( $mime, 'spreadsheet' ) !== false || strpos( $mime, 'excel' ) !== false ) {
+            return 'dashicons-media-spreadsheet';
+        }
+        if ( strpos( $mime, 'word' ) !== false || strpos( $mime, 'text' ) !== false ) {
+            return 'dashicons-media-text';
+        }
+        return 'dashicons-media-default';
+    }
+}

--- a/templates/front/dashboard-club.php
+++ b/templates/front/dashboard-club.php
@@ -1,0 +1,68 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+$documents = UFSC_Documents::get_club_documents( $club_id );
+?>
+<div class="ufsc-documents-grid">
+    <?php if ( ! empty( $documents ) ) : ?>
+        <?php foreach ( $documents as $doc ) :
+            $nonce = wp_create_nonce( 'ufsc_download_doc_' . $doc->id );
+            $download_url = add_query_arg(
+                array(
+                    'ufsc_doc' => $doc->id,
+                    'nonce'    => $nonce,
+                ),
+                home_url( '/' )
+            );
+        ?>
+            <div class="ufsc-doc-item">
+                <a href="<?php echo esc_url( $download_url ); ?>" class="ufsc-doc-link">
+                    <span class="dashicons <?php echo esc_attr( UFSC_Documents::get_file_icon( $doc->mime_type ) ); ?> ufsc-doc-icon" aria-hidden="true"></span>
+                    <span class="ufsc-doc-title"><?php echo esc_html( $doc->file_name ); ?></span>
+                </a>
+                <div class="ufsc-doc-actions">
+                    <a href="<?php echo esc_url( $download_url ); ?>" class="ufsc-action" title="<?php esc_attr_e( 'Télécharger', 'ufsc-clubs' ); ?>">
+                        <span class="dashicons dashicons-download" aria-hidden="true"></span>
+                    </a>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    <?php else : ?>
+        <p><?php esc_html_e( 'Aucun document disponible.', 'ufsc-clubs' ); ?></p>
+    <?php endif; ?>
+</div>
+
+<style>
+.ufsc-documents-grid{
+    display:grid;
+    grid-template-columns:repeat(3,1fr);
+    gap:20px;
+}
+@media(max-width:1024px){
+    .ufsc-documents-grid{grid-template-columns:repeat(2,1fr);}
+}
+@media(max-width:600px){
+    .ufsc-documents-grid{grid-template-columns:1fr;}
+}
+.ufsc-doc-item{
+    position:relative;
+    padding:20px;
+    border:1px solid #ddd;
+    border-radius:4px;
+    text-align:center;
+}
+.ufsc-doc-icon{
+    font-size:40px;
+    display:block;
+    margin-bottom:10px;
+}
+.ufsc-doc-actions{
+    position:absolute;
+    top:10px;
+    right:10px;
+    display:none;
+}
+.ufsc-doc-item:hover .ufsc-doc-actions{
+    display:block;
+}
+</style>

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -40,6 +40,7 @@ require_once UFSC_CL_DIR.'includes/admin/list-tables/class-ufsc-clubs-list-table
 // New frontend layer components
 require_once UFSC_CL_DIR.'includes/frontend/class-frontend-shortcodes.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-auth-shortcodes.php';
+require_once UFSC_CL_DIR.'includes/front/class-ufsc-documents.php';
 require_once UFSC_CL_DIR.'includes/api/class-rest-api.php';
 require_once UFSC_CL_DIR.'includes/core/class-audit-logger.php';
 require_once UFSC_CL_DIR.'includes/core/class-email-notifications.php';
@@ -96,6 +97,7 @@ final class UFSC_CL_Bootstrap {
         // Initialize new UFSC Gestion enhancement components
         add_action( 'init', array( 'UFSC_Affiliation_Form', 'init' ) );
         add_action( 'init', array( 'UFSC_CL_Club_Form', 'init' ) );
+        add_action( 'init', array( 'UFSC_Documents', 'init' ) );
         add_action( 'init', array( 'UFSC_Unified_Handlers', 'init' ) );
         add_action( 'init', array( 'UFSC_Cache_Manager', 'init' ) );
         add_action( 'plugins_loaded', array( 'UFSC_DB_Migrations', 'run_migrations' ) );


### PR DESCRIPTION
## Summary
- add UFSC_Documents module for uploading, listing and secure download of club files
- render club documents in new dashboard template with responsive grid and hover actions
- wire module into plugin bootstrap for initialization

## Testing
- `php -l includes/front/class-ufsc-documents.php`
- `php -l templates/front/dashboard-club.php`
- `php -l ufsc-clubs-licences-sql.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba1f4b7edc832bae60199069ead8df