### PR TITLE
Register frontend assets on init

### DIFF
--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -70,6 +70,10 @@ class UFSC_CL_Admin_Menu {
             }
         }
     }
+    /**
+     * Register frontend assets so they can be enqueued later.
+     * This runs on the `init` hook.
+     */
     public static function register_front(){
         wp_register_style( 'ufsc-frontend', UFSC_CL_URL.'assets/frontend/css/frontend.css', array(), UFSC_CL_VERSION );
         wp_register_script( 'ufsc-frontend', UFSC_CL_URL.'assets/frontend/js/frontend.js', array('jquery'), UFSC_CL_VERSION, true );
@@ -569,3 +573,6 @@ class UFSC_CL_Admin_Menu {
         return ob_get_clean();
     }
 }
+
+// Register frontend assets on init so they can be enqueued later.
+add_action( 'init', array( 'UFSC_CL_Admin_Menu', 'register_front' ) );

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -96,7 +96,6 @@ final class UFSC_CL_Bootstrap {
 
         add_action( 'admin_menu', array( 'UFSC_CL_Admin_Menu', 'register' ) );
         add_action( 'admin_enqueue_scripts', array( 'UFSC_CL_Admin_Menu', 'enqueue_admin' ) );
-        add_action( 'wp_enqueue_scripts', array( 'UFSC_CL_Admin_Menu', 'register_front' ) );
 
         // SQL Admin CRUD actions (pages cachées mais enregistrées pour les actions directes)
         add_action( 'admin_menu', array( 'UFSC_SQL_Admin', 'register_hidden_pages' ) );
@@ -176,8 +175,8 @@ final class UFSC_CL_Bootstrap {
         }
 
         if ( $should_enqueue ) {
-            wp_enqueue_style('ufsc-frontend', UFSC_CL_URL . 'assets/frontend/css/frontend.css', array(), UFSC_CL_VERSION );
-            wp_enqueue_script('ufsc-frontend', UFSC_CL_URL . 'assets/frontend/js/frontend.js', array('jquery'), UFSC_CL_VERSION, true );
+            wp_enqueue_style( 'ufsc-frontend' );
+            wp_enqueue_script( 'ufsc-frontend' );
         }
     }
 


### PR DESCRIPTION
## Summary
- Register frontend assets early on `init` and defer actual enqueues to their hooks
- Use registered handles when enqueueing frontend scripts and styles

## Testing
- `php -l includes/admin/class-admin-menu.php`
- `php -l ufsc-clubs-licences-sql.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc66b31cc0832b8c673ec3ad58f77b