### PR TITLE
Protect SQL admin logic from non-admin context

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -1,6 +1,11 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+// Only load the admin class in the dashboard context.
+if ( ! is_admin() ) {
+    return;
+}
+
 class UFSC_SQL_Admin {
 
     /**


### PR DESCRIPTION
## Summary
- Guard UFSC_SQL_Admin from loading outside of wp-admin to avoid early calls to admin-only functions

## Testing
- `php -l includes/admin/class-sql-admin.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad5af9034832b9da3a1d1d8a61c70