### PR TITLE
Refactor club and licence exports to use shared CSV helper

### DIFF
--- a/includes/admin/class-ufsc-export-clubs.php
+++ b/includes/admin/class-ufsc-export-clubs.php
@@ -1,7 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-class UFSC_Export_Clubs {
+class UFSC_Export_Clubs extends UFSC_Export_Base {
     public static function init() {
         add_action( 'admin_post_ufsc_export_clubs', array( __CLASS__, 'handle_export' ) );
     }
@@ -84,17 +84,6 @@ class UFSC_Export_Clubs {
         $rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A );
 
         nocache_headers();
-        header( 'Content-Type: text/csv; charset=utf-8' );
-        header( 'Content-Disposition: attachment; filename="clubs.csv"' );
-        $out = fopen( 'php://output', 'w' );
-        fputs( $out, "\xEF\xBB\xBF" );
-        fputcsv( $out, $cols );
-        if ( $rows ) {
-            foreach ( $rows as $r ) {
-                fputcsv( $out, $r );
-            }
-        }
-        fclose( $out );
-        exit;
+        self::output_csv( 'clubs.csv', $cols, $rows );
     }
 }

--- a/includes/admin/class-ufsc-export-licences.php
+++ b/includes/admin/class-ufsc-export-licences.php
@@ -1,7 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-class UFSC_Export_Licences {
+class UFSC_Export_Licences extends UFSC_Export_Base {
     public static function init() {
         add_action( 'admin_post_ufsc_export_licences', array( __CLASS__, 'handle_export' ) );
     }
@@ -89,17 +89,6 @@ class UFSC_Export_Licences {
         $rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A );
 
         nocache_headers();
-        header( 'Content-Type: text/csv; charset=utf-8' );
-        header( 'Content-Disposition: attachment; filename="licences.csv"' );
-        $out = fopen( 'php://output', 'w' );
-        fputs( $out, "\xEF\xBB\xBF" );
-        fputcsv( $out, $cols );
-        if ( $rows ) {
-            foreach ( $rows as $r ) {
-                fputcsv( $out, $r );
-            }
-        }
-        fclose( $out );
-        exit;
+        self::output_csv( 'licences.csv', $cols, $rows );
     }
 }

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -18,6 +18,7 @@ require_once UFSC_CL_DIR.'includes/admin/class-admin-menu.php';
 require_once UFSC_CL_DIR.'includes/admin/class-ufsc-settings-page.php';
 require_once UFSC_CL_DIR.'includes/core/class-sql.php';
 require_once UFSC_CL_DIR.'includes/admin/class-sql-admin.php';
+require_once UFSC_CL_DIR.'includes/admin/class-ufsc-export-base.php';
 require_once UFSC_CL_DIR.'includes/admin/class-ufsc-export-clubs.php';
 require_once UFSC_CL_DIR.'includes/admin/class-ufsc-export-licences.php';
 require_once UFSC_CL_DIR.'includes/admin/class-ufsc-import-csv.php';


### PR DESCRIPTION
## Summary
- refactor UFSC_Export_Clubs to extend UFSC_Export_Base and use output_csv
- refactor UFSC_Export_Licences to extend UFSC_Export_Base and use output_csv
- load new UFSC_Export_Base in plugin bootstrap

## Testing
- `php -l includes/admin/class-ufsc-export-clubs.php`
- `php -l includes/admin/class-ufsc-export-licences.php`
- `php -l ufsc-clubs-licences-sql.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68bb0bfbf958832ba1f27a581602f4bb