### PR TITLE
Fix draft status parsing and secure CSV exports

### DIFF
--- a/assets/js/frontend-dashboard.js
+++ b/assets/js/frontend-dashboard.js
@@ -273,14 +273,15 @@
                 'non_payee': 'pending',
                 'payee': 'pending',
                 'validee': 'active',
-                'rejected': 'expired'
+                'rejected': 'rejected'
             };
             statut = map[statut] || statut;
             var badges = {
                 'draft': '<span class="ufsc-badge -draft">draft</span>',
                 'pending': '<span class="ufsc-badge -pending">pending</span>',
                 'active': '<span class="ufsc-badge -ok">active</span>',
-                'expired': '<span class="ufsc-badge -expired">expired</span>'
+                'expired': '<span class="ufsc-badge -expired">expired</span>',
+                'rejected': '<span class="ufsc-badge -rejected">rejected</span>'
             };
             return badges[statut] || '<span class="ufsc-badge">' + statut + '</span>';
         },
@@ -291,7 +292,7 @@
             var statusMap = {
                 'brouillon': 'draft',
                 'non_payee': 'pending',
-                'rejected': 'expired'
+                'rejected': 'rejected'
             };
             var status = statusMap[licence.statut] || licence.statut;
             var editableStatuses = ['draft', 'pending', 'expired'];

--- a/includes/admin/class-ufsc-export-clubs.php
+++ b/includes/admin/class-ufsc-export-clubs.php
@@ -50,8 +50,11 @@ class UFSC_Export_Clubs {
             wp_die( 'Accès refusé' );
         }
         check_admin_referer( 'ufsc_export_clubs' );
+        set_time_limit( 0 );
 
-        $cols = isset( $_POST['columns'] ) ? array_map( 'sanitize_key', (array) $_POST['columns'] ) : array();
+        $allowed_cols   = self::get_columns();
+        $selected_cols  = isset( $_POST['columns'] ) ? array_map( 'sanitize_key', (array) $_POST['columns'] ) : array();
+        $cols           = array_values( array_intersect( $allowed_cols, $selected_cols ) );
         if ( empty( $cols ) ) {
             wp_die( __( 'Aucune colonne sélectionnée', 'ufsc-clubs' ) );
         }
@@ -84,6 +87,7 @@ class UFSC_Export_Clubs {
         header( 'Content-Type: text/csv; charset=utf-8' );
         header( 'Content-Disposition: attachment; filename="clubs.csv"' );
         $out = fopen( 'php://output', 'w' );
+        fputs( $out, "\xEF\xBB\xBF" );
         fputcsv( $out, $cols );
         if ( $rows ) {
             foreach ( $rows as $r ) {

--- a/includes/admin/class-ufsc-export-licences.php
+++ b/includes/admin/class-ufsc-export-licences.php
@@ -51,8 +51,11 @@ class UFSC_Export_Licences {
             wp_die( 'Accès refusé' );
         }
         check_admin_referer( 'ufsc_export_licences' );
+        set_time_limit( 0 );
 
-        $cols = isset( $_POST['columns'] ) ? array_map( 'sanitize_key', (array) $_POST['columns'] ) : array();
+        $allowed_cols   = self::get_columns();
+        $selected_cols  = isset( $_POST['columns'] ) ? array_map( 'sanitize_key', (array) $_POST['columns'] ) : array();
+        $cols           = array_values( array_intersect( $allowed_cols, $selected_cols ) );
         if ( empty( $cols ) ) {
             wp_die( __( 'Aucune colonne sélectionnée', 'ufsc-clubs' ) );
         }
@@ -89,6 +92,7 @@ class UFSC_Export_Licences {
         header( 'Content-Type: text/csv; charset=utf-8' );
         header( 'Content-Disposition: attachment; filename="licences.csv"' );
         $out = fopen( 'php://output', 'w' );
+        fputs( $out, "\xEF\xBB\xBF" );
         fputcsv( $out, $cols );
         if ( $rows ) {
             foreach ( $rows as $r ) {

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1662,7 +1662,7 @@ class UFSC_Frontend_Shortcodes {
             'paid'      => 'pending',
             'validated' => 'active',
             'applied'   => 'active',
-            'rejected'  => 'expired',
+            'rejected'  => 'rejected',
         );
 
         $status = strtolower( $status );
@@ -1671,18 +1671,11 @@ class UFSC_Frontend_Shortcodes {
         }
 
         $labels = array(
-
-            'draft'   => __( 'Brouillon', 'ufsc-clubs' ),
-            'pending' => __( 'En attente', 'ufsc-clubs' ),
-            'active'  => __( 'Active', 'ufsc-clubs' ),
-            'expired' => __( 'Expirée', 'ufsc-clubs' ),
-            'rejected' => __( 'Refusée', 'ufsc-clubs' )
-
-            'draft'   => __( 'draft', 'ufsc-clubs' ),
-            'pending' => __( 'pending', 'ufsc-clubs' ),
-            'active'  => __( 'active', 'ufsc-clubs' ),
-            'expired' => __( 'expired', 'ufsc-clubs' ),
-
+            'draft'    => __( 'Brouillon', 'ufsc-clubs' ),
+            'pending'  => __( 'En attente', 'ufsc-clubs' ),
+            'active'   => __( 'Active', 'ufsc-clubs' ),
+            'expired'  => __( 'Expirée', 'ufsc-clubs' ),
+            'rejected' => __( 'Refusée', 'ufsc-clubs' ),
         );
 
         return $labels[ $status ] ?? $status;
@@ -1698,7 +1691,7 @@ class UFSC_Frontend_Shortcodes {
             'paid'      => 'pending',
             'validated' => 'active',
             'applied'   => 'active',
-            'rejected'  => 'expired',
+            'rejected'  => 'rejected',
         );
 
         $status = strtolower( $status );
@@ -1707,15 +1700,11 @@ class UFSC_Frontend_Shortcodes {
         }
 
         $classes = array(
-            'draft'   => '-draft',
-            'pending' => '-pending',
-            'active'  => '-ok',
-
-            'expired' => '-warning',
-            'rejected'  => '-rejected',
-
-            'expired' => '-expired',
-
+            'draft'    => '-draft',
+            'pending'  => '-pending',
+            'active'   => '-ok',
+            'expired'  => '-expired',
+            'rejected' => '-rejected',
         );
 
         return $classes[ $status ] ?? '-draft';


### PR DESCRIPTION
## Summary
- fix `draft` status label map and badge class without syntax errors
- secure and sanitize Clubs & Licences CSV exports with column whitelist, UTF-8 BOM, and unlimited execution time
- align dashboard JavaScript with new `rejected` status handling

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l includes/admin/class-ufsc-export-clubs.php`
- `php -l includes/admin/class-ufsc-export-licences.php`
- `find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bb01e01fe0832b8d025c0e107d3e0d