### PR TITLE
Allow contact-only licence edits after validation

### DIFF
--- a/assets/js/ufsc-license-form.js
+++ b/assets/js/ufsc-license-form.js
@@ -8,6 +8,7 @@
 
     // Initialize when document is ready
     $(document).ready(function() {
+        applyLicenceStatus();
         initLicenseFormValidation();
         initClubRegionSync();
 
@@ -21,7 +22,7 @@
      * Initialize form validation for license forms
      */
     function initLicenseFormValidation() {
-        const form = $('form[action*="ufsc_sql_save_licence"]');
+        const form = $('.ufsc-licence-form');
         if (form.length === 0) return;
 
         // Real-time validation on blur
@@ -53,6 +54,9 @@
      */
     function validateEmail() {
         const input = $(this);
+        if (input.prop('disabled') || input.prop('readonly')) {
+            return true;
+        }
         const email = input.val().trim();
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -71,6 +75,9 @@
      */
     function validatePhone() {
         const input = $(this);
+        if (input.prop('disabled') || input.prop('readonly')) {
+            return true;
+        }
         const phone = input.val().trim();
         // French phone number regex (flexible)
         const phoneRegex = /^(?:(?:\+|00)33[\s.-]{0,3}(?:\(0\)[\s.-]{0,3})?|0)[1-9](?:[\s.-]?\d{2}){4}$/;
@@ -90,6 +97,9 @@
      */
     function validateDate() {
         const input = $(this);
+        if (input.prop('disabled') || input.prop('readonly')) {
+            return true;
+        }
         const date = input.val();
 
         clearFieldError(input);
@@ -128,6 +138,9 @@
      */
     function validateRequired() {
         const input = $(this);
+        if (input.prop('disabled') || input.prop('readonly')) {
+            return true;
+        }
         const value = input.val().trim();
 
         clearFieldError(input);
@@ -276,6 +289,15 @@
                 this.checked = false;
             }
         });
+    }
+
+    function applyLicenceStatus() {
+        const form = $('.ufsc-licence-form');
+        if (!form.length) return;
+        const status = form.data('licence-status') || 'draft';
+        if (status !== 'draft') {
+            form.find(':input').not('#email, #tel_fixe, #tel_mobile, [type="hidden"], button').prop('readonly', true).prop('disabled', true);
+        }
     }
 
     /**

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -388,6 +388,7 @@ class UFSC_Unified_Handlers {
             self::store_form_and_redirect( $_POST, array( __( 'Aucun club associé à votre compte', 'ufsc-clubs' ) ), $licence_id );
         }
 
+        $licence_status = 'draft';
         if ( $licence_id > 0 ) {
             $licence_status = self::get_licence_status( $licence_id, $club_id );
             if ( ! $licence_status ) {
@@ -405,6 +406,10 @@ class UFSC_Unified_Handlers {
             self::store_form_and_redirect( $_POST, array( $data->get_error_message() ), $licence_id );
         }
 
+        if ( 'draft' !== $licence_status ) {
+            $allowed = array( 'email', 'tel_fixe', 'tel_mobile' );
+            $data    = array_intersect_key( $data, array_flip( $allowed ) );
+        }
 
         $result = self::save_licence_data( $licence_id, $club_id, $data );
         if ( is_wp_error( $result ) ) {

--- a/includes/front/class-ufsc-licences-table.php
+++ b/includes/front/class-ufsc-licences-table.php
@@ -71,8 +71,12 @@ class UFSC_Licences_Table {
                             $expiration = mysql2date( get_option( 'date_format' ), $licence->date_expiration );
                         }
                         $actions  = '<a class="ufsc-action" href="' . esc_url( add_query_arg( 'view_licence', $licence->id ?? 0 ) ) . '">' . esc_html__( 'Consulter', 'ufsc-clubs' ) . '</a>';
-                        if ( in_array( $licence->statut ?? '', array( 'draft', 'pending' ), true ) ) {
+                        $can_edit = in_array( $licence->statut ?? '', array( 'draft', 'pending' ), true ) || UFSC_Badges::is_active_licence_status( $licence->statut ?? '' );
+                        if ( $can_edit ) {
                             $actions .= ' <a class="ufsc-action" href="' . esc_url( add_query_arg( 'edit_licence', $licence->id ?? 0 ) ) . '">' . esc_html__( 'Modifier', 'ufsc-clubs' ) . '</a>';
+                            if ( 'draft' !== ( $licence->statut ?? 'draft' ) && 'pending' !== ( $licence->statut ?? 'draft' ) ) {
+                                $actions .= ' <span class="ufsc-edit-note">' . esc_html__( 'coordonnées uniquement', 'ufsc-clubs' ) . '</span>';
+                            }
                         }
                         ?>
                         <tr>
@@ -219,9 +223,13 @@ class UFSC_Licences_Table {
 
             $actions  = '<div class="ufsc-actions">';
             $actions .= '<a class="ufsc-action" href="' . esc_url( add_query_arg( array( 'ufsc_action' => 'view', 'licence_id' => $row->id ) ) ) . '">' . esc_html__( 'Consulter', 'ufsc-clubs' ) . '</a>';
-            if ( empty( $row->statut ) || ! UFSC_Badges::is_active_licence_status( $row->statut ) ) {
+            $can_edit = empty( $row->statut ) || UFSC_Badges::is_active_licence_status( $row->statut ) || in_array( $row->statut, array( 'draft', 'pending' ), true );
+            if ( $can_edit ) {
                 $actions .= ' <a class="ufsc-action" href="' . esc_url( add_query_arg( array( 'ufsc_action' => 'edit', 'licence_id' => $row->id ) ) ) . '">' . esc_html__( 'Modifier', 'ufsc-clubs' ) . '</a>';
-                if ( current_user_can( 'manage_options' ) ) {
+                if ( UFSC_Badges::is_active_licence_status( $row->statut ) && ! in_array( $row->statut, array( 'draft', 'pending' ), true ) ) {
+                    $actions .= ' <span class="ufsc-edit-note">' . esc_html__( 'coordonnées uniquement', 'ufsc-clubs' ) . '</span>';
+                }
+                if ( ( empty( $row->statut ) || ! UFSC_Badges::is_active_licence_status( $row->statut ) ) && current_user_can( 'manage_options' ) ) {
                     $actions .= '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" class="ufsc-inline-form">';
                     $actions .= '<input type="hidden" name="action" value="ufsc_delete_licence" />';
                     $actions .= '<input type="hidden" name="licence_id" value="' . intval( $row->id ) . '" />';

--- a/templates/frontend/licence-form.php
+++ b/templates/frontend/licence-form.php
@@ -5,35 +5,51 @@ $wc_settings    = ufsc_get_woocommerce_settings();
 $included_limit = isset( $wc_settings['included_licenses'] ) ? (int) $wc_settings['included_licenses'] : 10;
 $included_count = UFSC_Licence_Form::get_included_count();
 $club_id       = ufsc_get_user_club_id( get_current_user_id() );
+$licence_status = $licence->statut ?? 'draft';
+$is_restricted  = 'draft' !== $licence_status;
+$lock_attr      = $is_restricted ? ' readonly disabled' : '';
+$lock_only_dis  = $is_restricted ? ' disabled' : '';
 ?>
 <div class="ufsc-front ufsc-full">
-<form method="post" class="ufsc-licence-form cart">
+<form method="post" class="ufsc-licence-form cart" data-licence-status="<?php echo esc_attr( $licence_status ); ?>">
     <?php wp_nonce_field( 'ufsc_save_licence' ); ?>
     <input type="hidden" name="licence_id" value="<?php echo isset( $licence->id ) ? intval( $licence->id ) : 0; ?>" />
     <input type="hidden" name="ufsc_club_id" value="<?php echo esc_attr( $club_id ); ?>" />
     <input type="hidden" id="included_count" value="<?php echo esc_attr( $included_count ); ?>" />
     <input type="hidden" id="included_limit" value="<?php echo esc_attr( $included_limit ); ?>" />
 
+    <?php if ( $is_restricted ) : ?>
+        <p class="ufsc-edit-help"><?php esc_html_e( 'Seules les coordonnées (email et téléphone) peuvent être modifiées.', 'ufsc-clubs' ); ?></p>
+    <?php endif; ?>
+
     <div class="ufsc-grid">
         <div class="ufsc-field">
             <label for="prenom"><?php esc_html_e( 'Pr\u00e9nom', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="prenom" name="prenom" value="<?php echo esc_attr( $licence->prenom ?? '' ); ?>" />
+            <input type="text" id="prenom" name="prenom" value="<?php echo esc_attr( $licence->prenom ?? '' ); ?>"<?php echo $lock_attr; ?> />
         </div>
         <div class="ufsc-field">
             <label for="nom"><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="nom" name="nom" value="<?php echo esc_attr( $licence->nom ?? '' ); ?>" />
+            <input type="text" id="nom" name="nom" value="<?php echo esc_attr( $licence->nom ?? '' ); ?>"<?php echo $lock_attr; ?> />
         </div>
         <div class="ufsc-field ufsc-field-full">
             <label for="email">Email</label>
             <input type="email" id="email" name="email" value="<?php echo esc_attr( $licence->email ?? '' ); ?>" />
         </div>
         <div class="ufsc-field">
+            <label for="tel_fixe"><?php esc_html_e( 'T\u00e9l\u00e9phone fixe', 'ufsc-clubs' ); ?></label>
+            <input type="tel" id="tel_fixe" name="tel_fixe" value="<?php echo esc_attr( $licence->tel_fixe ?? '' ); ?>" />
+        </div>
+        <div class="ufsc-field">
+            <label for="tel_mobile"><?php esc_html_e( 'T\u00e9l\u00e9phone mobile', 'ufsc-clubs' ); ?></label>
+            <input type="tel" id="tel_mobile" name="tel_mobile" value="<?php echo esc_attr( $licence->tel_mobile ?? '' ); ?>" />
+        </div>
+        <div class="ufsc-field">
             <label for="date_naissance"><?php esc_html_e( 'Date de naissance', 'ufsc-clubs' ); ?></label>
-            <input type="date" id="date_naissance" name="date_naissance" value="<?php echo esc_attr( $licence->date_naissance ?? '' ); ?>" />
+            <input type="date" id="date_naissance" name="date_naissance" value="<?php echo esc_attr( $licence->date_naissance ?? '' ); ?>"<?php echo $lock_attr; ?> />
         </div>
         <div class="ufsc-field">
             <label for="role"><?php esc_html_e( 'R\u00f4le', 'ufsc-clubs' ); ?></label>
-            <select id="role" name="role">
+            <select id="role" name="role"<?php echo $lock_only_dis; ?>>
                 <option value=""<?php selected( $licence->role ?? '', '' ); ?>><?php esc_html_e( 'S\u00e9lectionner', 'ufsc-clubs' ); ?></option>
                 <option value="president"<?php selected( $licence->role ?? '', 'president' ); ?>><?php esc_html_e( 'Pr\u00e9sident', 'ufsc-clubs' ); ?></option>
                 <option value="secretaire"<?php selected( $licence->role ?? '', 'secretaire' ); ?>><?php esc_html_e( 'Secr\u00e9taire', 'ufsc-clubs' ); ?></option>
@@ -43,28 +59,28 @@ $club_id       = ufsc_get_user_club_id( get_current_user_id() );
             </select>
         </div>
         <div class="ufsc-field">
-            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_postier" name="reduction_postier" value="1" <?php checked( $licence->reduction_postier ?? 0, 1 ); ?> /> <?php esc_html_e( 'R\u00e9duction postier', 'ufsc-clubs' ); ?></label>
+            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_postier" name="reduction_postier" value="1" <?php checked( $licence->reduction_postier ?? 0, 1 ); ?><?php echo $lock_only_dis; ?> /> <?php esc_html_e( 'R\u00e9duction postier', 'ufsc-clubs' ); ?></label>
         </div>
         <div class="ufsc-field ufsc-field-identifiant-laposte ufsc-field-full" style="display:none;">
             <label for="identifiant_laposte"><?php esc_html_e( 'Identifiant La Poste', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="identifiant_laposte" name="identifiant_laposte" value="<?php echo esc_attr( $licence->identifiant_laposte ?? '' ); ?>" />
+            <input type="text" id="identifiant_laposte" name="identifiant_laposte" value="<?php echo esc_attr( $licence->identifiant_laposte ?? '' ); ?>"<?php echo $lock_attr; ?> />
         </div>
         <div class="ufsc-field">
-            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_benevole" name="reduction_benevole" value="1" <?php checked( $licence->reduction_benevole ?? 0, 1 ); ?> /> <?php esc_html_e( 'R\u00e9duction b\u00e9n\u00e9vole', 'ufsc-clubs' ); ?></label>
+            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_benevole" name="reduction_benevole" value="1" <?php checked( $licence->reduction_benevole ?? 0, 1 ); ?><?php echo $lock_only_dis; ?> /> <?php esc_html_e( 'R\u00e9duction b\u00e9n\u00e9vole', 'ufsc-clubs' ); ?></label>
         </div>
         <div class="ufsc-field">
-            <label class="ufsc-checkbox"><input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1" <?php checked( $licence->licence_delegataire ?? 0, 1 ); ?> /> <?php esc_html_e( 'Licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
+            <label class="ufsc-checkbox"><input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1" <?php checked( $licence->licence_delegataire ?? 0, 1 ); ?><?php echo $lock_only_dis; ?> /> <?php esc_html_e( 'Licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
         </div>
         <div class="ufsc-field ufsc-field-numero-delegataire ufsc-field-full" style="display:none;">
             <label for="numero_licence_delegataire"><?php esc_html_e( 'Num\u00e9ro de licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="numero_licence_delegataire" name="numero_licence_delegataire" value="<?php echo esc_attr( $licence->numero_licence_delegataire ?? '' ); ?>" />
+            <input type="text" id="numero_licence_delegataire" name="numero_licence_delegataire" value="<?php echo esc_attr( $licence->numero_licence_delegataire ?? '' ); ?>"<?php echo $lock_attr; ?> />
         </div>
         <div class="ufsc-field ufsc-field-full">
             <label for="note"><?php esc_html_e( 'Note', 'ufsc-clubs' ); ?></label>
-            <textarea id="note" name="note" rows="3"><?php echo esc_textarea( $licence->note ?? '' ); ?></textarea>
+            <textarea id="note" name="note" rows="3"<?php echo $lock_attr; ?>><?php echo esc_textarea( $licence->note ?? '' ); ?></textarea>
         </div>
         <div class="ufsc-field">
-            <label class="ufsc-checkbox"><input type="checkbox" id="is_included" name="is_included" value="1" <?php checked( $licence->is_included ?? 0, 1 ); ?> /> <?php esc_html_e( 'Inclure dans quota', 'ufsc-clubs' ); ?></label>
+            <label class="ufsc-checkbox"><input type="checkbox" id="is_included" name="is_included" value="1" <?php checked( $licence->is_included ?? 0, 1 ); ?><?php echo $lock_only_dis; ?> /> <?php esc_html_e( 'Inclure dans quota', 'ufsc-clubs' ); ?></label>
         </div>
     </div>
     <div class="ufsc-form-actions">


### PR DESCRIPTION
## Summary
- limit non-draft licence updates to email and phone fields
- permit editing validated licences from frontend table with notice
- lock most fields on licence form and handle status in JS

## Testing
- ⚠️ `composer phpcs` *(phpcs: not found)*
- ⚠️ `composer phpstan` *(phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc4272418832ba4a1b0aca0174102