### PR TITLE
Use select input for club status and validate on save

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -397,15 +397,19 @@ class UFSC_SQL_Admin {
 
         $data = array();
         foreach ( $fields as $k => $conf ) {
+            if ( 'statut' === $k ) {
+                continue;
+            }
             $data[ $k ] = isset( $_POST[ $k ] ) ? sanitize_text_field( $_POST[ $k ] ) : null;
         }
 
-
+        $status_column    = function_exists( 'ufsc_club_col' ) ? ufsc_club_col( 'statut' ) : 'statut';
         $allowed_statuses = array_keys( UFSC_SQL::statuses() );
-        if ( empty( $data['statut'] ) || ! in_array( $data['statut'], $allowed_statuses, true ) ) {
-
-            $data['statut'] = 'en_attente';
+        $submitted_status = isset( $_POST['statut'] ) ? sanitize_text_field( $_POST['statut'] ) : '';
+        if ( ! in_array( $submitted_status, $allowed_statuses, true ) ) {
+            $submitted_status = 'en_attente';
         }
+        $data[ $status_column ] = $submitted_status;
 
         // Handle file uploads before validation
         $upload_errors = array();

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -759,7 +759,7 @@ class UFSC_Frontend_Shortcodes {
                         <?php self::render_field( 'nom', $club, __( 'Nom du club', 'ufsc-clubs' ), 'text', true, $is_admin ); ?>
                         <?php self::render_field( 'region', $club, __( 'Région', 'ufsc-clubs' ), 'text', true, $is_admin ); ?>
                         <?php self::render_field( 'num_affiliation', $club, __( 'N° d\'affiliation', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
-                        <?php self::render_field( 'statut', $club, __( 'Statut', 'ufsc-clubs' ), 'text', true, false ); ?>
+                        <?php self::render_field( 'statut', $club, __( 'Statut', 'ufsc-clubs' ), 'select', false, $is_admin, UFSC_SQL::statuses() ); ?>
                     </div>
                 </div>
 
@@ -2220,20 +2220,31 @@ class UFSC_Frontend_Shortcodes {
      * @param string $type Input type
      * @param bool $readonly Force readonly
      * @param bool $editable Whether field is editable for current user
+     * @param array $options Options for select fields
      */
-    private static function render_field( $field_key, $club, $label, $type = 'text', $readonly = false, $editable = false ) {
+    private static function render_field( $field_key, $club, $label, $type = 'text', $readonly = false, $editable = false, $options = array() ) {
         $value = isset( $club->{$field_key} ) ? $club->{$field_key} : '';
         $field_readonly = $readonly || ! $editable;
-        
+
         echo '<div class="ufsc-field">';
         echo '<label for="' . esc_attr( $field_key ) . '">' . esc_html( $label ) . '</label>';
-        
+
         if ( $type === 'textarea' ) {
             echo '<textarea id="' . esc_attr( $field_key ) . '" name="' . esc_attr( $field_key ) . '"';
             if ( $field_readonly ) {
                 echo ' readonly';
             }
             echo '>' . esc_textarea( $value ) . '</textarea>';
+        } elseif ( $type === 'select' ) {
+            echo '<select id="' . esc_attr( $field_key ) . '" name="' . esc_attr( $field_key ) . '"';
+            if ( $field_readonly ) {
+                echo ' disabled';
+            }
+            echo '>';
+            foreach ( $options as $option_value => $option_label ) {
+                echo '<option value="' . esc_attr( $option_value ) . '"' . selected( $value, $option_value, false ) . '>' . esc_html( $option_label ) . '</option>';
+            }
+            echo '</select>';
         } else {
             echo '<input type="' . esc_attr( $type ) . '" id="' . esc_attr( $field_key ) . '" name="' . esc_attr( $field_key ) . '"';
             echo ' value="' . esc_attr( $value ) . '"';
@@ -2242,7 +2253,7 @@ class UFSC_Frontend_Shortcodes {
             }
             echo '>';
         }
-        
+
         echo '<span class="ufsc-field-error" aria-live="polite"></span></div>';
     }
 }


### PR DESCRIPTION
## Summary
- Use a select field for club status populated from configured statuses
- Validate and map submitted status to the proper column when saving clubs

## Testing
- `php tests/test-frontend.php` *(fails: Class "PHPUnit\Framework\TestCase" not found)*
- `php tests/test-club-save.php` *(fails: Call to undefined function check_admin_referer())*


------
https://chatgpt.com/codex/tasks/task_e_68bc5a74ea34832b9de7d39f811e8c22