### PR TITLE
Redirect saving actions to dashboard tabs

### DIFF
--- a/assets/frontend/js/frontend.js
+++ b/assets/frontend/js/frontend.js
@@ -94,14 +94,10 @@ jQuery(document).ready(function($) {
 
         // Handle URL hash or tab parameter on page load
         var params = new URLSearchParams(window.location.search);
-        var tab = params.get('tab');
-        var hash = window.location.hash.substring(1);
-        var target = tab || hash;
+        var target = params.get('tab') || window.location.hash.substring(1);
         if (target && $('.ufsc-nav-btn[data-section="' + target + '"]').length) {
-            $('.ufsc-nav-btn[data-section="' + target + '"]').click();
-
-            activateTab($(this).data('section'), true);
-        });
+            activateTab(target, true, false);
+        }
 
         $tabs.on('keydown', function(e) {
             var index = $tabs.index(this);

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -614,15 +614,15 @@ class UFSC_Unified_Handlers {
             }
         }
 
-        $redirect_url = esc_url_raw( add_query_arg(
-            array(
-                'updated'    => 1,
-                'licence_id' => $new_id,
-            ),
-            wp_get_referer()
-        ) );
+        $dashboard_page = get_option( 'ufsc_dashboard_page' );
+        if ( $dashboard_page ) {
+            $dashboard_url = get_permalink( $dashboard_page );
+        } else {
+            $dashboard_url = home_url( '/club-dashboard/' );
+        }
+
         set_transient( 'ufsc_admin_save', time(), 10 );
-        UFSC_Licence_Form::redirect_with_notice( $redirect_url, 'licence_saved' );
+        UFSC_Licence_Form::redirect_with_notice( $dashboard_url, 'licence_saved', 'licences' );
     }
 
     /**

--- a/includes/front/class-ufsc-media.php
+++ b/includes/front/class-ufsc-media.php
@@ -104,8 +104,15 @@ class UFSC_Media {
             wp_die( $result->get_error_message() );
         }
 
-        $redirect = ufsc_redirect_with_notice( wp_get_referer(), 'profile_photo_updated' );
-        wp_safe_redirect( $redirect );
+        $dashboard_page = get_option( 'ufsc_dashboard_page' );
+        if ( $dashboard_page ) {
+            $dashboard_url = get_permalink( $dashboard_page );
+        } else {
+            $dashboard_url = home_url( '/club-dashboard/' );
+        }
+
+        $redirect = add_query_arg( 'tab', 'club', $dashboard_url );
+        wp_safe_redirect( ufsc_redirect_with_notice( $redirect, 'profile_photo_updated' ) );
         exit;
     }
 

--- a/includes/frontend/class-auth-shortcodes.php
+++ b/includes/frontend/class-auth-shortcodes.php
@@ -308,10 +308,11 @@ class UFSC_Auth_Shortcodes {
                 return admin_url( 'admin.php?page=ufsc-gestion' );
             }
             
-            // Club managers go to club dashboard
+            // Club managers go to club dashboard, licences tab
             $club_id = ufsc_get_user_club_id( $user->ID );
             if ( $club_id ) {
-                return home_url( '/club-dashboard/' );
+                $dashboard_url = home_url( '/club-dashboard/' );
+                return add_query_arg( 'tab', 'licences', $dashboard_url );
             }
             
             // Regular users go to homepage


### PR DESCRIPTION
## Summary
- Redirect club saves to dashboard with club tab and notice
- Redirect licence and profile photo uploads to dashboard tabs
- Send club managers to licences tab after login
- Activate dashboard tab based on URL param in frontend JS

## Testing
- `composer install` (fails: CONNECT tunnel failed)
- `composer phpcs` (fails: phpcs: not found)
- `composer phpstan` (fails: phpstan: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bca495da58832b80fafa8ec11a8deb