### PR TITLE
Add quota control and cart validation for licence form

### DIFF
--- a/assets/js/ufsc-license-form.js
+++ b/assets/js/ufsc-license-form.js
@@ -10,6 +10,7 @@
     $(document).ready(function() {
         initLicenseFormValidation();
         initClubRegionSync();
+        initIncludedQuotaCheck();
     });
 
     /**
@@ -218,6 +219,22 @@
                 regionField.val(region);
             });
         }
+    }
+
+    /**
+     * Limit included quota checkbox
+     */
+    function initIncludedQuotaCheck() {
+        const checkbox = $('#is_included');
+        if (!checkbox.length) return;
+        const limit = parseInt($('#included_limit').val(), 10) || 10;
+        const count = parseInt($('#included_count').val(), 10) || 0;
+        checkbox.on('change', function() {
+            if (this.checked && count >= limit) {
+                alert('Quota maximum atteint');
+                this.checked = false;
+            }
+        });
     }
 
     /**

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -493,6 +493,13 @@ class UFSC_Unified_Handlers {
             self::store_form_and_redirect( $_POST, array( $data->get_error_message() ), $licence_id );
         }
 
+        if ( isset( $_POST['ufsc_submit_action'] ) && 'add_to_cart' === $_POST['ufsc_submit_action'] ) {
+            $validation = UFSC_Licence_Form::validate_names_for_cart( $data );
+            if ( is_wp_error( $validation ) ) {
+                self::store_form_and_redirect( $_POST, array( $validation->get_error_message() ), $licence_id );
+            }
+        }
+
         $result = self::save_licence_data( $licence_id, $club_id, $data );
         if ( is_wp_error( $result ) ) {
             self::store_form_and_redirect( $_POST, array( $result->get_error_message() ), $licence_id );
@@ -674,7 +681,7 @@ class UFSC_Unified_Handlers {
         $data = array();
         
         // Required fields
-        $required_fields = array( 'prenom', 'nom', 'email' );
+        $required_fields = array( 'email' );
         foreach ( $required_fields as $field ) {
             if ( empty( $post_data[$field] ) ) {
                 $errors[] = sprintf( __( 'Le champ %s est requis', 'ufsc-clubs' ), $field );
@@ -692,6 +699,8 @@ class UFSC_Unified_Handlers {
         
         // Optional fields with sanitization
         $optional_fields = array(
+            'prenom' => 'sanitize_text_field',
+            'nom' => 'sanitize_text_field',
             'telephone' => 'sanitize_text_field',
             'adresse' => 'sanitize_textarea_field',
             'date_naissance' => 'sanitize_text_field',
@@ -722,7 +731,8 @@ class UFSC_Unified_Handlers {
             'infos_partenaires',
             'honorabilite',
             'assurance_dommage_corporel',
-            'assurance_assistance'
+            'assurance_assistance',
+            'is_included'
         );
 
         foreach ( $boolean_fields as $field ) {

--- a/includes/front/class-ufsc-licence-form.php
+++ b/includes/front/class-ufsc-licence-form.php
@@ -1,0 +1,37 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Helper for licence form operations on the frontend.
+ */
+class UFSC_Licence_Form {
+
+    /**
+     * Get current number of licences included in the quota for a club.
+     *
+     * @param int $club_id Optional club ID. Defaults to current user's club.
+     * @return int
+     */
+    public static function get_included_count( $club_id = 0 ) {
+        if ( ! $club_id && is_user_logged_in() ) {
+            $club_id = ufsc_get_user_club_id( get_current_user_id() );
+        }
+        if ( ! $club_id ) {
+            return 0;
+        }
+        return UFSC_SQL::count_included_licences( $club_id );
+    }
+
+    /**
+     * Ensure first and last name are present before adding to cart.
+     *
+     * @param array $data Licence data.
+     * @return true|WP_Error
+     */
+    public static function validate_names_for_cart( $data ) {
+        if ( empty( $data['prenom'] ) || empty( $data['nom'] ) ) {
+            return new WP_Error( 'missing_name', __( 'Le nom et le prénom sont obligatoires pour ajouter au panier.', 'ufsc-clubs' ) );
+        }
+        return true;
+    }
+}

--- a/templates/frontend/licence-form.php
+++ b/templates/frontend/licence-form.php
@@ -6,15 +6,23 @@ include UFSC_CL_DIR . 'templates/partials/notice.php';
     <input type="hidden" name="action" value="ufsc_save_licence" />
     <?php wp_nonce_field( 'ufsc_save_licence' ); ?>
     <input type="hidden" name="licence_id" value="<?php echo isset( $licence->id ) ? intval( $licence->id ) : 0; ?>" />
+    <?php
+    $wc_settings    = ufsc_get_woocommerce_settings();
+    $included_limit = isset( $wc_settings['included_licenses'] ) ? (int) $wc_settings['included_licenses'] : 10;
+    $included_count = UFSC_Licence_Form::get_included_count();
+    ?>
+    <input type="hidden" id="included_count" value="<?php echo esc_attr( $included_count ); ?>" />
+    <input type="hidden" id="included_limit" value="<?php echo esc_attr( $included_limit ); ?>" />
+    <input type="hidden" name="ufsc_submit_action" id="ufsc_submit_action" value="save" />
 
     <div class="ufsc-grid">
         <div class="ufsc-field">
             <label for="prenom"><?php esc_html_e( 'Pr\u00e9nom', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="prenom" name="prenom" value="<?php echo esc_attr( $licence->prenom ?? '' ); ?>" required />
+            <input type="text" id="prenom" name="prenom" value="<?php echo esc_attr( $licence->prenom ?? '' ); ?>" />
         </div>
         <div class="ufsc-field">
             <label for="nom"><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="nom" name="nom" value="<?php echo esc_attr( $licence->nom ?? '' ); ?>" required />
+            <input type="text" id="nom" name="nom" value="<?php echo esc_attr( $licence->nom ?? '' ); ?>" />
         </div>
         <div class="ufsc-field">
             <label for="email">Email</label>
@@ -56,10 +64,16 @@ include UFSC_CL_DIR . 'templates/partials/notice.php';
             <label for="note"><?php esc_html_e( 'Note', 'ufsc-clubs' ); ?></label>
             <textarea id="note" name="note" rows="3"><?php echo esc_textarea( $licence->note ?? '' ); ?></textarea>
         </div>
+        <div class="ufsc-field">
+            <label class="ufsc-checkbox"><input type="checkbox" id="is_included" name="is_included" value="1" <?php checked( $licence->is_included ?? 0, 1 ); ?> /> <?php esc_html_e( 'Inclure dans quota', 'ufsc-clubs' ); ?></label>
+        </div>
     </div>
     <div class="ufsc-form-actions">
-        <button type="submit" class="ufsc-btn ufsc-btn-primary">
-            <?php echo isset( $licence->id ) && $licence->id ? esc_html__( 'Mettre \u00e0 jour', 'ufsc-clubs' ) : esc_html__( 'Cr\u00e9er', 'ufsc-clubs' ); ?>
+        <button type="submit" class="ufsc-btn ufsc-btn-primary" onclick="document.getElementById('ufsc_submit_action').value='save';">
+            <?php esc_html_e( 'Enregistrer', 'ufsc-clubs' ); ?>
+        </button>
+        <button type="submit" class="ufsc-btn ufsc-btn-secondary" onclick="document.getElementById('ufsc_submit_action').value='add_to_cart';">
+            <?php esc_html_e( 'Ajouter au panier', 'ufsc-clubs' ); ?>
         </button>
     </div>
 </form>

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -43,6 +43,7 @@ require_once UFSC_CL_DIR.'includes/admin/list-tables/class-ufsc-clubs-list-table
 require_once UFSC_CL_DIR.'includes/admin/class-ufsc-club-metaboxes.php';
 
 require_once UFSC_CL_DIR.'includes/front/class-ufsc-stats.php';
+require_once UFSC_CL_DIR.'includes/front/class-ufsc-licence-form.php';
 
 
 // New frontend layer components


### PR DESCRIPTION
## Summary
- add frontend helper for licence quota and validation
- extend licence form with quota checkbox and cart submit options
- enforce name check before adding licence to cart and limit quota via JS

## Testing
- `php -l includes/front/class-ufsc-licence-form.php`
- `php -l includes/core/class-unified-handlers.php`
- `php -l templates/frontend/licence-form.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9ea5c704832b88218ddb1322e1c9