### PR TITLE
Refactor export handlers to use shared CSV output

### DIFF
--- a/includes/admin/class-ufsc-export-clubs.php
+++ b/includes/admin/class-ufsc-export-clubs.php
@@ -92,19 +92,16 @@ class UFSC_Export_Clubs extends UFSC_Export_Base {
         }
         $rows = $wpdb->get_results( $sql, ARRAY_A );
 
-        nocache_headers();
-
-        header( 'Content-Type: text/csv; charset=utf-8' );
-        header( 'Content-Disposition: attachment; filename="clubs.csv"' );
-        $out = fopen( 'php://output', 'w' );
-        fputs( $out, "\xEF\xBB\xBF" );
-        fputcsv( $out, $headers );
+        $csv_rows = array();
         if ( $rows ) {
             foreach ( $rows as $r ) {
-                fputcsv( $out, array_map( fn( $c ) => $r[ $c ] ?? '', $cols ) );
+                $csv_rows[] = array_map( fn( $c ) => $r[ $c ] ?? '', $cols );
             }
         }
-        fclose( $out );
+
+        nocache_headers();
+        $filename = 'clubs-' . current_time( 'Ymd' ) . '.csv';
+        self::output_csv( $filename, $headers, $csv_rows );
         exit;
 
     }

--- a/includes/admin/class-ufsc-export-licences.php
+++ b/includes/admin/class-ufsc-export-licences.php
@@ -95,19 +95,16 @@ class UFSC_Export_Licences extends UFSC_Export_Base {
         }
         $rows = $wpdb->get_results( $sql, ARRAY_A );
 
-        nocache_headers();
-
-        header( 'Content-Type: text/csv; charset=utf-8' );
-        header( 'Content-Disposition: attachment; filename="licences.csv"' );
-        $out = fopen( 'php://output', 'w' );
-        fputs( $out, "\xEF\xBB\xBF" );
-        fputcsv( $out, $headers );
+        $csv_rows = array();
         if ( $rows ) {
             foreach ( $rows as $r ) {
-                fputcsv( $out, array_map( fn( $c ) => $r[ $c ] ?? '', $cols ) );
+                $csv_rows[] = array_map( fn( $c ) => $r[ $c ] ?? '', $cols );
             }
         }
-        fclose( $out );
+
+        nocache_headers();
+        $filename = 'licences-' . current_time( 'Ymd' ) . '.csv';
+        self::output_csv( $filename, $headers, $csv_rows );
         exit;
 
     }


### PR DESCRIPTION
## Summary
- switch club and licence exports to shared `output_csv` helper
- generate dated filenames like `clubs-YYYYMMDD.csv` and `licences-YYYYMMDD.csv`
- ensure no-cache headers and exit after CSV output

## Testing
- `php -l includes/admin/class-ufsc-export-clubs.php`
- `php -l includes/admin/class-ufsc-export-licences.php`
- `php tests/test-export-csv.php` *(fails: Class "PHPUnit\Framework\TestCase" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a77cdb4832ba6752a8450e3a1d0