### PR TITLE
Harden AJAX handlers and standardize script enqueues

### DIFF
--- a/includes/front/class-ufsc-documents.php
+++ b/includes/front/class-ufsc-documents.php
@@ -19,6 +19,10 @@ class UFSC_Documents {
      * Handle document uploads from club dashboard forms.
      */
     public static function handle_upload() {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
         if ( ! isset( $_POST['club_id'], $_POST['_wpnonce'] ) ) {
             wp_die( __( 'Requête invalide.', 'ufsc-clubs' ) );
         }
@@ -130,6 +134,10 @@ class UFSC_Documents {
      * Export club documents as CSV.
      */
     public static function export_documents() {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
         if ( ! isset( $_GET['club_id'], $_GET['_wpnonce'] ) ) {
             wp_die( __( 'Requête invalide.', 'ufsc-clubs' ) );
         }

--- a/includes/front/class-ufsc-licences-table.php
+++ b/includes/front/class-ufsc-licences-table.php
@@ -35,8 +35,8 @@ class UFSC_Licences_Table {
     public static function ajax_fetch_licences() {
         check_ajax_referer( 'ufsc_frontend_nonce', 'nonce' );
 
-        if ( ! is_user_logged_in() ) {
-            wp_send_json_error( array( 'message' => __( 'Vous devez être connecté.', 'ufsc-clubs' ) ), 401 );
+        if ( ! current_user_can( 'read' ) ) {
+            wp_send_json_error( array( 'message' => __( 'Accès refusé.', 'ufsc-clubs' ) ), 401 );
         }
 
         $user_id = get_current_user_id();

--- a/includes/frontend/class-affiliation-form.php
+++ b/includes/frontend/class-affiliation-form.php
@@ -18,12 +18,13 @@ class UFSC_Affiliation_Form {
         add_action( 'wp_ajax_nopriv_ufsc_affiliation_pay', array( __CLASS__, 'ajax_affiliation_pay' ) );
         add_action( 'admin_post_ufsc_affiliation_pay', array( __CLASS__, 'handle_affiliation_pay' ) );
         add_action( 'admin_post_nopriv_ufsc_affiliation_pay', array( __CLASS__, 'handle_affiliation_pay' ) );
+        add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
     }
 
     /**
      * Enqueue affiliation payment script
      */
-    private static function enqueue_scripts() {
+    public static function enqueue_scripts() {
         if ( ! function_exists( 'ufsc_is_woocommerce_active' ) || ! ufsc_is_woocommerce_active() ) {
             return;
         }
@@ -91,8 +92,6 @@ class UFSC_Affiliation_Form {
                             esc_html( sanitize_text_field( $_GET['error'] ) ) .
                             '</div>';
         }
-
-        self::enqueue_scripts();
 
         ob_start();
         ?>
@@ -239,6 +238,10 @@ class UFSC_Affiliation_Form {
      */
     public static function ajax_affiliation_pay() {
         check_ajax_referer( 'ufsc_affiliation_pay', 'nonce' );
+
+        if ( ! current_user_can( 'read' ) ) {
+            wp_send_json_error( array( 'message' => __( 'Accès refusé.', 'ufsc-clubs' ) ), 403 );
+        }
 
         if ( ! function_exists( 'ufsc_is_woocommerce_active' ) || ! ufsc_is_woocommerce_active() ) {
             wp_send_json_error();


### PR DESCRIPTION
## Summary
- enforce capability checks for AJAX document export and licence fetch handlers
- hook affiliation form script into `wp_enqueue_scripts` and gate AJAX handler with `current_user_can`

## Testing
- `composer install` *(fails: curl error 56 while downloading packages)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca49d93b0832bafcc016e909f51b2