### PR TITLE
Ensure migrations run on activation and clean deactivation

### DIFF
--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -128,6 +128,7 @@ final class UFSC_CL_Bootstrap {
         if ( ! wp_next_scheduled( 'ufsc_daily' ) ) {
             wp_schedule_event( time(), 'daily', 'ufsc_daily' );
         }
+        UFSC_DB_Migrations::run_migrations();
         flush_rewrite_rules();
     }
     public function on_deactivate(){
@@ -137,11 +138,6 @@ final class UFSC_CL_Bootstrap {
         }
         flush_rewrite_rules();
     }
-
-        UFSC_DB_Migrations::run_migrations();
-        flush_rewrite_rules();
-    }
-    public function on_deactivate(){ flush_rewrite_rules(); }
 
     /**
      * Enqueue frontend assets


### PR DESCRIPTION
## Summary
- Remove duplicate deactivation block
- Run database migrations when the plugin activates
- Keep deactivation handler unscheduling `ufsc_daily` and flushing rewrite rules

## Testing
- `php -l ufsc-clubs-licences-sql.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba294d1778832b819b49b23a3a3839