### PR TITLE
Load export admin template on demand

### DIFF
--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -21,7 +21,6 @@ require_once UFSC_CL_DIR.'includes/admin/class-sql-admin.php';
 require_once UFSC_CL_DIR.'includes/admin/class-ufsc-export-clubs.php';
 require_once UFSC_CL_DIR.'includes/admin/class-ufsc-export-licences.php';
 require_once UFSC_CL_DIR.'includes/admin/class-ufsc-import-csv.php';
-require_once UFSC_CL_DIR.'includes/admin/page-ufsc-exports.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-sql-shortcodes.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-club-form.php';
 require_once UFSC_CL_DIR.'includes/frontend/class-club-form-handler.php';


### PR DESCRIPTION
## Summary
- Avoid early output by removing bootstrap `page-ufsc-exports.php` include
- Export page template is now loaded only within `UFSC_SQL_Admin::render_exports()`

## Testing
- `php -l ufsc-clubs-licences-sql.php`
- `php -l includes/admin/class-sql-admin.php`
- `composer global require phpunit/phpunit --quiet` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0bf3efa4832b9687fd5a89469009