### PR TITLE
Exclude deleted licences from club quota

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1947,7 +1947,7 @@ class UFSC_Frontend_Shortcodes {
         ) );
 
         $used = (int) $wpdb->get_var( $wpdb->prepare(
-            "SELECT COUNT(*) FROM `{$licences_table}` WHERE club_id = %d",
+            "SELECT COUNT(*) FROM `{$licences_table}` WHERE club_id = %d AND deleted_at IS NULL",
             $club_id
         ) );
 


### PR DESCRIPTION
## Summary
- count only non-deleted licences when calculating club quota

## Testing
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -d display_errors=1 -r 'define("ABSPATH","\"); require "includes/frontend/class-frontend-shortcodes.php"; class UFSC_SQL { public static function get_settings(){ return ["table_clubs"=>"clubs","table_licences"=>"licences"]; } } function ufsc_club_col($col){ return $col; } $wpdb = new class { public $last_query=""; public function prepare($q,...$a){$q=str_replace(["%d","%s"],"%s",$q);return vsprintf($q,$a);} public function get_var($q){$this->last_query=$q; if(strpos($q,"quota_licences")!==false){return 10;} return 6;} }; $GLOBALS["wpdb"]=$wpdb; $ref=new ReflectionClass("UFSC_Frontend_Shortcodes"); $method=$ref->getMethod("get_club_quota_info"); $method->setAccessible(true); $result=$method->invoke(null,1); var_export($result); echo "\nQuery: {$wpdb->last_query}\n";'`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer global require phpunit/phpunit` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd54295eec832b8e7145919eda9e9c