### PR TITLE
Ensure stats arrays default to zero

### DIFF
--- a/includes/front/class-ufsc-stats.php
+++ b/includes/front/class-ufsc-stats.php
@@ -203,6 +203,9 @@ class UFSC_Stats {
     public static function get_club_stats( $club_id, $season = null ) {
         global $wpdb;
 
+        $club_id = (int) $club_id;
+        $season  = null !== $season ? (int) $season : null;
+
         if ( function_exists( 'ufsc_get_licences_table' ) ) {
             $table = ufsc_get_licences_table();
         } else {
@@ -210,13 +213,13 @@ class UFSC_Stats {
         }
 
         $where_clauses = array( 'club_id = %d' );
-        $where_values  = array( $club_id );
+        $where_values  = array( (int) $club_id );
         if ( null !== $season ) {
             // Season column optional; only add if exists.
             $columns = method_exists( $wpdb, 'get_col' ) ? $wpdb->get_col( "DESCRIBE `{$table}`" ) : array();
             if ( in_array( 'season', $columns, true ) ) {
                 $where_clauses[] = 'season = %d';
-                $where_values[]  = $season;
+                $where_values[]  = (int) $season;
             }
         }
 
@@ -282,7 +285,14 @@ class UFSC_Stats {
 
         $quota_remaining = max( 0, 10 - $included_active );
 
-        return array(
+        $defaults = array(
+            'paid_licences'      => 0,
+            'validated_licences' => 0,
+            'paid'               => 0,
+            'validated'          => 0,
+        );
+
+        $stats = array(
             'total_licences'     => $total_licences,
             'paid_licences'      => $paid,
             'validated_licences' => $validated,
@@ -296,5 +306,7 @@ class UFSC_Stats {
             'by_practice'        => $practice_counts,
             'by_birth_year'      => $birth_year_counts,
         );
+
+        return array_merge( $defaults, $stats );
     }
 }

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -607,11 +607,14 @@ class UFSC_Frontend_Shortcodes {
 
         if ( empty( $atts['season'] ) ) {
             $wc_settings   = ufsc_get_woocommerce_settings();
-            $atts['season'] = isset( $wc_settings['season'] ) ? $wc_settings['season'] : '';
+            $atts['season'] = isset( $wc_settings['season'] ) ? (int) $wc_settings['season'] : 0;
         }
 
+        $club_id = (int) $atts['club_id'];
+        $season  = isset( $atts['season'] ) ? (int) $atts['season'] : 0;
+
         $stats = wp_parse_args(
-            self::get_club_stats( $atts['club_id'], $atts['season'] ),
+            self::get_club_stats( $club_id, $season ),
             array(
                 'total_licences'     => 0,
                 'paid_licences'      => 0,
@@ -1768,6 +1771,8 @@ class UFSC_Frontend_Shortcodes {
      * Get club statistics
      */
     private static function get_club_stats( $club_id, $season ) {
+        $club_id   = (int) $club_id;
+        $season    = (int) $season;
         $cache_key = "ufsc_stats_{$club_id}_{$season}";
         $stats     = get_transient( $cache_key );
 


### PR DESCRIPTION
## Summary
- Cast IDs and seasons in club stats lookups
- Prefill club stats with paid and validated counts defaulting to 0

## Testing
- `composer phpcs` *(fails: phpcs: not found)*
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*
- `phpunit tests/test-ufsc-stats.php` *(fails: command not found: phpunit)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca4999ccc832b86f3d48610e464bb