### PR TITLE
Simplify statut validation

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -402,10 +402,7 @@ class UFSC_SQL_Admin {
 
 
         $allowed_statuses = array_keys( UFSC_SQL::statuses() );
-        if ( ! in_array( $data['statut'], $allowed_statuses, true ) ) {
-
-        $valid_statuses = array_keys( UFSC_SQL::statuses() );
-        if ( empty( $data['statut'] ) || ! in_array( $data['statut'], $valid_statuses, true ) ){
+        if ( empty( $data['statut'] ) || ! in_array( $data['statut'], $allowed_statuses, true ) ) {
 
             $data['statut'] = 'en_attente';
         }


### PR DESCRIPTION
## Summary
- Combine redundant statut validation logic in handle_save_club and default to `en_attente`

## Testing
- `php -l includes/admin/class-sql-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb3cd76ef8832b9a0ac55c9270b955