### PR TITLE
Use en_attente as default licence status and sync WooCommerce

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -399,7 +399,9 @@ class UFSC_SQL_Admin {
         foreach( $fields as $k=>$conf ){
             $data[$k] = isset($_POST[$k]) ? sanitize_text_field($_POST[$k]) : null;
         }
-        if ( empty($data['statut']) ){
+
+        $valid_statuses = array_keys( UFSC_SQL::statuses() );
+        if ( empty( $data['statut'] ) || ! in_array( $data['statut'], $valid_statuses, true ) ){
             $data['statut'] = 'en_attente';
         }
 
@@ -1234,8 +1236,10 @@ class UFSC_SQL_Admin {
                 $data[$k] = isset($_POST[$k]) ? sanitize_text_field($_POST[$k]) : null;
             }
         }
-        if ( empty($data['statut']) ){
-            $data['statut'] = 'draft';
+
+        $valid_statuses = array_keys( UFSC_SQL::statuses() );
+        if ( empty( $data['statut'] ) || ! in_array( $data['statut'], $valid_statuses, true ) ){
+            $data['statut'] = 'en_attente';
         }
 
         // Validate included quota if checkbox is set

--- a/includes/core/class-sql.php
+++ b/includes/core/class-sql.php
@@ -10,10 +10,10 @@ class UFSC_SQL {
             'pk_licence'      => 'id',
             // Supported licence statuses
             'status_values'   => array(
-                'draft'   => 'Draft',
-                'pending' => 'Pending',
-                'active'  => 'Active',
-                'expired' => 'Expired',
+                'en_attente' => 'En attente',
+                'a_regler'   => 'À régler',
+                'valide'     => 'Validé',
+                'desactive'  => 'Désactivé',
             ),
             'club_fields' => array(
                 'nom'=>array('Nom du club','text'),
@@ -163,7 +163,7 @@ class UFSC_SQL {
         $settings       = self::get_settings();
         $licences_table = $settings['table_licences'];
 
-        $statuses      = array( 'draft', 'pending', 'active' );
+        $statuses      = array( 'en_attente', 'a_regler', 'valide' );
         $placeholders  = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
         $query_args    = array_merge( array( $club_id ), $statuses );
         $query         = $wpdb->prepare(

--- a/includes/woo/class-ufsc-woo-sync.php
+++ b/includes/woo/class-ufsc-woo-sync.php
@@ -161,8 +161,13 @@ class UFSC_Woo_Sync {
 
         global $wpdb;
         $licences_table = ufsc_get_licences_table();
+        $status_col     = function_exists( 'ufsc_lic_col' ) ? ufsc_lic_col( 'statut' ) : 'statut';
+        $paid_col       = function_exists( 'ufsc_lic_col' ) ? ufsc_lic_col( 'paid' ) : 'paid';
 
-        $licence = $wpdb->get_row( $wpdb->prepare( "SELECT club_id, is_included, status FROM {$licences_table} WHERE id = %d", $licence_id ), ARRAY_A );
+        $licence = $wpdb->get_row(
+            $wpdb->prepare( "SELECT club_id, is_included, {$status_col} AS statut FROM {$licences_table} WHERE id = %d", $licence_id ),
+            ARRAY_A
+        );
         if ( ! $licence ) {
             return;
         }
@@ -170,8 +175,8 @@ class UFSC_Woo_Sync {
         $wpdb->update(
             $licences_table,
             array(
-                'status' => 'active',
-                'paid'   => 1,
+                $status_col => 'valide',
+                $paid_col   => 1,
             ),
             array( 'id' => $licence_id ),
             array( '%s', '%d' ),
@@ -180,7 +185,7 @@ class UFSC_Woo_Sync {
 
         $club_id     = (int) $licence['club_id'];
         $is_included = ! empty( $licence['is_included'] );
-        $was_active  = ( 'active' === $licence['status'] );
+        $was_active  = ( 'valide' === $licence['statut'] );
 
         if ( $club_id && $is_included && ! $was_active ) {
             $clubs_table = ufsc_get_clubs_table();
@@ -200,15 +205,20 @@ class UFSC_Woo_Sync {
 
         global $wpdb;
         $licences_table = ufsc_get_licences_table();
+        $status_col     = function_exists( 'ufsc_lic_col' ) ? ufsc_lic_col( 'statut' ) : 'statut';
+        $paid_col       = function_exists( 'ufsc_lic_col' ) ? ufsc_lic_col( 'paid' ) : 'paid';
 
-        $licence = $wpdb->get_row( $wpdb->prepare( "SELECT club_id, is_included, status FROM {$licences_table} WHERE id = %d", $licence_id ), ARRAY_A );
+        $licence = $wpdb->get_row(
+            $wpdb->prepare( "SELECT club_id, is_included, {$status_col} AS statut FROM {$licences_table} WHERE id = %d", $licence_id ),
+            ARRAY_A
+        );
         if ( ! $licence ) {
             return;
         }
 
         $wpdb->update(
             $licences_table,
-            array( 'status' => 'pending', 'paid' => 0 ),
+            array( $status_col => 'en_attente', $paid_col => 0 ),
             array( 'id' => $licence_id ),
             array( '%s', '%d' ),
             array( '%d' )
@@ -216,7 +226,7 @@ class UFSC_Woo_Sync {
 
         $club_id     = (int) $licence['club_id'];
         $is_included = ! empty( $licence['is_included'] );
-        $was_active  = ( 'active' === $licence['status'] );
+        $was_active  = ( 'valide' === $licence['statut'] );
 
         if ( $club_id && $is_included && $was_active ) {
             $clubs_table = ufsc_get_clubs_table();


### PR DESCRIPTION
## Summary
- default status now `en_attente` and validated against allowed values
- WooCommerce sync uses mapped licence columns and sets `valide` after payment
- core SQL settings include French status enums

## Testing
- `php -l includes/admin/class-sql-admin.php`
- `php -l includes/core/class-sql.php`
- `php -l includes/woo/class-ufsc-woo-sync.php`
- `phpunit --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1d406ae8832b832984991ea29a2a