### PR TITLE
chore: scope frontend styles

### DIFF
--- a/assets/css/ufsc-front.css
+++ b/assets/css/ufsc-front.css
@@ -3,7 +3,7 @@
  * Design tokens and base components for front shortcodes
  */
 
-:root {
+.ufsc-front{
     --ufsc-primary: #2271b1;      /* Bleu UFSC */
     --ufsc-secondary: #135e96;    /* Bleu foncé */
     --ufsc-success: #047857;      /* Vert validation */
@@ -25,73 +25,73 @@
 }
 
 /* Grid system */
-.ufsc-grid {
+.ufsc-front .ufsc-grid{
     display: grid;
     gap: var(--ufsc-spacing-md);
     grid-template-columns: 1fr;
 }
 @media (min-width: var(--tablet)) {
-    .ufsc-grid {
+.ufsc-front .ufsc-grid{
         grid-template-columns: repeat(2, 1fr);
     }
 }
 @media (min-width: var(--desktop)) {
-    .ufsc-grid {
+.ufsc-front .ufsc-grid{
         grid-template-columns: repeat(3, 1fr);
     }
 }
-.ufsc-grid.-wide {
+.ufsc-front .ufsc-grid.-wide{
     grid-template-columns: 1fr;
 }
 
 /* Licence cards grid */
-.ufsc-licence-grid {
+.ufsc-front .ufsc-licence-grid{
     display: grid;
     gap: var(--ufsc-spacing-md);
     grid-template-columns: 1fr;
 }
 @media (min-width: var(--tablet)) {
-    .ufsc-licence-grid {
+.ufsc-front .ufsc-licence-grid{
         grid-template-columns: repeat(2, 1fr);
     }
 }
 @media (min-width: var(--tablet)) {
-    .ufsc-grid.-wide {
+.ufsc-front .ufsc-grid.-wide{
         grid-template-columns: repeat(2, 1fr);
     }
 }
 
 /* Licence cards grid */
-.ufsc-licence-cards {
+.ufsc-front .ufsc-licence-cards{
     display: grid;
     gap: var(--ufsc-spacing-md);
     grid-template-columns: 1fr;
 }
 @media (min-width: var(--tablet)) {
-    .ufsc-licence-cards {
+.ufsc-front .ufsc-licence-cards{
         grid-template-columns: repeat(2, 1fr);
     }
 }
 
 /* Documents status grid */
-.ufsc-documents-status {
+.ufsc-front .ufsc-documents-status{
     display: grid;
     gap: var(--ufsc-spacing-md);
     grid-template-columns: 1fr;
 }
 @media (min-width: var(--tablet)) {
-    .ufsc-documents-status {
+.ufsc-front .ufsc-documents-status{
         grid-template-columns: repeat(2, 1fr);
     }
 }
 @media (min-width: var(--desktop)) {
-    .ufsc-documents-status {
+.ufsc-front .ufsc-documents-status{
         grid-template-columns: repeat(3, 1fr);
     }
 }
 
 /* Card */
-.ufsc-card {
+.ufsc-front .ufsc-card{
     background: #ffffff;
     border: 1px solid #e1e5e9;
     border-radius: 8px;
@@ -99,29 +99,29 @@
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
     transition: box-shadow 0.3s ease, transform 0.3s ease;
 }
-.ufsc-card:hover {
+.ufsc-front .ufsc-card:hover{
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     transform: translateY(-2px);
 }
 
-.ufsc-card:focus,
-.ufsc-card:focus-within,
-.ufsc-licence-card:focus,
-.ufsc-document-item:focus {
+.ufsc-front .ufsc-card:focus,
+.ufsc-front .ufsc-card:focus-within,
+.ufsc-front .ufsc-licence-card:focus,
+.ufsc-front .ufsc-document-item:focus{
     outline: 3px solid var(--ufsc-info);
     outline-offset: 2px;
 }
 
 /* Club profile grids */
-.ufsc-club-profile .ufsc-card .ufsc-grid {
+.ufsc-front .ufsc-club-profile .ufsc-card .ufsc-grid{
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: var(--ufsc-spacing-md);
 }
 
 /* Club profile typography and spacing */
-.ufsc-club-profile .ufsc-card h4,
-.ufsc-club-profile fieldset legend {
+.ufsc-front .ufsc-club-profile .ufsc-card h4,
+.ufsc-front .ufsc-club-profile fieldset legend{
     font-size: 1.1rem;
     font-weight: 600;
     line-height: 1.4;
@@ -129,7 +129,7 @@
     color: var(--ufsc-secondary);
 }
 
-.ufsc-club-profile fieldset {
+.ufsc-front .ufsc-club-profile fieldset{
     margin-bottom: var(--ufsc-spacing-lg);
     padding: var(--ufsc-spacing-md);
     background: #ffffff;
@@ -138,17 +138,17 @@
 }
 
 /* Field */
-.ufsc-club-profile .ufsc-field {
+.ufsc-front .ufsc-club-profile .ufsc-field{
     margin-bottom: var(--ufsc-spacing-md);
 }
-.ufsc-field label {
+.ufsc-front .ufsc-field label{
     display: block;
     margin-bottom: 4px;
     font-weight: 600;
 }
-.ufsc-field input,
-.ufsc-field select,
-.ufsc-field textarea {
+.ufsc-front .ufsc-field input,
+.ufsc-front .ufsc-field select,
+.ufsc-front .ufsc-field textarea{
     width: 100%;
     padding: 10px;
     border: 1px solid #ddd;
@@ -157,7 +157,7 @@
 }
 
 /* Buttons */
-.ufsc-btn {
+.ufsc-front .ufsc-btn{
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
@@ -170,25 +170,25 @@
     cursor: pointer;
     transition: all 0.3s ease;
 }
-.ufsc-btn-primary {
+.ufsc-front .ufsc-btn-primary{
     background: var(--ufsc-primary);
     color: #fff;
 }
-.ufsc-btn-primary:hover {
+.ufsc-front .ufsc-btn-primary:hover{
     background: #005a87;
     color: #fff;
 }
-.ufsc-btn-secondary {
+.ufsc-front .ufsc-btn-secondary{
     background: var(--ufsc-neutral);
     color: #fff;
 }
-.ufsc-btn-secondary:hover {
+.ufsc-front .ufsc-btn-secondary:hover{
     background: #4b5563;
     color: #fff;
 }
 
 /* Badges */
-.ufsc-badge {
+.ufsc-front .ufsc-badge{
     display: inline-flex;
     align-items: center;
     padding: 0.25rem 0.5rem;
@@ -198,75 +198,75 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
-.ufsc-badge-success {
+.ufsc-front .ufsc-badge-success{
     background: var(--ufsc-success);
     color: #fff;
 }
-.ufsc-badge-warning {
+.ufsc-front .ufsc-badge-warning{
     background: var(--ufsc-warning);
     color: #fff;
 }
-.ufsc-badge-info {
+.ufsc-front .ufsc-badge-info{
     background: var(--ufsc-info);
     color: #fff;
 }
-.ufsc-badge-danger {
+.ufsc-front .ufsc-badge-danger{
     background: var(--ufsc-danger);
     color: #fff;
 }
-.ufsc-badge-region {
+.ufsc-front .ufsc-badge-region{
     background: var(--ufsc-primary);
     color: #fff;
 }
 
-.ufsc-badge-doc-complete {
+.ufsc-front .ufsc-badge-doc-complete{
     background: var(--ufsc-success);
     color: #fff;
 }
-.ufsc-badge-doc-partial {
+.ufsc-front .ufsc-badge-doc-partial{
     background: var(--ufsc-warning);
     color: #fff;
 }
-.ufsc-badge-doc-missing {
+.ufsc-front .ufsc-badge-doc-missing{
     background: var(--ufsc-danger);
     color: #fff;
 }
 
 /* Licence status badges */
-.ufsc-badge-pending {
+.ufsc-front .ufsc-badge-pending{
     background: var(--ufsc-info);
     color: #fff;
 }
-.ufsc-badge-validated {
+.ufsc-front .ufsc-badge-validated{
     background: var(--ufsc-success);
     color: #fff;
 }
-.ufsc-badge-expired {
+.ufsc-front .ufsc-badge-expired{
     background: var(--ufsc-warning);
     color: #fff;
 }
-.ufsc-badge-rejected {
+.ufsc-front .ufsc-badge-rejected{
     background: var(--ufsc-danger);
     color: #fff;
 }
 
-.ufsc-badge:hover {
+.ufsc-front .ufsc-badge:hover{
     opacity: 0.8;
     text-decoration: none;
 }
 
-.ufsc-badge-sm {
+.ufsc-front .ufsc-badge-sm{
     padding: 0.2em 0.5em;
     font-size: 0.65em;
 }
 
-.ufsc-badge-lg {
+.ufsc-front .ufsc-badge-lg{
     padding: 0.35em 0.8em;
     font-size: 0.85em;
 }
 
 /* Login form */
-.ufsc-login-form {
+.ufsc-front .ufsc-login-form{
     max-width: 400px;
     margin: 0 auto;
     padding: var(--ufsc-spacing-md);
@@ -274,47 +274,47 @@
     border-radius: 8px;
     background: #fff;
 }
-.ufsc-login-title {
+.ufsc-front .ufsc-login-title{
     text-align: center;
     margin-bottom: var(--ufsc-spacing-md);
     color: #333;
 }
-.ufsc-form-group {
+.ufsc-front .ufsc-form-group{
     margin-bottom: var(--ufsc-spacing-sm);
 }
-.ufsc-form-group label {
+.ufsc-front .ufsc-form-group label{
     display: block;
     margin-bottom: 5px;
     font-weight: bold;
     color: #555;
 }
-.ufsc-form-control {
+.ufsc-front .ufsc-form-control{
     width: 100%;
     padding: 10px;
     border: 1px solid #ddd;
     border-radius: 4px;
     font-size: 14px;
 }
-.ufsc-form-control:focus {
+.ufsc-front .ufsc-form-control:focus{
     border-color: var(--ufsc-primary);
     outline: none;
     box-shadow: 0 0 0 2px rgba(34,113,177,0.2);
 }
-.ufsc-form-links {
+.ufsc-front .ufsc-form-links{
     text-align: center;
     margin-top: 10px;
 }
-.ufsc-form-links a {
+.ufsc-front .ufsc-form-links a{
     color: var(--ufsc-primary);
     text-decoration: none;
     font-size: 13px;
 }
-.ufsc-form-links a:hover {
+.ufsc-front .ufsc-form-links a:hover{
     text-decoration: underline;
 }
 
 /* User status */
-.ufsc-user-status {
+.ufsc-front .ufsc-user-status{
     display: flex;
     align-items: center;
     gap: 10px;
@@ -323,33 +323,33 @@
     border-radius: 4px;
     border: 1px solid #e9ecef;
 }
-.ufsc-user-status.ufsc-not-logged-in {
+.ufsc-front .ufsc-user-status.ufsc-not-logged-in{
     text-align: center;
     color: #6c757d;
 }
-.ufsc-user-avatar img {
+.ufsc-front .ufsc-user-avatar img{
     border-radius: 50%;
 }
-.ufsc-user-info {
+.ufsc-front .ufsc-user-info{
     flex: 1;
 }
-.ufsc-user-name {
+.ufsc-front .ufsc-user-name{
     margin-bottom: 2px;
 }
-.ufsc-user-role,
-.ufsc-user-club {
+.ufsc-front .ufsc-user-role,
+.ufsc-front .ufsc-user-club{
     font-size: 12px;
     color: #6c757d;
     margin-bottom: 2px;
 }
-.ufsc-user-actions {
+.ufsc-front .ufsc-user-actions{
     margin-top: 5px;
 }
-.ufsc-logout-button {
+.ufsc-front .ufsc-logout-button{
     font-size: 12px;
     color: #dc3545;
     text-decoration: none;
 }
-.ufsc-logout-button:hover {
+.ufsc-front .ufsc-logout-button:hover{
     text-decoration: underline;
 }

--- a/includes/frontend/class-auth-shortcodes.php
+++ b/includes/frontend/class-auth-shortcodes.php
@@ -92,6 +92,7 @@ class UFSC_Auth_Shortcodes {
 
         ob_start();
         ?>
+        <div class="ufsc-front ufsc-full">
         <div class="<?php echo esc_attr( $atts['class'] ); ?>">
 
             <div class="ufsc-card ufsc-col-span-2 ufsc-login-card">
@@ -153,6 +154,7 @@ class UFSC_Auth_Shortcodes {
                 </form>
             </div>
         </div>
+        </div>
 
 
         <?php
@@ -194,7 +196,7 @@ class UFSC_Auth_Shortcodes {
             '';
 
         return sprintf(
-            '<a href="%s" class="%s" onclick="%s">%s</a>',
+            '<div class="ufsc-front ufsc-full"><a href="%s" class="%s" onclick="%s">%s</a></div>',
             esc_url( $logout_url ),
             esc_attr( $atts['class'] ),
             $onclick,
@@ -218,9 +220,9 @@ class UFSC_Auth_Shortcodes {
         ), $atts, 'ufsc_user_status' );
 
         if ( ! is_user_logged_in() ) {
-            return '<div class="ufsc-user-status ufsc-not-logged-in">' .
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-user-status ufsc-not-logged-in">' .
                    esc_html__( 'Non connecté', 'ufsc-clubs' ) .
-                   '</div>';
+                   '</div></div>';
         }
 
         $user = wp_get_current_user();
@@ -228,6 +230,7 @@ class UFSC_Auth_Shortcodes {
 
         ob_start();
         ?>
+        <div class="ufsc-front ufsc-full">
         <div class="ufsc-user-status ufsc-logged-in">
             <?php if ( $atts['show_avatar'] === 'true' ): ?>
                 <div class="ufsc-user-avatar">
@@ -260,6 +263,7 @@ class UFSC_Auth_Shortcodes {
                 <?php endif; ?>
             </div>
         </div>
+        </div>
         <?php
         return ob_get_clean();
     }
@@ -272,10 +276,10 @@ class UFSC_Auth_Shortcodes {
         $dashboard_url = self::get_user_dashboard_url( $user );
 
         return sprintf(
-            '<div class="ufsc-already-logged-in">
+            '<div class="ufsc-front ufsc-full"><div class="ufsc-already-logged-in">
                 <p>%s <strong>%s</strong></p>
                 <p><a href="%s" class="ufsc-btn ufsc-btn-primary">%s</a></p>
-            </div>',
+            </div></div>',
             esc_html__( 'Vous êtes déjà connecté en tant que', 'ufsc-clubs' ),
             esc_html( $user->display_name ),
             esc_url( $dashboard_url ),

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -75,24 +75,25 @@ class UFSC_Frontend_Shortcodes {
         ), $atts );
 
         if ( ! is_user_logged_in() ) {
-            return '<div class="ufsc-message ufsc-error">' . 
-                   esc_html__( 'Vous devez être connecté pour accéder au tableau de bord.', 'ufsc-clubs' ) . 
-                   '</div>';
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
+                   esc_html__( 'Vous devez être connecté pour accéder au tableau de bord.', 'ufsc-clubs' ) .
+                   '</div></div>';
         }
 
         $user_id = get_current_user_id();
         $club_id = self::get_user_club_id( $user_id );
 
         if ( ! $club_id ) {
-            return '<div class="ufsc-message ufsc-error">' . 
-                   esc_html__( 'Aucun club associé à votre compte.', 'ufsc-clubs' ) . 
-                   '</div>';
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
+                   esc_html__( 'Aucun club associé à votre compte.', 'ufsc-clubs' ) .
+                   '</div></div>';
         }
 
         $sections = explode( ',', $atts['show_sections'] );
         
         ob_start();
         ?>
+        <div class="ufsc-front ufsc-full">
         <div class="ufsc-club-dashboard" id="ufsc-dashboard">
             <div class="ufsc-dashboard-header">
                 <h2><?php esc_html_e( 'Tableau de bord - Mon Club', 'ufsc-clubs' ); ?></h2>
@@ -162,6 +163,7 @@ class UFSC_Frontend_Shortcodes {
                 <?php endif; ?>
             </div>
         </div>
+        </div>
 
         <script>
         jQuery(document).ready(function($) {
@@ -207,9 +209,9 @@ class UFSC_Frontend_Shortcodes {
         }
 
         if ( ! $atts['club_id'] ) {
-            return '<div class="ufsc-message ufsc-error">' . 
-                   esc_html__( 'Club non trouvé.', 'ufsc-clubs' ) . 
-                   '</div>';
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
+                   esc_html__( 'Club non trouvé.', 'ufsc-clubs' ) .
+                   '</div></div>';
         }
 
         // Handle pagination and filters from URL
@@ -257,6 +259,7 @@ class UFSC_Frontend_Shortcodes {
 
         ob_start();
         ?>
+        <div class="ufsc-front ufsc-full">
         <div class="ufsc-licences-section">
             <div class="ufsc-feedback" id="ufsc-feedback" aria-live="polite">
                 <?php if ( isset( $_GET['ufsc_message'] ) ) : ?>
@@ -439,6 +442,7 @@ class UFSC_Frontend_Shortcodes {
 
         <!-- Import Modal -->
         <?php echo self::render_import_modal( $atts['club_id'] ); ?>
+        </div>
         <?php
         return ob_get_clean();
     }
@@ -452,22 +456,23 @@ class UFSC_Frontend_Shortcodes {
     public static function render_single_licence( $licence_id ) {
         $club_id = self::get_user_club_id( get_current_user_id() );
         if ( ! $club_id ) {
-            return '<div class="ufsc-message ufsc-error">' .
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
                    esc_html__( 'Club non trouvé.', 'ufsc-clubs' ) .
-                   '</div>';
+                   '</div></div>';
         }
 
         $licence = self::get_licence( $club_id, $licence_id );
         if ( ! $licence ) {
-            return '<div class="ufsc-message ufsc-error">' .
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
                    esc_html__( 'Licence non trouvée.', 'ufsc-clubs' ) .
-                   '</div>';
+                   '</div></div>';
         }
 
         $wc_settings = ufsc_get_woocommerce_settings();
 
         ob_start();
         ?>
+        <div class="ufsc-front ufsc-full">
         <div class="ufsc-licence-detail">
             <div class="ufsc-section-header">
                 <h3><?php esc_html_e( 'Détails de la licence', 'ufsc-clubs' ); ?></h3>
@@ -564,6 +569,7 @@ class UFSC_Frontend_Shortcodes {
                 </a>
             </p>
         </div>
+        </div>
         <?php
         return ob_get_clean();
     }
@@ -594,9 +600,9 @@ class UFSC_Frontend_Shortcodes {
         }
 
         if ( ! $atts['club_id'] ) {
-            return '<div class="ufsc-message ufsc-error">' . 
-                   esc_html__( 'Club non trouvé.', 'ufsc-clubs' ) . 
-                   '</div>';
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
+                   esc_html__( 'Club non trouvé.', 'ufsc-clubs' ) .
+                   '</div></div>';
         }
 
         if ( empty( $atts['season'] ) ) {
@@ -715,6 +721,7 @@ class UFSC_Frontend_Shortcodes {
 
         ob_start();
         ?>
+        <div class="ufsc-front ufsc-full">
         <div class="ufsc-stats-section">
             <div class="ufsc-section-header">
                 <h3><?php esc_html_e( 'Statistiques', 'ufsc-clubs' ); ?></h3>
@@ -764,6 +771,7 @@ class UFSC_Frontend_Shortcodes {
                 <h4><?php esc_html_e( 'Évolution des licences (12 semaines)', 'ufsc-clubs' ); ?></h4>
                 <canvas id="ufsc-evolution-chart" height="200"></canvas>
             </div>
+        </div>
         </div>
 
         <script>
@@ -854,9 +862,9 @@ class UFSC_Frontend_Shortcodes {
         }
 
         if ( ! $atts['club_id'] ) {
-            return '<div class="ufsc-message ufsc-error">' . 
-                   esc_html__( 'Club non trouvé.', 'ufsc-clubs' ) . 
-                   '</div>';
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
+                   esc_html__( 'Club non trouvé.', 'ufsc-clubs' ) .
+                   '</div></div>';
         }
 
         $club = self::get_club_data( $atts['club_id'] );
@@ -865,18 +873,18 @@ class UFSC_Frontend_Shortcodes {
         $is_admin = current_user_can( 'manage_options' );
 
         if ( ! $club ) {
-            return '<div class="ufsc-message ufsc-error">' . 
-                   esc_html__( 'Données du club non trouvées.', 'ufsc-clubs' ) . 
-                   '</div>';
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
+                   esc_html__( 'Données du club non trouvées.', 'ufsc-clubs' ) .
+                   '</div></div>';
         }
         
         $is_admin = current_user_can( 'manage_options' );
         $can_edit = UFSC_CL_Permissions::ufsc_user_can_edit_club( $atts['club_id'] );
         
         if ( ! $can_edit ) {
-            return '<div class="ufsc-message ufsc-error">' . 
-                   esc_html__( 'Vous n\'avez pas les permissions pour voir ce club.', 'ufsc-clubs' ) . 
-                   '</div>';
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
+                   esc_html__( 'Vous n\'avez pas les permissions pour voir ce club.', 'ufsc-clubs' ) .
+                   '</div></div>';
         }
 
         
@@ -898,6 +906,7 @@ class UFSC_Frontend_Shortcodes {
 
         ob_start();
         ?>
+        <div class="ufsc-front ufsc-full">
         <div class="ufsc-club-profile">
             <!-- // UFSC: Enhanced club profile with sections and cards -->
             <div class="ufsc-section-header">
@@ -1138,6 +1147,7 @@ class UFSC_Frontend_Shortcodes {
 
             </form>
         </div>
+        </div>
         <?php
         return ob_get_clean();
     }
@@ -1158,9 +1168,9 @@ class UFSC_Frontend_Shortcodes {
         }
 
         if ( ! $atts['club_id'] ) {
-            return '<div class="ufsc-message ufsc-error">' . 
-                   esc_html__( 'Club non trouvé.', 'ufsc-clubs' ) . 
-                   '</div>';
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
+                   esc_html__( 'Club non trouvé.', 'ufsc-clubs' ) .
+                   '</div></div>';
         }
 
         // Check quota
@@ -1203,6 +1213,7 @@ class UFSC_Frontend_Shortcodes {
 
         ob_start();
         ?>
+        <div class="ufsc-front ufsc-full">
         <div class="ufsc-add-licence-section">
             <div class="ufsc-section-header">
                 <h3><?php esc_html_e( 'Ajouter une Licence', 'ufsc-clubs' ); ?></h3>
@@ -1470,6 +1481,7 @@ class UFSC_Frontend_Shortcodes {
                 </div>
             </form>
         </div>
+        </div>
         <?php
         return ob_get_clean();
     }
@@ -1487,9 +1499,9 @@ class UFSC_Frontend_Shortcodes {
         }
 
         if ( ! $atts['club_id'] ) {
-            return '<div class="ufsc-message ufsc-error">' .
+            return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
                    esc_html__( 'Club non trouv\u00e9.', 'ufsc-clubs' ) .
-                   '</div>';
+                   '</div></div>';
         }
 
         $action     = isset( $_GET['ufsc_action'] ) ? sanitize_key( $_GET['ufsc_action'] ) : '';

--- a/templates/frontend/club-dashboard.php
+++ b/templates/frontend/club-dashboard.php
@@ -14,7 +14,7 @@ $stats_practice = $ufsc_stats->get_practice_counts();
 $stats_age     = $ufsc_stats->get_age_group_counts();
 
 ?>
-
+<div class="ufsc-front ufsc-full">
 <div class="ufsc-club-dashboard" id="ufsc-club-dashboard">
     <div class="ufsc-feedback" id="ufsc-feedback" aria-live="polite" role="status" tabindex="-1"></div>
     
@@ -370,7 +370,8 @@ $stats_age     = $ufsc_stats->get_age_group_counts();
         </div>
     </div>
 
-</div>
+ </div>
 
 <!-- Toast notifications -->
 <div class="ufsc-toast-container" id="ufsc-toast-container" aria-live="polite"></div>
+</div>

--- a/templates/frontend/licence-form.php
+++ b/templates/frontend/licence-form.php
@@ -2,6 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 include UFSC_CL_DIR . 'templates/partials/notice.php';
 ?>
+<div class="ufsc-front ufsc-full">
 <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-licence-form">
     <input type="hidden" name="action" value="ufsc_save_licence" />
     <?php wp_nonce_field( 'ufsc_save_licence' ); ?>
@@ -77,3 +78,4 @@ include UFSC_CL_DIR . 'templates/partials/notice.php';
         </button>
     </div>
 </form>
+</div>

--- a/templates/frontend/licences-list.php
+++ b/templates/frontend/licences-list.php
@@ -1,4 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-UFSC_Licences_Table::render( $licences );
+?>
+<div class="ufsc-front ufsc-full">
+<?php UFSC_Licences_Table::render( $licences ); ?>
+</div>


### PR DESCRIPTION
## Summary
- scope front styles under .ufsc-front to avoid leaking into themes
- wrap shortcode and template markup in `<div class="ufsc-front ufsc-full">` so styles apply correctly

## Testing
- `composer install` *(fails: curl error 56)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*
- `php -l includes/frontend/class-auth-shortcodes.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l templates/frontend/licence-form.php`
- `php -l templates/frontend/club-dashboard.php`
- `php -l templates/frontend/licences-list.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc9df36700832b93d0033592e3a10c