### PR TITLE
Add club profile photo upload and display

### DIFF
--- a/includes/core/class-sql.php
+++ b/includes/core/class-sql.php
@@ -62,6 +62,7 @@ class UFSC_SQL {
                 'rna_number'=>array('RNA','text'),
                 'iban'=>array('IBAN','text'),
                 'logo_url'=>array('Logo URL','text'),
+                'profile_photo_url'=>array('Photo de profil','text'),
                 'doc_statuts'=>array('Document Statuts','number'),
                 'doc_recepisse'=>array('Document Récépissé','number'),
                 'doc_jo'=>array('Document JO','number'),

--- a/includes/front/class-ufsc-media.php
+++ b/includes/front/class-ufsc-media.php
@@ -1,0 +1,142 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Frontend media handler for club profile photos.
+ */
+class UFSC_Media {
+    const MAX_SIZE = 5242880; // 5MB
+
+    /**
+     * Register actions.
+     */
+    public static function init() {
+        add_action( 'admin_post_ufsc_upload_profile_photo', array( __CLASS__, 'upload_profile_photo_action' ) );
+        add_action( 'admin_post_nopriv_ufsc_upload_profile_photo', array( __CLASS__, 'upload_profile_photo_action' ) );
+        add_action( 'admin_post_ufsc_remove_profile_photo', array( __CLASS__, 'remove_profile_photo_action' ) );
+        add_action( 'admin_post_nopriv_ufsc_remove_profile_photo', array( __CLASS__, 'remove_profile_photo_action' ) );
+    }
+
+    /**
+     * Allowed mime types for profile photos.
+     *
+     * @return array
+     */
+    public static function allowed_mimes() {
+        return array(
+            'jpg'  => 'image/jpeg',
+            'jpeg' => 'image/jpeg',
+            'png'  => 'image/png',
+            'webp' => 'image/webp',
+        );
+    }
+
+    /**
+     * Handle upload from a form field.
+     *
+     * @param string $field   Field name in the $_FILES array.
+     * @param int    $club_id Club identifier.
+     * @return string|WP_Error URL of uploaded file or error.
+     */
+    public static function handle_profile_photo_upload( $field, $club_id = 0 ) {
+        if ( empty( $_FILES[ $field ]['name'] ) ) {
+            return new WP_Error( 'no_file', __( 'Aucun fichier envoyé.', 'ufsc-clubs' ) );
+        }
+
+        $file = $_FILES[ $field ];
+
+        if ( $file['size'] > self::MAX_SIZE ) {
+            return new WP_Error( 'file_too_large', __( 'Image trop volumineuse (max 5MB).', 'ufsc-clubs' ) );
+        }
+
+        $filetype = wp_check_filetype_and_ext( $file['tmp_name'], $file['name'] );
+        $allowed  = self::allowed_mimes();
+        if ( empty( $filetype['type'] ) || ! in_array( $filetype['type'], $allowed, true ) ) {
+            return new WP_Error( 'invalid_file_type', __( 'Type de fichier non autorisé.', 'ufsc-clubs' ) );
+        }
+
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/media.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+
+        $overrides = array(
+            'test_form' => false,
+            'mimes'     => $allowed,
+        );
+
+        $attach_id = media_handle_upload( $field, 0, array(), $overrides );
+        if ( is_wp_error( $attach_id ) ) {
+            return $attach_id;
+        }
+
+        $url = wp_get_attachment_url( $attach_id );
+
+        if ( $club_id ) {
+            global $wpdb;
+            $settings = UFSC_SQL::get_settings();
+            $table    = $settings['table_clubs'];
+            $wpdb->update( $table, array( 'profile_photo_url' => $url ), array( 'id' => $club_id ) );
+        }
+
+        return $url;
+    }
+
+    /**
+     * Action handler for uploading a profile photo.
+     */
+    public static function upload_profile_photo_action() {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
+        $club_id = isset( $_POST['club_id'] ) ? (int) $_POST['club_id'] : 0;
+        if ( ! UFSC_CL_Permissions::ufsc_user_can_edit_club( $club_id ) ) {
+            wp_die( __( 'Permissions insuffisantes.', 'ufsc-clubs' ) );
+        }
+
+        check_admin_referer( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' );
+
+        $result = self::handle_profile_photo_upload( 'profile_photo', $club_id );
+        if ( is_wp_error( $result ) ) {
+            wp_die( $result->get_error_message() );
+        }
+
+        wp_safe_redirect( wp_get_referer() );
+        exit;
+    }
+
+    /**
+     * Remove profile photo action handler.
+     */
+    public static function remove_profile_photo_action() {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
+        $club_id = isset( $_POST['club_id'] ) ? (int) $_POST['club_id'] : 0;
+        if ( ! UFSC_CL_Permissions::ufsc_user_can_edit_club( $club_id ) ) {
+            wp_die( __( 'Permissions insuffisantes.', 'ufsc-clubs' ) );
+        }
+
+        check_admin_referer( 'ufsc_remove_profile_photo', 'ufsc_remove_profile_photo_nonce' );
+
+        self::remove_profile_photo( $club_id );
+        wp_safe_redirect( wp_get_referer() );
+        exit;
+    }
+
+    /**
+     * Remove profile photo from database.
+     *
+     * @param int $club_id Club identifier.
+     */
+    public static function remove_profile_photo( $club_id ) {
+        if ( ! $club_id ) {
+            return;
+        }
+        global $wpdb;
+        $settings = UFSC_SQL::get_settings();
+        $table    = $settings['table_clubs'];
+        $wpdb->update( $table, array( 'profile_photo_url' => '' ), array( 'id' => $club_id ) );
+    }
+}

--- a/includes/frontend/class-club-form-handler.php
+++ b/includes/frontend/class-club-form-handler.php
@@ -214,18 +214,29 @@ class UFSC_CL_Club_Form_Handler {
         // Handle logo upload
         if ( ! empty( $_FILES['logo_upload']['name'] ) ) {
             $logo_id = UFSC_Uploads::handle_single_upload_field( 'logo_upload', $club_id, UFSC_Uploads::get_logo_mime_types(), UFSC_Uploads::get_logo_max_size() );
-            
+
             if ( is_wp_error( $logo_id ) ) {
                 return $logo_id;
             }
-            
+
             $logo_url = wp_get_attachment_url( $logo_id );
             $upload_results['logo_url'] = $logo_url;
             if ( $club_id ) {
                 update_post_meta( $club_id, 'logo_url', $logo_id );
             }
         }
-        
+
+        // Handle profile photo upload
+        if ( ! empty( $_FILES['profile_photo']['name'] ) ) {
+            $photo_url = UFSC_Media::handle_profile_photo_upload( 'profile_photo', $club_id );
+            if ( is_wp_error( $photo_url ) ) {
+                return $photo_url;
+            }
+            $upload_results['profile_photo_url'] = $photo_url;
+        } elseif ( ! empty( $_POST['remove_profile_photo'] ) ) {
+            $upload_results['profile_photo_url'] = '';
+        }
+
         // Handle required document uploads
         $doc_results = UFSC_Uploads::handle_required_docs( $club_id );
         if ( is_wp_error( $doc_results ) ) {

--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -146,7 +146,22 @@ class UFSC_CL_Club_Form {
                 <!-- General Information Section -->
                 <fieldset class="ufsc-form-section ufsc-grid">
                     <legend><?php esc_html_e( 'Informations générales', 'ufsc-clubs' ); ?></legend>
-                    
+
+                    <div class="ufsc-field">
+                        <label for="profile_photo" class="ufsc-label"><?php esc_html_e( 'Photo du club', 'ufsc-clubs' ); ?></label>
+                        <?php if ( ! empty( $club_data['profile_photo_url'] ) ) : ?>
+                            <div class="ufsc-profile-photo-preview">
+                                <img src="<?php echo esc_url( $club_data['profile_photo_url'] ); ?>" alt="<?php esc_attr_e( 'Photo du club', 'ufsc-clubs' ); ?>" />
+                            </div>
+                            <div class="ufsc-upload-actions">
+                                <input type="file" id="profile_photo" name="profile_photo" accept="image/jpeg,image/png,image/webp" />
+                                <button type="submit" name="remove_profile_photo" value="1" class="ufsc-btn ufsc-btn-secondary"><?php esc_html_e( 'Supprimer la photo', 'ufsc-clubs' ); ?></button>
+                            </div>
+                        <?php else : ?>
+                            <input type="file" id="profile_photo" name="profile_photo" accept="image/jpeg,image/png,image/webp" />
+                        <?php endif; ?>
+                    <div class="ufsc-field-error" aria-live="polite"></div></div>
+
                     <div class="ufsc-field">
                         <label for="nom" class="ufsc-label required"><?php esc_html_e( 'Nom du club', 'ufsc-clubs' ); ?></label>
                         <input type="text" id="nom" name="nom" value="<?php echo esc_attr( $club_data['nom'] ?? '' ); ?>" required />

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -717,6 +717,32 @@ class UFSC_Frontend_Shortcodes {
                     </p>
                 <?php endif; ?>
             </div>
+            <?php if ( ! empty( $club->profile_photo_url ) ) : ?>
+                <div class="ufsc-club-photo">
+                    <img src="<?php echo esc_url( $club->profile_photo_url ); ?>" alt="<?php esc_attr_e( 'Photo du club', 'ufsc-clubs' ); ?>" />
+                    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-remove-photo-form">
+                        <?php wp_nonce_field( 'ufsc_remove_profile_photo', 'ufsc_remove_profile_photo_nonce' ); ?>
+                        <input type="hidden" name="action" value="ufsc_remove_profile_photo" />
+                        <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
+                        <button type="submit" class="button ufsc-remove-photo"><?php esc_html_e( 'Supprimer la photo', 'ufsc-clubs' ); ?></button>
+                    </form>
+                    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-change-photo-form">
+                        <?php wp_nonce_field( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' ); ?>
+                        <input type="hidden" name="action" value="ufsc_upload_profile_photo" />
+                        <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
+                        <input type="file" name="profile_photo" accept="image/jpeg,image/png,image/webp" />
+                        <button type="submit" class="button ufsc-upload-photo"><?php esc_html_e( 'Changer la photo', 'ufsc-clubs' ); ?></button>
+                    </form>
+                </div>
+            <?php else : ?>
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-upload-photo-form">
+                    <?php wp_nonce_field( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' ); ?>
+                    <input type="hidden" name="action" value="ufsc_upload_profile_photo" />
+                    <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
+                    <input type="file" name="profile_photo" accept="image/jpeg,image/png,image/webp" />
+                    <button type="submit" class="button ufsc-upload-photo"><?php esc_html_e( 'Ajouter une photo', 'ufsc-clubs' ); ?></button>
+                </form>
+            <?php endif; ?>
 
             <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-club-form ufsc-club-profile">
                 <div class="ufsc-notices" aria-live="polite"></div>

--- a/templates/frontend/club-dashboard.php
+++ b/templates/frontend/club-dashboard.php
@@ -14,6 +14,34 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
     <!-- 1. En-tête Club -->
     <div class="ufsc-dashboard-header">
         <div class="ufsc-club-header">
+            <?php if ( ! empty( $club->profile_photo_url ) ) : ?>
+                <div class="ufsc-club-photo">
+                    <img src="<?php echo esc_url( $club->profile_photo_url ); ?>" alt="<?php esc_attr_e( 'Photo du club', 'ufsc-clubs' ); ?>" />
+                    <?php if ( UFSC_CL_Permissions::ufsc_user_can_edit_club( $club->id ) ) : ?>
+                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-remove-photo-form">
+                            <?php wp_nonce_field( 'ufsc_remove_profile_photo', 'ufsc_remove_profile_photo_nonce' ); ?>
+                            <input type="hidden" name="action" value="ufsc_remove_profile_photo" />
+                            <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
+                            <button type="submit" class="button ufsc-remove-photo"><?php esc_html_e( 'Supprimer la photo', 'ufsc-clubs' ); ?></button>
+                        </form>
+                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-change-photo-form">
+                            <?php wp_nonce_field( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' ); ?>
+                            <input type="hidden" name="action" value="ufsc_upload_profile_photo" />
+                            <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
+                            <input type="file" name="profile_photo" accept="image/jpeg,image/png,image/webp" />
+                            <button type="submit" class="button ufsc-upload-photo"><?php esc_html_e( 'Changer la photo', 'ufsc-clubs' ); ?></button>
+                        </form>
+                    <?php endif; ?>
+                </div>
+            <?php elseif ( UFSC_CL_Permissions::ufsc_user_can_edit_club( $club->id ) ) : ?>
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-upload-photo-form">
+                    <?php wp_nonce_field( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' ); ?>
+                    <input type="hidden" name="action" value="ufsc_upload_profile_photo" />
+                    <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
+                    <input type="file" name="profile_photo" accept="image/jpeg,image/png,image/webp" />
+                    <button type="submit" class="button ufsc-upload-photo"><?php esc_html_e( 'Ajouter une photo', 'ufsc-clubs' ); ?></button>
+                </form>
+            <?php endif; ?>
             <h1 class="ufsc-club-name"><?php echo esc_html( $club->nom ); ?></h1>
             <div class="ufsc-club-meta">
                 <span class="ufsc-region"><?php echo esc_html( $club->region ); ?></span>

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -21,6 +21,7 @@ require_once UFSC_CL_DIR.'includes/frontend/class-sql-shortcodes.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-club-form.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-club-form-handler.php';
 require_once UFSC_CL_DIR.'includes/core/class-uploads.php';
+require_once UFSC_CL_DIR.'includes/front/class-ufsc-media.php';
 require_once UFSC_CL_DIR.'includes/core/class-permissions.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-badges.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-pdf-attestations.php';
@@ -96,6 +97,7 @@ final class UFSC_CL_Bootstrap {
         // Initialize new UFSC Gestion enhancement components
         add_action( 'init', array( 'UFSC_Affiliation_Form', 'init' ) );
         add_action( 'init', array( 'UFSC_CL_Club_Form', 'init' ) );
+        add_action( 'init', array( 'UFSC_Media', 'init' ) );
         add_action( 'init', array( 'UFSC_Unified_Handlers', 'init' ) );
         add_action( 'init', array( 'UFSC_Cache_Manager', 'init' ) );
         add_action( 'plugins_loaded', array( 'UFSC_DB_Migrations', 'run_migrations' ) );


### PR DESCRIPTION
## Summary
- enable JPEG/PNG/WebP uploads up to 5MB with UFSC_Media class and admin-post handlers
- allow club form to upload/remove profile photos and store URL in `profile_photo_url`
- show and manage profile photo on club dashboard and "Mon club" frontend sections

## Testing
- `php -l includes/front/class-ufsc-media.php`
- `php -l includes/frontend/class-club-form-handler.php`
- `php -l includes/frontend/class-club-form.php`
- `php -l templates/frontend/club-dashboard.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l includes/core/class-sql.php`
- `php -l ufsc-clubs-licences-sql.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f45e52c832baacb1408509704fe