### PR TITLE
Limit licence quota to ten included items

### DIFF
--- a/assets/js/ufsc-license-form.js
+++ b/assets/js/ufsc-license-form.js
@@ -10,6 +10,7 @@
     $(document).ready(function() {
         initLicenseFormValidation();
         initClubRegionSync();
+        initIncludedQuotaLimit();
     });
 
     /**
@@ -218,6 +219,43 @@
                 regionField.val(region);
             });
         }
+    }
+
+    function initIncludedQuotaLimit() {
+        const checkbox = $('#is_included');
+        const counterEl = $('#ufsc-included-counter');
+        const max = 10;
+
+        if (!checkbox.length || !counterEl.length) {
+            return;
+        }
+
+        let count = parseInt(counterEl.data('count'), 10) || 0;
+
+        function update() {
+            counterEl.text(count + '/' + max);
+            if (count >= max && !checkbox.prop('checked')) {
+                checkbox.prop('disabled', true);
+            } else {
+                checkbox.prop('disabled', false);
+            }
+        }
+
+        checkbox.on('change', function() {
+            if (checkbox.prop('checked')) {
+                if (count >= max) {
+                    checkbox.prop('checked', false);
+                    showNotification('Quota maximum de 10 licences atteint', 'error');
+                    return;
+                }
+                count++;
+            } else {
+                count = Math.max(0, count - 1);
+            }
+            update();
+        });
+
+        update();
     }
 
     /**

--- a/inc/woocommerce/hooks.php
+++ b/inc/woocommerce/hooks.php
@@ -380,12 +380,11 @@ if ( ! function_exists( 'ufsc_mark_licence_paid' ) ) {
             $licences_table,
             array(
                 'statut'      => 'en_attente',
-                'is_included' => 0,
                 'paid_season' => $season,
                 'paid_date'   => current_time( 'mysql' ),
             ),
             array( 'id' => $license_id ),
-            array( '%s', '%d', '%s', '%s' ),
+            array( '%s', '%s', '%s' ),
             array( '%d' )
         );
 

--- a/includes/core/class-sql.php
+++ b/includes/core/class-sql.php
@@ -152,10 +152,15 @@ class UFSC_SQL {
         $settings       = self::get_settings();
         $licences_table = $settings['table_licences'];
 
-        $count = (int) $wpdb->get_var( $wpdb->prepare(
-            "SELECT COUNT(*) FROM {$licences_table} WHERE club_id = %d AND is_included = 1",
-            $club_id
-        ) );
+        $statuses      = array( 'draft', 'pending', 'active' );
+        $placeholders  = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+        $query_args    = array_merge( array( $club_id ), $statuses );
+        $query         = $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$licences_table} WHERE club_id = %d AND is_included = 1 AND statut IN ($placeholders)",
+            $query_args
+        );
+
+        $count = (int) $wpdb->get_var( $query );
 
         return $count;
     }

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -722,7 +722,8 @@ class UFSC_Unified_Handlers {
             'infos_partenaires',
             'honorabilite',
             'assurance_dommage_corporel',
-            'assurance_assistance'
+            'assurance_assistance',
+            'is_included'
         );
 
         foreach ( $boolean_fields as $field ) {
@@ -816,6 +817,21 @@ class UFSC_Unified_Handlers {
         $fields = UFSC_SQL::get_licence_fields();
         $data   = array_intersect_key( $data, $fields );
         $data['club_id'] = $club_id;
+
+        // Ensure we don't exceed the quota of included licences
+        if ( ! empty( $data['is_included'] ) ) {
+            $included_count = UFSC_SQL::count_included_licences( $club_id );
+            $existing       = 0;
+
+            if ( $licence_id > 0 ) {
+                $existing = (int) $wpdb->get_var( $wpdb->prepare( "SELECT is_included FROM {$licences_table} WHERE id = %d", $licence_id ) );
+            }
+
+            if ( $included_count - $existing >= 10 ) {
+                $data['is_included'] = 0;
+                return new WP_Error( 'quota_exceeded', __( 'Quota de 10 licences incluses atteint', 'ufsc-clubs' ) );
+            }
+        }
         
         if ( $licence_id > 0 ) {
             // Update


### PR DESCRIPTION
## Summary
- Restrict included licence counting to draft, pending or active statuses
- Prevent saving more than ten included licences and surface a quota warning
- Add client-side quota enforcement for the "Inclure dans quota" checkbox
- Keep licence inclusion flag when marking as paid

## Testing
- `vendor/bin/phpunit tests` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9e9a0714832ba28b79be945586cd