### PR TITLE
Add dashboard profile photo notices and placeholder support

### DIFF
--- a/includes/front/class-ufsc-media.php
+++ b/includes/front/class-ufsc-media.php
@@ -101,7 +101,8 @@ class UFSC_Media {
             wp_die( $result->get_error_message() );
         }
 
-        wp_safe_redirect( wp_get_referer() );
+        $redirect = ufsc_redirect_with_notice( wp_get_referer(), 'profile_photo_updated' );
+        wp_safe_redirect( $redirect );
         exit;
     }
 
@@ -121,7 +122,8 @@ class UFSC_Media {
         check_admin_referer( 'ufsc_remove_profile_photo', 'ufsc_remove_profile_photo_nonce' );
 
         self::remove_profile_photo( $club_id );
-        wp_safe_redirect( wp_get_referer() );
+        $redirect = ufsc_redirect_with_notice( wp_get_referer(), 'profile_photo_removed' );
+        wp_safe_redirect( $redirect );
         exit;
     }
 

--- a/templates/front/dashboard-club.php
+++ b/templates/front/dashboard-club.php
@@ -8,20 +8,22 @@ global $wpdb;
 $settings = UFSC_SQL::get_settings();
 $table    = $settings['table_clubs'];
 $club     = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE id = %d", $club_id ) );
+
+include UFSC_CL_DIR . 'templates/partials/notice.php';
 ?>
 
 <div class="ufsc-dashboard-header">
-    <?php if ( ! empty( $club->profile_photo_url ) ) : ?>
-        <div class="ufsc-club-photo">
-            <img src="<?php echo esc_url( $club->profile_photo_url ); ?>" alt="<?php esc_attr_e( 'Photo du club', 'ufsc-clubs' ); ?>" />
+    <div class="ufsc-club-photo">
+        <img src="<?php echo esc_url( ! empty( $club->profile_photo_url ) ? $club->profile_photo_url : 'https://via.placeholder.com/150?text=Club' ); ?>" alt="<?php esc_attr_e( 'Photo du club', 'ufsc-clubs' ); ?>" />
+        <?php if ( ! empty( $club->profile_photo_url ) ) : ?>
             <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-remove-photo-form">
                 <?php wp_nonce_field( 'ufsc_remove_profile_photo', 'ufsc_remove_profile_photo_nonce' ); ?>
                 <input type="hidden" name="action" value="ufsc_remove_profile_photo" />
                 <input type="hidden" name="club_id" value="<?php echo esc_attr( $club_id ); ?>" />
                 <button type="submit" class="button ufsc-remove-photo"><?php esc_html_e( 'Supprimer', 'ufsc-clubs' ); ?></button>
             </form>
-        </div>
-    <?php endif; ?>
+        <?php endif; ?>
+    </div>
     <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-upload-photo-form">
         <?php wp_nonce_field( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' ); ?>
         <input type="hidden" name="action" value="ufsc_upload_profile_photo" />


### PR DESCRIPTION
## Summary
- Add query-arg redirects to show dashboard notices after profile photo upload or removal
- Show placeholder image on club dashboard when no profile photo is set and include notice partial

## Testing
- `apt-get update` *(fails: repository InRelease is not signed)*
- `phpunit tests/test-core.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1d431960832b8f23403005295876