### PR TITLE
Wrap translation strings in exports page

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -1900,6 +1900,7 @@ class UFSC_SQL_Admin {
      * Render Exports page
      */
     public static function render_exports() {
-        include UFSC_CL_DIR . 'includes/admin/page-ufsc-exports.php';
+        require_once UFSC_CL_DIR . 'includes/admin/page-ufsc-exports.php';
+        ufsc_render_exports_page();
     }
 } /* end class */

--- a/includes/admin/page-ufsc-exports.php
+++ b/includes/admin/page-ufsc-exports.php
@@ -1,15 +1,28 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) { exit; }
-?>
-<div class="wrap">
-    <h1><?php echo esc_html__( 'Exports', 'ufsc-clubs' ); ?></h1>
-    <div class="ufsc-export-section">
-        <h2><?php echo esc_html__( 'Export Clubs', 'ufsc-clubs' ); ?></h2>
-        <?php UFSC_Export_Clubs::render_form(); ?>
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Render the exports admin page.
+ *
+ * Wrapping the markup in a function ensures translation functions are executed
+ * only after the plugin has initialized.
+ */
+function ufsc_render_exports_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php echo esc_html__( 'Exports', 'ufsc-clubs' ); ?></h1>
+        <div class="ufsc-export-section">
+            <h2><?php echo esc_html__( 'Export Clubs', 'ufsc-clubs' ); ?></h2>
+            <?php UFSC_Export_Clubs::render_form(); ?>
+        </div>
+        <hr/>
+        <div class="ufsc-export-section">
+            <h2><?php echo esc_html__( 'Export Licences', 'ufsc-clubs' ); ?></h2>
+            <?php UFSC_Export_Licences::render_form(); ?>
+        </div>
     </div>
-    <hr/>
-    <div class="ufsc-export-section">
-        <h2><?php echo esc_html__( 'Export Licences', 'ufsc-clubs' ); ?></h2>
-        <?php UFSC_Export_Licences::render_form(); ?>
-    </div>
-</div>
+    <?php
+}
+


### PR DESCRIPTION
## Summary
- wrap exports admin page strings in a function to execute translations after init
- call wrapped function from SQL admin class

## Testing
- `php -l includes/admin/page-ufsc-exports.php`
- `php -l includes/admin/class-sql-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc66b47f08832b9dfada6454e81e74