### PR TITLE
Add CSV export utilities with UTF-8 BOM

### DIFF
--- a/includes/admin/class-ufsc-export-base.php
+++ b/includes/admin/class-ufsc-export-base.php
@@ -1,0 +1,39 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Base helper for CSV exports.
+ */
+abstract class UFSC_Export_Base {
+    /**
+     * Output a CSV file from rows.
+     *
+     * @param string $filename CSV filename.
+     * @param array  $headers  Header row.
+     * @param array  $rows     Data rows.
+     */
+    protected static function output_csv( $filename, $headers, $rows ) {
+        if ( ob_get_level() ) {
+            ob_end_clean();
+        }
+
+        header( 'Content-Type: text/csv; charset=UTF-8' );
+        header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+        echo "\xEF\xBB\xBF";
+
+        $out = fopen( 'php://output', 'w' );
+
+        if ( ! empty( $headers ) ) {
+            fputcsv( $out, $headers );
+        }
+
+        if ( ! empty( $rows ) ) {
+            foreach ( $rows as $row ) {
+                fputcsv( $out, $row );
+            }
+        }
+
+        fclose( $out );
+        exit;
+    }
+}


### PR DESCRIPTION
## Summary
- Add CSV export handler for club documents with UTF-8 BOM and headers
- Introduce reusable UFSC_Export_Base for future admin exports

## Testing
- `php -l includes/front/class-ufsc-documents.php`
- `php -l includes/admin/class-ufsc-export-base.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba9eb0f870832ba850ec84e548432c