### PR TITLE
Validate club status against canonical list

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -264,11 +264,11 @@ class UFSC_SQL_Admin {
                 echo '<option value="'.esc_attr($r).'" '.selected($val,$r,false).'>'.esc_html($r).'</option>';
             }
             echo '</select>';
-        } elseif ( $type === 'licence_status' ){
+        } elseif ( in_array( $type, array( 'licence_status', 'club_status' ), true ) ) {
             $st = UFSC_SQL::statuses();
-            echo '<select name="'.esc_attr($k).'" '.$disabled_attr.'>';
-            foreach( $st as $sv=>$sl ){
-                echo '<option value="'.esc_attr($sv).'" '.selected($val,$sv,false).'>'.esc_html($sl).'</option>';
+            echo '<select name="' . esc_attr( $k ) . '" ' . $disabled_attr . '>';
+            foreach ( $st as $sv => $sl ) {
+                echo '<option value="' . esc_attr( $sv ) . '" ' . selected( $val, $sv, false ) . '>' . esc_html( $sl ) . '</option>';
             }
             echo '</select>';
         } else {
@@ -396,10 +396,12 @@ class UFSC_SQL_Admin {
         $fields = UFSC_SQL::get_club_fields();
 
         $data = array();
-        foreach( $fields as $k=>$conf ){
-            $data[$k] = isset($_POST[$k]) ? sanitize_text_field($_POST[$k]) : null;
+        foreach ( $fields as $k => $conf ) {
+            $data[ $k ] = isset( $_POST[ $k ] ) ? sanitize_text_field( $_POST[ $k ] ) : null;
         }
-        if ( empty($data['statut']) ){
+
+        $allowed_statuses = array_keys( UFSC_SQL::statuses() );
+        if ( ! in_array( $data['statut'], $allowed_statuses, true ) ) {
             $data['statut'] = 'en_attente';
         }
 

--- a/includes/core/class-sql.php
+++ b/includes/core/class-sql.php
@@ -8,12 +8,13 @@ class UFSC_SQL {
             'table_licences'  => 'licences',
             'pk_club'         => 'id',
             'pk_licence'      => 'id',
-            // Supported licence statuses
+            // Supported statuses
             'status_values'   => array(
-                'draft'   => 'Draft',
-                'pending' => 'Pending',
-                'active'  => 'Active',
-                'expired' => 'Expired',
+                'valide'      => 'Validé',
+                'en_attente'  => 'En attente',
+                'rejete'      => 'Rejeté',
+                'paye'        => 'Payé',
+                'refuse'      => 'Refusé',
             ),
             'club_fields' => array(
                 'nom'=>array('Nom du club','text'),
@@ -57,7 +58,7 @@ class UFSC_SQL {
                 'num_affiliation'=>array('N° Affiliation','text'),
                 'quota_licences'=>array('Quota licences','number'),
                 // Status selector for clubs
-                'statut'=>array('Status','licence_status'),
+                'statut'=>array('Status','club_status'),
                 'date_creation'=>array('Date création','date'),
                 'responsable_id'=>array('User ID responsable','number'),
                 'precision_distribution'=>array('Précision distribution','text'),


### PR DESCRIPTION
## Summary
- use canonical status whitelist when saving clubs
- expose the status list through default settings and reuse it in admin forms

## Testing
- `php -l includes/admin/class-sql-admin.php`
- `php -l includes/core/class-sql.php`
- `php tests/test-club-save.php` *(fails: undefined function check_admin_referer)*
- `php tests/test-export-csv.php` *(fails: class "PHPUnit\Framework\TestCase" not found)*
- `php tests/test-export-no-warnings.php` *(fails: class "PHPUnit\Framework\TestCase" not found)*
- `php tests/test-frontend.php` *(fails: class "PHPUnit\Framework\TestCase" not found)*
- `php tests/test-affiliation-redirect.php` *(fails: class "PHPUnit\Framework\TestCase" not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bb1d41918c832b8866086f0e3499e0