### PR TITLE
Refactor shortcode asset loading

### DIFF
--- a/includes/frontend/class-auth-shortcodes.php
+++ b/includes/frontend/class-auth-shortcodes.php
@@ -16,6 +16,36 @@ class UFSC_Auth_Shortcodes {
         add_shortcode( 'ufsc_user_status', array( __CLASS__, 'render_user_status' ) );
 
         add_action( 'wp_login_failed', array( __CLASS__, 'handle_login_failed' ) );
+
+        add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+        add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+    }
+
+    /**
+     * Enqueue assets for authentication shortcodes conditionally
+     */
+    public static function enqueue_assets() {
+        $post = get_post();
+        if ( ! $post ) {
+            return;
+        }
+
+        $content = $post->post_content;
+        $has_login  = has_shortcode( $content, 'ufsc_login_form' );
+        $has_status = has_shortcode( $content, 'ufsc_user_status' );
+
+        if ( $has_login || $has_status ) {
+            wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
+        }
+
+        if ( $has_login ) {
+            wp_enqueue_style(
+                'ufsc-login-form',
+                UFSC_CL_URL . 'assets/css/ufsc-login-form.css',
+                array( 'ufsc-front' ),
+                UFSC_CL_VERSION
+            );
+        }
     }
 
     /**
@@ -25,14 +55,6 @@ class UFSC_Auth_Shortcodes {
      * @return string HTML output
      */
     public static function render_login_form( $atts = array() ) {
-        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
-        wp_enqueue_style(
-            'ufsc-login-form',
-            UFSC_CL_URL . 'assets/css/ufsc-login-form.css',
-            array( 'ufsc-front' ),
-            UFSC_CL_VERSION
-        );
-
         $atts = shortcode_atts( array(
             'redirect_admin' => admin_url( 'admin.php?page=ufsc-gestion' ),
             'redirect_club' => home_url( '/club-dashboard/' ),
@@ -187,8 +209,6 @@ class UFSC_Auth_Shortcodes {
      * @return string HTML output
      */
     public static function render_user_status( $atts = array() ) {
-        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
-
         $atts = shortcode_atts( array(
             'show_avatar' => 'true',
             'show_role' => 'true',

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -17,6 +17,50 @@ class UFSC_Frontend_Shortcodes {
         add_shortcode( 'ufsc_club_profile', array( __CLASS__, 'render_club_profile' ) );
         add_shortcode( 'ufsc_add_licence', array( __CLASS__, 'render_add_licence' ) );
         add_shortcode( 'ufsc_licences', array( __CLASS__, 'render_licences' ) );
+
+        add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+        add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+    }
+
+    /**
+     * Enqueue assets for frontend shortcodes conditionally
+     */
+    public static function enqueue_assets() {
+        $post = get_post();
+        if ( ! $post ) {
+            return;
+        }
+
+        $content = $post->post_content;
+        $shortcodes = array(
+            'ufsc_club_dashboard',
+            'ufsc_club_licences',
+            'ufsc_club_stats',
+            'ufsc_club_profile',
+            'ufsc_add_licence',
+            'ufsc_licences',
+        );
+
+        foreach ( $shortcodes as $shortcode ) {
+            if ( has_shortcode( $content, $shortcode ) ) {
+                wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
+                break;
+            }
+        }
+
+        if ( has_shortcode( $content, 'ufsc_club_dashboard' ) ) {
+            wp_enqueue_script(
+                'chart-js',
+                'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js',
+                array(),
+                '4.4.0',
+                true
+            );
+        }
+
+        if ( has_shortcode( $content, 'ufsc_licences' ) ) {
+            wp_enqueue_script( 'ufsc-licences', UFSC_CL_URL . 'assets/js/ufsc-licences.js', array( 'jquery' ), UFSC_CL_VERSION, true );
+        }
     }
 
     /**
@@ -26,14 +70,6 @@ class UFSC_Frontend_Shortcodes {
      * @return string HTML output
      */
     public static function render_club_dashboard( $atts = array() ) {
-        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
-        wp_enqueue_script(
-            'chart-js',
-            'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js',
-            array(),
-            '4.4.0',
-            true
-        );
         $atts = shortcode_atts( array(
             'show_sections' => 'licences,stats,profile,add_licence'
         ), $atts );
@@ -195,7 +231,6 @@ class UFSC_Frontend_Shortcodes {
      * @return string HTML output
      */
     public static function render_club_licences( $atts = array() ) {
-        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
         $atts = shortcode_atts( array(
             'club_id' => 0,
             'per_page' => 20,
@@ -456,8 +491,6 @@ class UFSC_Frontend_Shortcodes {
      * @return string
      */
     public static function render_single_licence( $licence_id ) {
-        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
-
         $club_id = self::get_user_club_id( get_current_user_id() );
         if ( ! $club_id ) {
             return '<div class="ufsc-message ufsc-error">' .
@@ -653,7 +686,6 @@ class UFSC_Frontend_Shortcodes {
      * @return string HTML output
      */
     public static function render_club_profile( $atts = array() ) {
-        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
         $atts = shortcode_atts( array(
             'club_id' => 0
         ), $atts );
@@ -1303,8 +1335,6 @@ class UFSC_Frontend_Shortcodes {
 
         $action     = isset( $_GET['ufsc_action'] ) ? sanitize_key( $_GET['ufsc_action'] ) : '';
         $licence_id = isset( $_GET['licence_id'] ) ? intval( $_GET['licence_id'] ) : 0;
-
-        wp_enqueue_script( 'ufsc-licences', UFSC_CL_URL . 'assets/js/ufsc-licences.js', array( 'jquery' ), UFSC_CL_VERSION, true );
 
         ob_start();
         if ( in_array( $action, array( 'edit', 'new' ), true ) ) {


### PR DESCRIPTION
## Summary
- add `enqueue_assets` to load frontend shortcode scripts/styles only when needed
- add `enqueue_assets` to auth shortcodes for conditional login/user-status assets

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l includes/frontend/class-auth-shortcodes.php`
- `phpunit tests/test-core.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a710a9c832b95d2e0e6841f0692