### PR TITLE
Align stats with canonical statuses and fix chart sizing

### DIFF
--- a/assets/js/ufsc-stats.js
+++ b/assets/js/ufsc-stats.js
@@ -1,0 +1,44 @@
+(function() {
+    function setCanvasHeight(id) {
+        var canvas = document.getElementById(id);
+        if (canvas) {
+            canvas.height = 360;
+        }
+        return canvas;
+    }
+
+    function buildPie(el, dataset, key) {
+        var labels = dataset.map(function(d) { return d[key] || 'Inconnu'; });
+        var values = dataset.map(function(d) { return parseInt(d.total, 10); });
+        return new Chart(el.getContext('2d'), {
+            type: 'pie',
+            data: { labels: labels, datasets: [{ data: values }] },
+            options: { responsive: true, maintainAspectRatio: false }
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        var data = window.ufscStatsData || {};
+
+        var genderCanvas = setCanvasHeight('chart-gender');
+        if (genderCanvas && data.gender) {
+            buildPie(genderCanvas, data.gender, 'gender');
+        }
+
+        var practiceCanvas = setCanvasHeight('chart-practice');
+        if (practiceCanvas && data.practice) {
+            buildPie(practiceCanvas, data.practice, 'practice');
+        }
+
+        var ageCanvas = setCanvasHeight('chart-age');
+        if (ageCanvas && data.age) {
+            var labels = data.age.map(function(d) { return d.age_group; });
+            var values = data.age.map(function(d) { return parseInt(d.total, 10); });
+            new Chart(ageCanvas.getContext('2d'), {
+                type: 'bar',
+                data: { labels: labels, datasets: [{ data: values }] },
+                options: { responsive: true, maintainAspectRatio: false }
+            });
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- filter stats queries by canonical `active` status
- compute `paid`, `validated`, and quota from canonical stats
- add stats chart script with fixed height and aspect ratio

## Testing
- `php -l includes/front/class-ufsc-stats.php`
- `node --check assets/js/ufsc-stats.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba9eabfe48832bbf6638306fe46c2c