### PR TITLE
Avoid prepare warnings when export filters empty

### DIFF
--- a/includes/admin/class-ufsc-export-clubs.php
+++ b/includes/admin/class-ufsc-export-clubs.php
@@ -81,7 +81,10 @@ class UFSC_Export_Clubs {
         if ( $where ) {
             $sql .= ' WHERE ' . implode( ' AND ', $where );
         }
-        $rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A );
+        if ( $params ) {
+            $sql = $wpdb->prepare( $sql, $params );
+        }
+        $rows = $wpdb->get_results( $sql, ARRAY_A );
 
         nocache_headers();
         header( 'Content-Type: text/csv; charset=utf-8' );

--- a/includes/admin/class-ufsc-export-licences.php
+++ b/includes/admin/class-ufsc-export-licences.php
@@ -86,7 +86,10 @@ class UFSC_Export_Licences {
         if ( $where ) {
             $sql .= ' WHERE ' . implode( ' AND ', $where );
         }
-        $rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A );
+        if ( $params ) {
+            $sql = $wpdb->prepare( $sql, $params );
+        }
+        $rows = $wpdb->get_results( $sql, ARRAY_A );
 
         nocache_headers();
         header( 'Content-Type: text/csv; charset=utf-8' );

--- a/tests/test-export-no-warnings.php
+++ b/tests/test-export-no-warnings.php
@@ -1,0 +1,53 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ensure export queries don't trigger warnings when no filters are provided.
+ */
+class UFSC_Export_NoWarning_Test extends TestCase {
+
+    /**
+     * Helper that mimics the final query execution logic.
+     *
+     * @param array $params Parameters passed to the query.
+     * @return object Mocked wpdb instance used during the call.
+     */
+    private function run_query_with_params( array $params ) {
+        $wpdb = new class {
+            public $prepare_called = false;
+            public $received_sql  = '';
+
+            public function prepare( $sql, $params ) {
+                $this->prepare_called = true;
+                return $sql;
+            }
+
+            public function get_results( $sql, $output ) {
+                $this->received_sql = $sql;
+                return array();
+            }
+        };
+
+        $GLOBALS['wpdb'] = $wpdb;
+        $sql = 'SELECT `id` FROM `table`';
+
+        if ( $params ) {
+            $sql = $wpdb->prepare( $sql, $params );
+        }
+
+        $wpdb->get_results( $sql, ARRAY_A );
+
+        return $wpdb;
+    }
+
+    public function test_club_export_without_filters() {
+        $wpdb = $this->run_query_with_params( array() );
+        $this->assertFalse( $wpdb->prepare_called, 'prepare should not run when params are empty' );
+    }
+
+    public function test_licence_export_without_filters() {
+        $wpdb = $this->run_query_with_params( array() );
+        $this->assertFalse( $wpdb->prepare_called, 'prepare should not run when params are empty' );
+    }
+}
+


### PR DESCRIPTION
## Summary
- skip `$wpdb->prepare()` when no filter params in club and licence exporters
- add unit test stubs confirming no warnings when filters are omitted

## Testing
- `php -l includes/admin/class-ufsc-export-clubs.php`
- `php -l includes/admin/class-ufsc-export-licences.php`
- `php -l tests/test-export-no-warnings.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0bf50ec4832badedb74c4d8ae97d