### PR TITLE
Preserve dashboard tab after frontend form actions

### DIFF
--- a/assets/frontend/js/frontend.js
+++ b/assets/frontend/js/frontend.js
@@ -23,30 +23,36 @@ jQuery(document).ready(function($) {
     function initDashboardNavigation() {
         $('.ufsc-nav-btn').on('click', function(e) {
             e.preventDefault();
-            
+
             var section = $(this).data('section');
-            
+
             // Update nav buttons
             $('.ufsc-nav-btn').removeClass('active');
             $(this).addClass('active');
-            
+
             // Show corresponding section
             $('.ufsc-dashboard-section').removeClass('active');
             $('#ufsc-section-' + section).addClass('active');
-            
-            // Update URL hash for bookmarking
+
+            // Update URL with hash and tab parameter
             if (history.pushState) {
-                history.pushState(null, null, '#' + section);
+                var url = new URL(window.location.href);
+                url.hash = section;
+                url.searchParams.set('tab', section);
+                history.pushState(null, '', url.toString());
             }
-            
+
             // Focus management for accessibility
             $('#ufsc-section-' + section).focus();
         });
-        
-        // Handle URL hash on page load
+
+        // Handle URL hash or tab parameter on page load
+        var params = new URLSearchParams(window.location.search);
+        var tab = params.get('tab');
         var hash = window.location.hash.substring(1);
-        if (hash && $('.ufsc-nav-btn[data-section="' + hash + '"]').length) {
-            $('.ufsc-nav-btn[data-section="' + hash + '"]').click();
+        var target = tab || hash;
+        if (target && $('.ufsc-nav-btn[data-section="' + target + '"]').length) {
+            $('.ufsc-nav-btn[data-section="' + target + '"]').click();
         }
     }
     

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -614,8 +614,7 @@ class UFSC_Unified_Handlers {
             wp_get_referer()
         ) );
         set_transient( 'ufsc_admin_save', time(), 10 );
-        wp_safe_redirect( $redirect_url );
-        exit;
+        UFSC_Licence_Form::redirect_with_notice( $redirect_url, 'licence_saved' );
     }
 
     /**

--- a/includes/front/class-ufsc-licence-form.php
+++ b/includes/front/class-ufsc-licence-form.php
@@ -34,4 +34,20 @@ class UFSC_Licence_Form {
         }
         return true;
     }
+
+    /**
+     * Redirect to given URL with notice and optional tab parameter
+     *
+     * @param string $url     Base URL for redirection.
+     * @param string $notice  Notice slug to display.
+     * @param string $tab     Optional tab to preserve on redirect.
+     */
+    public static function redirect_with_notice( $url, $notice, $tab = '' ) {
+        $redirect = ufsc_redirect_with_notice( $url, $notice );
+        if ( $tab ) {
+            $redirect = add_query_arg( 'tab', sanitize_key( $tab ), $redirect );
+        }
+        wp_safe_redirect( $redirect );
+        exit;
+    }
 }

--- a/includes/frontend/class-club-form-handler.php
+++ b/includes/frontend/class-club-form-handler.php
@@ -445,10 +445,17 @@ class UFSC_CL_Club_Form_Handler {
      */
     private static function redirect_with_error( $message, $club_id, $affiliation ) {
         $redirect_url = wp_get_referer() ?: home_url();
-        $redirect_url = add_query_arg( array(
-            'ufsc_error' => urlencode( $message )
-        ), $redirect_url );
-        
+        $tab          = self::get_referrer_tab( $redirect_url );
+        $redirect_url = add_query_arg(
+            array(
+                'ufsc_error' => urlencode( $message ),
+            ),
+            $redirect_url
+        );
+        if ( $tab ) {
+            $redirect_url = add_query_arg( 'tab', $tab, $redirect_url );
+        }
+
         wp_safe_redirect( $redirect_url );
         exit;
     }
@@ -462,12 +469,34 @@ class UFSC_CL_Club_Form_Handler {
      */
     private static function redirect_with_success( $message, $club_id, $affiliation ) {
         $redirect_url = wp_get_referer() ?: home_url();
-        $redirect_url = add_query_arg( array(
-            'ufsc_success' => urlencode( $message )
-        ), $redirect_url );
-        
+        $tab          = self::get_referrer_tab( $redirect_url );
+        $redirect_url = add_query_arg(
+            array(
+                'ufsc_success' => urlencode( $message ),
+            ),
+            $redirect_url
+        );
+        if ( $tab ) {
+            $redirect_url = add_query_arg( 'tab', $tab, $redirect_url );
+        }
+
         wp_safe_redirect( $redirect_url );
         exit;
+    }
+
+    /**
+     * Extract tab parameter from referrer URL
+     */
+    private static function get_referrer_tab( $url ) {
+        $tab = '';
+        $ref_query = wp_parse_url( $url, PHP_URL_QUERY );
+        if ( $ref_query ) {
+            parse_str( $ref_query, $args );
+            if ( isset( $args['tab'] ) ) {
+                $tab = sanitize_key( $args['tab'] );
+            }
+        }
+        return $tab;
     }
 }
 


### PR DESCRIPTION
## Summary
- Keep active dashboard tab in URL via `?tab` param and restore on load
- Carry tab parameter through club save redirects and show notices
- Add licence redirect helper with notices and preserve tab

## Testing
- `composer install` *(fails: curl error 56)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9dfa9cf4832b8b9a711c393fd1e3