### PR TITLE
Consolidate UFSC_Stats class and move get_club_stats method

### DIFF
--- a/includes/front/class-ufsc-stats.php
+++ b/includes/front/class-ufsc-stats.php
@@ -93,10 +93,8 @@ class UFSC_Stats {
 
         $prepared = $this->wpdb->prepare( $sql, 'active', 1 );
         return $this->wpdb->get_results( $prepared, ARRAY_A );
+    }
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-
-class UFSC_Stats {
     /**
      * Get aggregated statistics for a club's licences.
      * Utilises indexed columns and GROUP BY queries for performance.
@@ -184,6 +182,5 @@ class UFSC_Stats {
             'by_practice'        => $practice_counts,
             'by_birth_year'      => $birth_year_counts,
         );
-
     }
 }


### PR DESCRIPTION
## Summary
- close get_age_group_counts properly and remove duplicate class declaration
- integrate get_club_stats into the main UFSC_Stats class

## Testing
- `php -l includes/front/class-ufsc-stats.php`
- `php tests/test-core.php`
- `phpunit` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y phpunit` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2cb54874832b830b0d938cf06234