### PR TITLE
Sanitize ufsc_notice parameter

### DIFF
--- a/templates/partials/notice.php
+++ b/templates/partials/notice.php
@@ -1,5 +1,7 @@
-<?php if ( ! empty( $_GET['ufsc_notice'] ) ): ?>
+<?php if ( ! empty( $_GET['ufsc_notice'] ) ) :
+    $ufsc_notice = sanitize_text_field( wp_unslash( $_GET['ufsc_notice'] ) );
+    ?>
   <div class="notice notice-info ufsc-notice">
-    <?php echo esc_html( ucfirst( str_replace( '_', ' ', (string) ( $_GET['ufsc_notice'] ?? '' ) ) ) ); ?>
+    <?php echo esc_html( ucfirst( str_replace( '_', ' ', $ufsc_notice ) ) ); ?>
   </div>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- sanitize and unslash `ufsc_notice` query parameter before rendering

## Testing
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde45dae5c832ba72440b1516fcb32