### PR TITLE
Configure WP debug settings

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -1,0 +1,17 @@
+<?php
+// Debug configuration
+// Default to production environment unless WP_ENVIRONMENT_TYPE is set.
+if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+    define( 'WP_ENVIRONMENT_TYPE', getenv( 'WP_ENVIRONMENT_TYPE' ) ?: 'production' );
+}
+
+// Enable debugging only on test environment.
+if ( WP_ENVIRONMENT_TYPE === 'test' ) {
+    define( 'WP_DEBUG', true );
+} else {
+    define( 'WP_DEBUG', false );
+}
+
+// Never display debug messages on screen.
+define( 'WP_DEBUG_DISPLAY', false );
+


### PR DESCRIPTION
## Summary
- disable on-screen debugging by default
- activate debug mode only when `WP_ENVIRONMENT_TYPE` is `test`

## Testing
- `php -l wp-config.php`
- `phpunit tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad88fef30832b98bd5a1f1c405671