### PR TITLE
Validate attestation download request parameters

### DIFF
--- a/includes/core/class-ufsc-pdf-attestations.php
+++ b/includes/core/class-ufsc-pdf-attestations.php
@@ -406,10 +406,15 @@ class UFSC_PDF_Attestations {
      * Handle secure download
      */
     public static function handle_secure_download() {
-        $attestation_id = intval( $_GET['id'] );
-        
-        if ( ! wp_verify_nonce( $_GET['_wpnonce'], 'ufsc_download_' . $attestation_id ) ) {
-            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        if ( ! isset( $_GET['id'], $_GET['_wpnonce'] ) ) {
+            wp_die( __( 'Paramètres manquants.', 'ufsc-clubs' ) );
+        }
+
+        $attestation_id = absint( $_GET['id'] );
+        $nonce          = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
+
+        if ( ! wp_verify_nonce( $nonce, 'ufsc_download_' . $attestation_id ) ) {
+            wp_die( __( 'Nonce de sécurité invalide.', 'ufsc-clubs' ) );
         }
 
         // Get attestation info


### PR DESCRIPTION
## Summary
- validate presence of attestation id and nonce before download
- sanitize and cast request parameters safely
- reject invalid or missing download parameters with clear errors

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde462055c832ba61eb74ea98f39a5