### PR TITLE
Hook frontend asset registration to wp_enqueue_scripts

### DIFF
--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -72,7 +72,7 @@ class UFSC_CL_Admin_Menu {
     }
     /**
      * Register frontend assets so they can be enqueued later.
-     * This runs on the `init` hook.
+     * This runs on the `wp_enqueue_scripts` hook.
      */
     public static function register_front(){
         wp_register_style( 'ufsc-frontend', UFSC_CL_URL.'assets/frontend/css/frontend.css', array(), UFSC_CL_VERSION );
@@ -574,5 +574,5 @@ class UFSC_CL_Admin_Menu {
     }
 }
 
-// Register frontend assets on init so they can be enqueued later.
-add_action( 'init', array( 'UFSC_CL_Admin_Menu', 'register_front' ) );
+// Register frontend assets during wp_enqueue_scripts so they can be enqueued later.
+add_action( 'wp_enqueue_scripts', array( 'UFSC_CL_Admin_Menu', 'register_front' ) );


### PR DESCRIPTION
## Summary
- hook frontend asset registration to `wp_enqueue_scripts`
- document `register_front` usage with updated hook reference

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde45afdf4832b96602fd90651d892