### PR TITLE
Use plugin directory constant for asset paths

### DIFF
--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -34,8 +34,8 @@ class UFSC_Frontend_Shortcodes {
 
         $content = $post->post_content;
 
-        $css_path = UFSC_CL_PATH . 'assets/css/ufsc-front.css';
-        $js_path  = UFSC_CL_PATH . 'assets/js/ufsc-front.js';
+        $css_path = UFSC_CL_DIR . 'assets/css/ufsc-front.css';
+        $js_path  = UFSC_CL_DIR . 'assets/js/ufsc-front.js';
 
         $css_version = file_exists( $css_path ) ? filemtime( $css_path ) : UFSC_CL_VERSION;
         $js_version  = file_exists( $js_path ) ? filemtime( $js_path ) : UFSC_CL_VERSION;


### PR DESCRIPTION
## Summary
- replace UFSC_CL_PATH with UFSC_CL_DIR for front-end asset paths

## Testing
- `composer install` (failed: CONNECT tunnel failed, response 403)
- `composer phpcs` (failed: command not found)
- `composer phpstan` (failed: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68bdcc0b4bac832ba1226b3708b13435