### PR TITLE
Limit grid columns for licence form and span long fields

### DIFF
--- a/assets/css/ufsc-front.css
+++ b/assets/css/ufsc-front.css
@@ -40,6 +40,21 @@
         grid-template-columns: repeat(3, 1fr);
     }
 }
+
+/* Specific grid layout for add licence section */
+.ufsc-add-licence-section .ufsc-grid{
+    grid-template-columns: 1fr;
+}
+@media (min-width: var(--tablet)) {
+    .ufsc-add-licence-section .ufsc-grid{
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+@media (min-width: var(--desktop)) {
+    .ufsc-add-licence-section .ufsc-grid{
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
 .ufsc-front .ufsc-grid.-wide{
     grid-template-columns: 1fr;
 }

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1238,7 +1238,7 @@ class UFSC_Frontend_Shortcodes {
                     <div class="ufsc-card ufsc-form-section">
                         <h4><?php esc_html_e( 'Adresse', 'ufsc-clubs' ); ?></h4>
                         
-                        <div class="ufsc-field">
+                        <div class="ufsc-field ufsc-grid-full">
                             <label for="adresse"><?php esc_html_e( 'Adresse complète', 'ufsc-clubs' ); ?></label>
                             <textarea id="adresse" name="adresse" rows="3"><?php echo esc_textarea( $form_data['adresse'] ?? '' ); ?></textarea>
                         </div>
@@ -1414,7 +1414,7 @@ class UFSC_Frontend_Shortcodes {
                             </label>
                         </div>
 
-                        <div class="ufsc-form-field">
+                        <div class="ufsc-form-field ufsc-grid-full">
                             <label for="note"><?php esc_html_e( 'Note', 'ufsc-clubs' ); ?></label>
                             <textarea id="note" name="note" rows="3"></textarea>
                         </div>


### PR DESCRIPTION
## Summary
- Restrict `ufsc-add-licence-section` grids to two columns at tablet and desktop sizes
- Allow long fields like address and note to span across the full grid width

## Testing
- `composer phpcs` *(fails: phpcs not found)*
- `composer phpstan` *(fails: phpstan not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb999bf18832baf0908403f7c6e82