### PR TITLE
Expose paid and validated licence stats

### DIFF
--- a/includes/front/class-ufsc-stats.php
+++ b/includes/front/class-ufsc-stats.php
@@ -272,10 +272,13 @@ class UFSC_Stats {
         $quota_remaining = max( 0, 10 - $included_active );
 
         return array(
-            'total_licences'  => $total_licences,
-            'paid'            => $paid,
-            'validated'       => $validated,
-            'quota_remaining' => $quota_remaining,
+            'total_licences'     => $total_licences,
+            'paid_licences'      => $paid,
+            'validated_licences' => $validated,
+            // Legacy keys preserved for backward compatibility.
+            'paid'               => $paid,
+            'validated'          => $validated,
+            'quota_remaining'    => $quota_remaining,
             'by_status'          => $status_counts,
             'by_paid'            => $paid_counts,
             'by_gender'          => $gender_counts,

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1577,6 +1577,13 @@ class UFSC_Frontend_Shortcodes {
             set_transient( $cache_key, $stats, HOUR_IN_SECONDS );
         }
 
+        if ( isset( $stats['paid'] ) && ! isset( $stats['paid_licences'] ) ) {
+            $stats['paid_licences'] = $stats['paid'];
+        }
+        if ( isset( $stats['validated'] ) && ! isset( $stats['validated_licences'] ) ) {
+            $stats['validated_licences'] = $stats['validated'];
+        }
+
         return $stats;
     }
 

--- a/tests/test-ufsc-stats.php
+++ b/tests/test-ufsc-stats.php
@@ -1,0 +1,37 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/front/class-ufsc-stats.php';
+
+class UFSC_StatsKeysTest extends TestCase {
+    protected function setUp(): void {
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = 'wp_';
+            public function prepare($query, ...$args) {
+                $query = str_replace(array('%d','%s'), '%s', $query);
+                return vsprintf($query, $args);
+            }
+            public function get_results($query) {
+                return array();
+            }
+            public function get_var($query) {
+                return 0;
+            }
+        };
+    }
+
+    public function test_stats_keys_default_zero() {
+        $stats = UFSC_Stats::get_club_stats(1);
+
+        $this->assertArrayHasKey('paid_licences', $stats);
+        $this->assertArrayHasKey('validated_licences', $stats);
+        $this->assertArrayHasKey('paid', $stats);
+        $this->assertArrayHasKey('validated', $stats);
+
+        $this->assertSame(0, $stats['paid_licences']);
+        $this->assertSame(0, $stats['validated_licences']);
+        $this->assertSame(0, $stats['paid']);
+        $this->assertSame(0, $stats['validated']);
+    }
+}


### PR DESCRIPTION
## Summary
- extend UFSC_Stats::get_club_stats to return paid_licences and validated_licences with legacy keys
- normalize frontend shortcodes to rely on new licence stats
- add tests verifying stats include paid_licences and validated_licences

## Testing
- `php -l includes/front/class-ufsc-stats.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l tests/test-ufsc-stats.php`
- `vendor/bin/phpunit tests/test-ufsc-stats.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a741a28832ba75371c3f394ef40