### PR TITLE
Guard club stats arrays and default license counts

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -600,8 +600,8 @@ class UFSC_Frontend_Shortcodes {
         }
 
         if ( empty( $atts['season'] ) ) {
-            $wc_settings = ufsc_get_woocommerce_settings();
-            $atts['season'] = $wc_settings['season'];
+            $wc_settings   = ufsc_get_woocommerce_settings();
+            $atts['season'] = isset( $wc_settings['season'] ) ? $wc_settings['season'] : '';
         }
 
         $stats = wp_parse_args(
@@ -613,6 +613,9 @@ class UFSC_Frontend_Shortcodes {
                 'quota_remaining'    => 0,
             )
         );
+
+        $stats['paid_licences']      = isset( $stats['paid_licences'] ) ? (int) $stats['paid_licences'] : 0;
+        $stats['validated_licences'] = isset( $stats['validated_licences'] ) ? (int) $stats['validated_licences'] : 0;
 
         $evolution = array();
         if ( class_exists( 'UFSC_Stats' ) ) {
@@ -627,7 +630,7 @@ class UFSC_Frontend_Shortcodes {
             'female' => esc_html__( 'Femmes', 'ufsc-clubs' ),
             'other'  => esc_html__( 'Autre', 'ufsc-clubs' ),
         );
-        if ( ! empty( $stats['by_gender'] ) ) {
+        if ( isset( $stats['by_gender'] ) && ! empty( $stats['by_gender'] ) ) {
             foreach ( $stats['by_gender'] as $gender => $count ) {
                 $gender_labels[] = isset( $gender_map[ $gender ] ) ? $gender_map[ $gender ] : ucfirst( $gender );
                 $gender_data[]   = (int) $count;
@@ -641,7 +644,7 @@ class UFSC_Frontend_Shortcodes {
             'loisir'      => esc_html__( 'Loisir', 'ufsc-clubs' ),
             'competition' => esc_html__( 'Compétition', 'ufsc-clubs' ),
         );
-        if ( ! empty( $stats['by_practice'] ) ) {
+        if ( isset( $stats['by_practice'] ) && ! empty( $stats['by_practice'] ) ) {
             foreach ( $stats['by_practice'] as $practice => $count ) {
                 $practice_labels[] = isset( $practice_map[ $practice ] ) ? $practice_map[ $practice ] : ucfirst( $practice );
                 $practice_data[]   = (int) $count;
@@ -657,10 +660,10 @@ class UFSC_Frontend_Shortcodes {
             '35-49' => 0,
             '50+'   => 0,
         );
-        if ( ! empty( $stats['by_birth_year'] ) ) {
+        if ( isset( $stats['by_birth_year'] ) && ! empty( $stats['by_birth_year'] ) ) {
             $current_year = (int) gmdate( 'Y' );
             foreach ( $stats['by_birth_year'] as $year => $count ) {
-                $age = $current_year - (int) $year;
+                $age   = $current_year - (int) $year;
                 $count = (int) $count;
                 if ( $age >= 5 && $age <= 11 ) {
                     $age_groups['5-11'] += $count;
@@ -683,8 +686,8 @@ class UFSC_Frontend_Shortcodes {
         $evolution_data   = array();
         if ( ! empty( $evolution ) ) {
             foreach ( $evolution as $row ) {
-                $evolution_labels[] = $row['week_start'];
-                $evolution_data[]   = (int) $row['total'];
+                $evolution_labels[] = isset( $row['week_start'] ) ? $row['week_start'] : '';
+                $evolution_data[]   = isset( $row['total'] ) ? (int) $row['total'] : 0;
             }
         }
 
@@ -725,22 +728,22 @@ class UFSC_Frontend_Shortcodes {
 
             <div class="ufsc-stats-kpi">
                 <div class="ufsc-kpi-card">
-                    <div class="ufsc-kpi-value"><?php echo esc_html( $stats['total_licences'] ); ?></div>
+                    <div class="ufsc-kpi-value"><?php echo esc_html( isset( $stats['total_licences'] ) ? (int) $stats['total_licences'] : 0 ); ?></div>
                     <div class="ufsc-kpi-label"><?php esc_html_e( 'Total Licences', 'ufsc-clubs' ); ?></div>
                 </div>
-                
+
                 <div class="ufsc-kpi-card">
-                    <div class="ufsc-kpi-value"><?php echo esc_html( $stats['paid_licences'] ); ?></div>
+                    <div class="ufsc-kpi-value"><?php echo esc_html( isset( $stats['paid_licences'] ) ? (int) $stats['paid_licences'] : 0 ); ?></div>
                     <div class="ufsc-kpi-label"><?php esc_html_e( 'Licences Payées', 'ufsc-clubs' ); ?></div>
                 </div>
-                
+
                 <div class="ufsc-kpi-card">
-                    <div class="ufsc-kpi-value"><?php echo esc_html( $stats['validated_licences'] ); ?></div>
+                    <div class="ufsc-kpi-value"><?php echo esc_html( isset( $stats['validated_licences'] ) ? (int) $stats['validated_licences'] : 0 ); ?></div>
                     <div class="ufsc-kpi-label"><?php esc_html_e( 'Licences Validées', 'ufsc-clubs' ); ?></div>
                 </div>
-                
+
                 <div class="ufsc-kpi-card">
-                    <div class="ufsc-kpi-value"><?php echo esc_html( $stats['quota_remaining'] ); ?></div>
+                    <div class="ufsc-kpi-value"><?php echo esc_html( isset( $stats['quota_remaining'] ) ? (int) $stats['quota_remaining'] : 0 ); ?></div>
                     <div class="ufsc-kpi-label"><?php esc_html_e( 'Quota Restant', 'ufsc-clubs' ); ?></div>
                 </div>
             </div>
@@ -1760,7 +1763,7 @@ class UFSC_Frontend_Shortcodes {
             if ( class_exists( 'UFSC_Stats' ) ) {
                 $stats = UFSC_Stats::get_club_stats( $club_id, $season );
             } else {
-                $stats = array( 'total_licences' => 0, 'paid_licences' => 0, 'validated_licences' => 0, 'quota_remaining' => 10 );
+                $stats = array();
             }
 
             set_transient( $cache_key, $stats, 10 * MINUTE_IN_SECONDS );
@@ -1772,6 +1775,19 @@ class UFSC_Frontend_Shortcodes {
         if ( isset( $stats['validated'] ) && ! isset( $stats['validated_licences'] ) ) {
             $stats['validated_licences'] = $stats['validated'];
         }
+
+        $stats = wp_parse_args(
+            is_array( $stats ) ? $stats : array(),
+            array(
+                'total_licences'     => 0,
+                'paid_licences'      => 0,
+                'validated_licences' => 0,
+                'quota_remaining'    => 0,
+            )
+        );
+
+        $stats['paid_licences']      = isset( $stats['paid_licences'] ) ? (int) $stats['paid_licences'] : 0;
+        $stats['validated_licences'] = isset( $stats['validated_licences'] ) ? (int) $stats['validated_licences'] : 0;
 
         return $stats;
     }


### PR DESCRIPTION
## Summary
- Ensure `get_club_stats()` returns integer defaults for paid and validated licences
- Guard all stats arrays in `render_club_stats()` with `isset()` and cast licence counts to integers

## Testing
- ✅ `php -l includes/frontend/class-frontend-shortcodes.php`
- ⚠️ `composer phpcs` (phpcs: not found)
- ⚠️ `composer phpstan` (phpstan: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bc9df86218832bb650f82c7989c3fa