### PR TITLE
feat: responsive licence table and form layout

### DIFF
--- a/assets/css/ufsc-front.css
+++ b/assets/css/ufsc-front.css
@@ -86,7 +86,7 @@
 }
 @media (min-width: var(--desktop)) {
 .ufsc-front .ufsc-documents-status{
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(2, 1fr);
     }
 }
 
@@ -330,6 +330,18 @@
 .ufsc-front .ufsc-user-avatar img{
     border-radius: 50%;
 }
+.ufsc-front .ufsc-club-photo img{
+    width: 140px;
+    height: 140px;
+    object-fit: cover;
+    border-radius: 50%;
+}
+@media (min-width: var(--desktop)){
+.ufsc-front .ufsc-club-photo img{
+        width: 220px;
+        height: 220px;
+    }
+}
 .ufsc-front .ufsc-user-info{
     flex: 1;
 }
@@ -352,4 +364,34 @@
 }
 .ufsc-front .ufsc-logout-button:hover{
     text-decoration: underline;
+}
+
+/* Licence form grid */
+.ufsc-front .ufsc-licence-form .ufsc-grid{
+    grid-template-columns: 1fr;
+}
+@media (min-width: var(--tablet)){
+.ufsc-front .ufsc-licence-form .ufsc-grid{
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+@media (min-width: var(--desktop)){
+.ufsc-front .ufsc-licence-form .ufsc-grid{
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+.ufsc-front .ufsc-licence-form .ufsc-field-full{
+    grid-column: 1 / -1;
+}
+
+/* Licences table */
+.ufsc-front .ufsc-licences-table{
+    width: 100%;
+    border-collapse: collapse;
+}
+.ufsc-front .ufsc-licences-table th,
+.ufsc-front .ufsc-licences-table td{
+    padding: var(--ufsc-spacing-xs);
+    border-bottom: 1px solid #e1e5e9;
+    text-align: left;
 }

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -371,57 +371,7 @@ class UFSC_Frontend_Shortcodes {
                         <?php esc_html_e( 'Aucune licence trouvée.', 'ufsc-clubs' ); ?>
                     </div>
                 <?php else : ?>
-                    <div class="ufsc-licence-grid">
-                        <?php foreach ( $licences as $licence ) :
-                            $full_name = trim( ( $licence->prenom ?? '' ) . ' ' . ( $licence->nom ?? '' ) );
-                            $gender_code = strtolower( $licence->sexe ?? '' );
-                            switch ( $gender_code ) {
-                                case 'm':
-                                case 'h':
-                                    $gender = __( 'Homme', 'ufsc-clubs' );
-                                    break;
-                                case 'f':
-                                    $gender = __( 'Femme', 'ufsc-clubs' );
-                                    break;
-                                default:
-                                    $gender = $licence->sexe ?? '';
-                            }
-
-                            $practice = isset( $licence->competition ) && $licence->competition
-                                ? __( 'Compétition', 'ufsc-clubs' )
-                                : __( 'Loisir', 'ufsc-clubs' );
-
-                            $age = '';
-                            if ( ! empty( $licence->date_naissance ) ) {
-                                $birth = strtotime( $licence->date_naissance );
-                                if ( $birth ) {
-                                    $age = floor( ( current_time( 'timestamp' ) - $birth ) / YEAR_IN_SECONDS );
-                                }
-                            }
-                            ?>
-                            <div class="ufsc-card ufsc-licence-card">
-                                <div class="ufsc-licence-card-header">
-                                    <h4 class="ufsc-licence-name"><?php echo esc_html( $full_name ); ?></h4>
-                                    <?php
-                                    $badge_label = self::get_licence_status_label( $licence->statut ?? '' );
-                                    $badge_class = self::get_licence_status_badge_class( $licence->statut ?? '' );
-                                    ?>
-                                    <span class="ufsc-badge <?php echo esc_attr( $badge_class ); ?>"><?php echo esc_html( $badge_label ); ?></span>
-                                </div>
-                                <div class="ufsc-licence-meta">
-                                    <?php if ( $gender ) : ?><span><?php echo esc_html( $gender ); ?></span><?php endif; ?>
-                                    <span><?php echo esc_html( $practice ); ?></span>
-                                    <?php if ( '' !== $age ) : ?><span><?php echo intval( $age ); ?> <?php esc_html_e( 'ans', 'ufsc-clubs' ); ?></span><?php endif; ?>
-                                </div>
-                                <div class="ufsc-licence-actions">
-                                    <a class="ufsc-action" href="<?php echo esc_url( add_query_arg( 'view_licence', $licence->id ?? 0 ) ); ?>"><?php esc_html_e( 'Consulter', 'ufsc-clubs' ); ?></a>
-                                    <?php if ( in_array( $licence->statut ?? '', array( 'draft', 'pending' ), true ) ) : ?>
-                                        <a class="ufsc-action" href="<?php echo esc_url( add_query_arg( 'edit_licence', $licence->id ?? 0 ) ); ?>"><?php esc_html_e( 'Modifier', 'ufsc-clubs' ); ?></a>
-                                    <?php endif; ?>
-                                </div>
-                            </div>
-                        <?php endforeach; ?>
-                    </div>
+                    <?php echo UFSC_Licences_Table::render( $licences ); ?>
                 <?php endif; ?>
             </div>
 
@@ -1684,7 +1634,7 @@ class UFSC_Frontend_Shortcodes {
         $offset   = ( $page - 1 ) * $per_page;
 
         $where_sql = $clauses ? 'WHERE ' . implode( ' AND ', $clauses ) : '';
-        $sql       = "SELECT * FROM `{$licences_table}` {$where_sql} ORDER BY {$order_by} LIMIT %d OFFSET %d";
+        $sql       = "SELECT DISTINCT * FROM `{$licences_table}` {$where_sql} ORDER BY {$order_by} LIMIT %d OFFSET %d";
         $values[]  = $per_page;
         $values[]  = $offset;
 
@@ -1759,7 +1709,7 @@ class UFSC_Frontend_Shortcodes {
         }
 
         $where_sql = $clauses ? 'WHERE ' . implode( ' AND ', $clauses ) : '';
-        $sql       = "SELECT COUNT(*) FROM `{$licences_table}` {$where_sql}";
+        $sql       = "SELECT COUNT(DISTINCT id) FROM `{$licences_table}` {$where_sql}";
 
         return (int) $wpdb->get_var( $wpdb->prepare( $sql, $values ) );
     }

--- a/templates/frontend/licence-form.php
+++ b/templates/frontend/licence-form.php
@@ -25,7 +25,7 @@ include UFSC_CL_DIR . 'templates/partials/notice.php';
             <label for="nom"><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></label>
             <input type="text" id="nom" name="nom" value="<?php echo esc_attr( $licence->nom ?? '' ); ?>" />
         </div>
-        <div class="ufsc-field">
+        <div class="ufsc-field ufsc-field-full">
             <label for="email">Email</label>
             <input type="email" id="email" name="email" value="<?php echo esc_attr( $licence->email ?? '' ); ?>" />
         </div>
@@ -47,7 +47,7 @@ include UFSC_CL_DIR . 'templates/partials/notice.php';
         <div class="ufsc-field">
             <label class="ufsc-checkbox"><input type="checkbox" id="reduction_postier" name="reduction_postier" value="1" <?php checked( $licence->reduction_postier ?? 0, 1 ); ?> /> <?php esc_html_e( 'R\u00e9duction postier', 'ufsc-clubs' ); ?></label>
         </div>
-        <div class="ufsc-field ufsc-field-identifiant-laposte" style="display:none;">
+        <div class="ufsc-field ufsc-field-identifiant-laposte ufsc-field-full" style="display:none;">
             <label for="identifiant_laposte"><?php esc_html_e( 'Identifiant La Poste', 'ufsc-clubs' ); ?></label>
             <input type="text" id="identifiant_laposte" name="identifiant_laposte" value="<?php echo esc_attr( $licence->identifiant_laposte ?? '' ); ?>" />
         </div>
@@ -57,11 +57,11 @@ include UFSC_CL_DIR . 'templates/partials/notice.php';
         <div class="ufsc-field">
             <label class="ufsc-checkbox"><input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1" <?php checked( $licence->licence_delegataire ?? 0, 1 ); ?> /> <?php esc_html_e( 'Licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
         </div>
-        <div class="ufsc-field ufsc-field-numero-delegataire" style="display:none;">
+        <div class="ufsc-field ufsc-field-numero-delegataire ufsc-field-full" style="display:none;">
             <label for="numero_licence_delegataire"><?php esc_html_e( 'Num\u00e9ro de licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
             <input type="text" id="numero_licence_delegataire" name="numero_licence_delegataire" value="<?php echo esc_attr( $licence->numero_licence_delegataire ?? '' ); ?>" />
         </div>
-        <div class="ufsc-field">
+        <div class="ufsc-field ufsc-field-full">
             <label for="note"><?php esc_html_e( 'Note', 'ufsc-clubs' ); ?></label>
             <textarea id="note" name="note" rows="3"><?php echo esc_textarea( $licence->note ?? '' ); ?></textarea>
         </div>


### PR DESCRIPTION
## Summary
- limit club avatars to 220px on desktop and 140px on mobile with `object-fit: cover`
- show club documents in two columns on tablet/desktop
- redesign licence form and list: responsive two-column grid and table with status/payment badges, with DISTINCT queries to avoid duplicates

## Testing
- `composer phpcs` *(fails: phpcs: not found)*
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca49c3e04832bb06a3c83e0a6145e