### PR TITLE
Handle included licence quota in WooCommerce

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -246,10 +246,9 @@ class UFSC_Frontend_Shortcodes {
         $total_count = self::get_club_licences_count( $atts['club_id'], $atts );
         $total_pages = ceil( $total_count / $atts['per_page'] );
 
-        $club_name = self::get_club_name( $atts['club_id'] );
-
+        $club_name  = self::get_club_name( $atts['club_id'] );
         $wc_settings = ufsc_get_woocommerce_settings();
-
+        $quota_info = self::get_club_quota_info( $atts['club_id'] );
 
         ob_start();
         ?>

--- a/templates/frontend/licences-list.php
+++ b/templates/frontend/licences-list.php
@@ -1,6 +1,11 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 ?>
+<?php if ( isset( $quota_info['remaining'] ) ) : ?>
+    <p class="ufsc-quota-remaining">
+        <?php printf( esc_html__( 'Quota restant : %d', 'ufsc-clubs' ), intval( $quota_info['remaining'] ) ); ?>
+    </p>
+<?php endif; ?>
 <table class="ufsc-table ufsc-licences-table">
     <thead>
         <tr>
@@ -18,6 +23,9 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                 <td><?php echo esc_html( $licence->role ?? '' ); ?></td>
                 <td>
                     <?php echo UFSC_Badges::render_licence_badge( $licence->statut ?? '', array( 'custom_class' => 'ufsc-badge' ) ); ?>
+                    <?php if ( ! empty( $licence->is_included ) ) : ?>
+                        <span class="ufsc-badge badge-success ufsc-badge-included"><?php esc_html_e( 'Incluse', 'ufsc-clubs' ); ?></span>
+                    <?php endif; ?>
                 </td>
                 <td>
                     <div class="ufsc-actions">


### PR DESCRIPTION
## Summary
- Offer free licence items when clubs still have included quota and flag consumed entries
- Update club records on order completion to track included quota usage
- Show remaining quota and an "Incluse" badge on licence listings when licences are free

## Testing
- `php -l inc/woocommerce/cart-integration.php`
- `php -l inc/woocommerce/hooks.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l templates/frontend/licences-list.php`
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: 403 Repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1f37a4b0832b8fcffbcb271a98fb