### PR TITLE
Sanitize page parameter for admin redirect

### DIFF
--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -4,7 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 class UFSC_CL_Admin_Menu {
     public static function register(){
         // Menu principal unifié UFSC
-        if ( isset( $_GET['page'] ) && $_GET['page'] === 'ufsc-attestations' ) {
+        $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+        if ( 'ufsc-attestations' === $page ) {
             wp_safe_redirect( admin_url( 'admin.php?page=ufsc-gestion' ) );
             exit;
         }


### PR DESCRIPTION
## Summary
- Sanitize `page` query parameter using `sanitize_key( wp_unslash() )` before redirect comparison in admin menu registration

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpcs --standard=PSR12 includes/admin/class-admin-menu.php` *(fails: ./vendor/bin/phpcs: No such file or directory)*
- `./vendor/bin/phpstan analyse --no-progress` *(fails: ./vendor/bin/phpstan: No such file or directory)*
- `php -l includes/admin/class-admin-menu.php`

------
https://chatgpt.com/codex/tasks/task_e_68bde45f838c832bbe9094085709cadc