### PR TITLE
refactor: replace manage_options with custom capability

### DIFF
--- a/inc/admin/menu.php
+++ b/inc/admin/menu.php
@@ -14,7 +14,7 @@ function ufsc_register_admin_menu() {
     add_menu_page(
         __( 'UFSC Gestion', 'ufsc-clubs' ),
         __( 'UFSC Gestion', 'ufsc-clubs' ),
-        'manage_options',
+        'ufsc_manage',
         'ufsc-gestion',
         'ufsc_render_dashboard_page',
         'dashicons-groups',
@@ -26,7 +26,7 @@ function ufsc_register_admin_menu() {
         'ufsc-gestion',
         __( 'Tableau de bord', 'ufsc-clubs' ),
         __( 'Tableau de bord', 'ufsc-clubs' ),
-        'manage_options',
+        'ufsc_manage',
         'ufsc-gestion',
         'ufsc_render_dashboard_page'
     );
@@ -36,7 +36,7 @@ function ufsc_register_admin_menu() {
         'ufsc-gestion',
         __( 'Clubs', 'ufsc-clubs' ),
         __( 'Clubs', 'ufsc-clubs' ),
-        'manage_options',
+        'ufsc_manage',
         'ufsc-gestion-clubs',
         'ufsc_render_clubs_page'
     );
@@ -46,7 +46,7 @@ function ufsc_register_admin_menu() {
         'ufsc-gestion',
         __( 'Licences', 'ufsc-clubs' ),
         __( 'Licences', 'ufsc-clubs' ),
-        'manage_options',
+        'ufsc_manage',
         'ufsc-gestion-licences',
         'ufsc_render_licences_page'
     );
@@ -56,7 +56,7 @@ function ufsc_register_admin_menu() {
         'ufsc-gestion',
         __( 'Paramètres', 'ufsc-clubs' ),
         __( 'Paramètres', 'ufsc-clubs' ),
-        'manage_options',
+        'ufsc_manage',
         'ufsc-gestion-parametres',
         'ufsc_render_settings_page'
     );
@@ -66,7 +66,7 @@ function ufsc_register_admin_menu() {
         'ufsc-gestion',
         __( 'WooCommerce', 'ufsc-clubs' ),
         __( 'WooCommerce', 'ufsc-clubs' ),
-        'manage_options',
+        'ufsc_manage',
         'ufsc-gestion-woocommerce',
         'ufsc_render_woocommerce_settings_page'
     );

--- a/inc/woocommerce/admin-actions.php
+++ b/inc/woocommerce/admin-actions.php
@@ -230,7 +230,7 @@ function ufsc_handle_admin_send_to_payment() {
     }
 
     // Verify nonce and capabilities
-    if ( ! check_admin_referer( 'ufsc_send_to_payment' ) || ! current_user_can( 'manage_options' ) ) {
+    if ( ! check_admin_referer( 'ufsc_send_to_payment' ) || ! current_user_can( 'ufsc_manage' ) ) {
         wp_die( __( 'Erreur de sécurité', 'ufsc-clubs' ) );
     }
     

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -13,7 +13,7 @@ class UFSC_CL_Admin_Menu {
         add_menu_page(
             __( 'UFSC Gestion', 'ufsc-clubs' ),
             __( 'UFSC Gestion', 'ufsc-clubs' ),
-            'manage_options',
+            'ufsc_manage',
             'ufsc-gestion',
             array( __CLASS__, 'render_dashboard' ),
             'dashicons-groups',
@@ -25,7 +25,7 @@ class UFSC_CL_Admin_Menu {
             'ufsc-gestion',
             __('Clubs','ufsc-clubs'),
             __('Clubs','ufsc-clubs'),
-            'manage_options',
+            'ufsc_manage',
             'ufsc-clubs',
             array( 'UFSC_SQL_Admin', 'render_clubs' )
         );
@@ -34,7 +34,7 @@ class UFSC_CL_Admin_Menu {
             'ufsc-gestion',
             __('Licences','ufsc-clubs'),
             __('Licences','ufsc-clubs'),
-            'manage_options',
+            'ufsc_manage',
             'ufsc-licences',
             array( 'UFSC_SQL_Admin', 'render_licences' )
         );
@@ -43,7 +43,7 @@ class UFSC_CL_Admin_Menu {
             'ufsc-gestion',
             __('Exports/Imports','ufsc-clubs'),
             __('Exports/Imports','ufsc-clubs'),
-            'manage_options',
+            'ufsc_manage',
             'ufsc-exports',
             array( 'UFSC_SQL_Admin', 'render_exports' )
         );
@@ -52,7 +52,7 @@ class UFSC_CL_Admin_Menu {
             'ufsc-gestion',
             __('Réglages','ufsc-clubs'),
             __('Réglages','ufsc-clubs'),
-            'manage_options',
+            'ufsc_manage',
             'ufsc-settings',
             array( 'UFSC_Settings_Page', 'render' )
         );
@@ -97,7 +97,7 @@ class UFSC_CL_Admin_Menu {
         echo '<p>'.esc_html__('Tableau de bord de gestion des clubs et licences sportives UFSC','ufsc-clubs').'</p>';
         echo '</div>';
         // Cache refresh button
-        if (current_user_can('manage_options')) {
+        if (current_user_can('ufsc_manage')) {
             $refresh_url = add_query_arg('ufsc_refresh_cache', '1', admin_url('admin.php?page=ufsc-gestion'));
             $refresh_url = wp_nonce_url($refresh_url, 'ufsc_refresh_cache');
             echo '<a href="'.esc_url($refresh_url).'" class="button" style="color: white; border-color: rgba(255,255,255,0.3);" title="'.esc_attr__('Actualiser les données (cache: 10 min)','ufsc-clubs').'">'.esc_html__('⟳ Actualiser','ufsc-clubs').'</a>';
@@ -106,7 +106,7 @@ class UFSC_CL_Admin_Menu {
         echo '</div>';
         
         // Handle cache refresh
-        if (isset($_GET['ufsc_refresh_cache']) && current_user_can('manage_options')) {
+        if (isset($_GET['ufsc_refresh_cache']) && current_user_can('ufsc_manage')) {
             check_admin_referer('ufsc_refresh_cache');
             delete_transient('ufsc_dashboard_data');
             echo '<div class="notice notice-success is-dismissible"><p>'.esc_html__('Cache du tableau de bord actualisé.','ufsc-clubs').'</p></div>';

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -46,10 +46,10 @@ class UFSC_SQL_Admin {
         // Enregistrer les pages cachées pour les actions directes (mentionnées dans les specs)
         $parent_slug = 'ufsc-gestion';
 
-        add_submenu_page($parent_slug, __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), 'manage_options', 'ufsc-sql-clubs', array(__CLASS__, 'render_clubs'));
-        add_submenu_page($parent_slug, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), 'manage_options', 'ufsc-sql-licences', array(__CLASS__, 'render_licences'));
+        add_submenu_page($parent_slug, __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), 'ufsc_manage', 'ufsc-sql-clubs', array(__CLASS__, 'render_clubs'));
+        add_submenu_page($parent_slug, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), 'ufsc_manage', 'ufsc-sql-licences', array(__CLASS__, 'render_licences'));
         // Alias pour compatibilité avec la spec (licenses vs licences)
-        add_submenu_page($parent_slug, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), 'manage_options', 'ufsc-sql-licenses', array(__CLASS__, 'render_licences'));
+        add_submenu_page($parent_slug, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), 'ufsc_manage', 'ufsc-sql-licenses', array(__CLASS__, 'render_licences'));
 
         remove_submenu_page($parent_slug, 'ufsc-sql-clubs');
         remove_submenu_page($parent_slug, 'ufsc-sql-licences');
@@ -58,10 +58,10 @@ class UFSC_SQL_Admin {
 
     /* ---------------- Menus complets (obsolète - remplacé par menu unifié) ---------------- */
     public static function register_menus(){
-        add_menu_page( __('UFSC – Données (SQL)','ufsc-clubs'), __('UFSC – Données (SQL)','ufsc-clubs'), 'manage_options', 'ufsc-sql', array(__CLASS__,'render_dashboard'), 'dashicons-database', 59 );
-        add_submenu_page( 'ufsc-sql', __('Clubs (SQL)','ufsc-clubs'), __('Clubs (SQL)','ufsc-clubs'), 'manage_options', 'ufsc-sql-clubs', array(__CLASS__,'render_clubs') );
-        add_submenu_page( 'ufsc-sql', __('Licences (SQL)','ufsc-clubs'), __('Licences (SQL)','ufsc-clubs'), 'manage_options', 'ufsc-sql-licences', array(__CLASS__,'render_licences') );
-        add_submenu_page( 'ufsc-sql', __('Réglages (SQL)','ufsc-clubs'), __('Réglages (SQL)','ufsc-clubs'), 'manage_options', 'ufsc-sql-settings', array(__CLASS__,'render_settings') );
+        add_menu_page( __('UFSC – Données (SQL)','ufsc-clubs'), __('UFSC – Données (SQL)','ufsc-clubs'), 'ufsc_manage', 'ufsc-sql', array(__CLASS__,'render_dashboard'), 'dashicons-database', 59 );
+        add_submenu_page( 'ufsc-sql', __('Clubs (SQL)','ufsc-clubs'), __('Clubs (SQL)','ufsc-clubs'), 'ufsc_manage', 'ufsc-sql-clubs', array(__CLASS__,'render_clubs') );
+        add_submenu_page( 'ufsc-sql', __('Licences (SQL)','ufsc-clubs'), __('Licences (SQL)','ufsc-clubs'), 'ufsc_manage', 'ufsc-sql-licences', array(__CLASS__,'render_licences') );
+        add_submenu_page( 'ufsc-sql', __('Réglages (SQL)','ufsc-clubs'), __('Réglages (SQL)','ufsc-clubs'), 'ufsc_manage', 'ufsc-sql-settings', array(__CLASS__,'render_settings') );
     }
 
     /* ---------------- Dashboard ---------------- */
@@ -247,7 +247,7 @@ class UFSC_SQL_Admin {
             echo '</form>';
         } else {
             echo '<p><a class="button" href="'.esc_url( admin_url('admin.php?page=ufsc-sql-clubs') ).'">'.esc_html__('Retour à la liste','ufsc-clubs').'</a>';
-            if ( current_user_can('manage_options') ) {
+            if ( current_user_can('ufsc_manage') ) {
                 echo ' <a class="button button-primary" href="'.esc_url( admin_url('admin.php?page=ufsc-sql-clubs&action=edit&id='.$id) ).'">'.esc_html__('Modifier','ufsc-clubs').'</a>';
             }
             echo '</p>';
@@ -380,7 +380,7 @@ class UFSC_SQL_Admin {
     }
 
     public static function handle_save_club(){
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
 
@@ -693,7 +693,7 @@ class UFSC_SQL_Admin {
         if ( ! current_user_can( 'read' ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
-        if ( ! current_user_can('manage_options') ) wp_die('Accès refusé');
+        if ( ! current_user_can('ufsc_manage') ) wp_die('Accès refusé');
         check_admin_referer('ufsc_sql_delete_club');
 
         global $wpdb;
@@ -1085,7 +1085,7 @@ class UFSC_SQL_Admin {
             echo '</form>';
         } else {
             echo '<p><a class="button" href="'.esc_url( admin_url('admin.php?page=ufsc-sql-licences') ).'">'.esc_html__('Retour à la liste','ufsc-clubs').'</a>';
-            if ( current_user_can('manage_options') ) {
+            if ( current_user_can('ufsc_manage') ) {
                 echo ' <a class="button button-primary" href="'.esc_url( admin_url('admin.php?page=ufsc-sql-licences&action=edit&id='.$id) ).'">'.esc_html__('Modifier','ufsc-clubs').'</a>';
             }
             echo '</p>';
@@ -1097,7 +1097,7 @@ class UFSC_SQL_Admin {
         $type  = $conf[1];
         $readonly_attr = $readonly ? 'readonly disabled' : '';
         $disabled_attr = $readonly ? 'disabled' : '';
-        if ( $readonly && current_user_can( 'manage_options' ) ) {
+        if ( $readonly && current_user_can( 'ufsc_manage' ) ) {
             $readonly_attr = '';
             $disabled_attr = '';
         }
@@ -1206,7 +1206,7 @@ class UFSC_SQL_Admin {
     }
 
     public static function handle_save_licence(){
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
 
@@ -1327,7 +1327,7 @@ class UFSC_SQL_Admin {
         if ( ! current_user_can( 'read' ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
-        if ( ! current_user_can('manage_options') ) wp_die('Accès refusé');
+        if ( ! current_user_can('ufsc_manage') ) wp_die('Accès refusé');
 
         $license_id = isset($_GET['license_id']) ? (int) $_GET['license_id'] : 0;
         check_admin_referer('ufsc_send_license_payment_'.$license_id);
@@ -1571,7 +1571,7 @@ class UFSC_SQL_Admin {
         $user_id = get_current_user_id();
 
         // Verify capability and club ownership before proceeding
-        if ( ! current_user_can( 'manage_options' ) && ufsc_get_user_club_id( $user_id ) !== $club_id ) {
+        if ( ! current_user_can( 'ufsc_manage' ) && ufsc_get_user_club_id( $user_id ) !== $club_id ) {
             set_transient( 'ufsc_error_' . $user_id, __( 'Permissions insuffisantes', 'ufsc-clubs' ), 30 );
             wp_safe_redirect( wp_get_referer() );
             exit; // Abort if user lacks rights on this club
@@ -1604,7 +1604,7 @@ class UFSC_SQL_Admin {
      */
     public static function handle_ajax_update_licence_status() {
         // Check nonce and permissions
-        if (!wp_verify_nonce($_POST['nonce'], 'ufsc_ajax_nonce') || !current_user_can('manage_options')) {
+        if (!wp_verify_nonce($_POST['nonce'], 'ufsc_ajax_nonce') || !current_user_can('ufsc_manage')) {
             wp_die();
         }
 
@@ -1656,7 +1656,7 @@ class UFSC_SQL_Admin {
      */
     public static function handle_ajax_send_to_payment() {
         // Check nonce and permissions
-        if (!wp_verify_nonce($_POST['nonce'], 'ufsc_ajax_nonce') || !current_user_can('manage_options')) {
+        if (!wp_verify_nonce($_POST['nonce'], 'ufsc_ajax_nonce') || !current_user_can('ufsc_manage')) {
             wp_die();
         }
 
@@ -1769,7 +1769,7 @@ class UFSC_SQL_Admin {
         if ( ! current_user_can( 'read' ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('ufsc_manage')) {
             wp_die('Accès refusé');
         }
         check_admin_referer('ufsc_export_data');

--- a/includes/admin/class-ufsc-export-clubs.php
+++ b/includes/admin/class-ufsc-export-clubs.php
@@ -45,7 +45,7 @@ class UFSC_Export_Clubs extends UFSC_Export_Base {
     }
 
     public static function handle_export() {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( 'Accès refusé' );
         }
         check_admin_referer( 'ufsc_export_clubs' );

--- a/includes/admin/class-ufsc-export-licences.php
+++ b/includes/admin/class-ufsc-export-licences.php
@@ -44,7 +44,7 @@ class UFSC_Export_Licences extends UFSC_Export_Base {
     }
 
     public static function handle_export() {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( 'Accès refusé' );
         }
         check_admin_referer( 'ufsc_export_licences' );

--- a/includes/admin/class-user-club-admin.php
+++ b/includes/admin/class-user-club-admin.php
@@ -34,7 +34,7 @@ class UFSC_User_Club_Admin {
             'ufsc-gestion',
             __( 'Associations Utilisateurs', 'ufsc-clubs' ),
             __( 'Associations', 'ufsc-clubs' ),
-            'manage_options',
+            'ufsc_manage',
             'ufsc-user-club-mapping',
             array( __CLASS__, 'render_admin_page' )
         );
@@ -44,7 +44,7 @@ class UFSC_User_Club_Admin {
      * Render admin page
      */
     public static function render_admin_page() {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( __( 'Vous n\'avez pas les permissions pour accéder à cette page.', 'ufsc-clubs' ) );
         }
 
@@ -380,7 +380,7 @@ class UFSC_User_Club_Admin {
 
         check_admin_referer( 'ufsc_associate_user_club', 'ufsc_nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( __( 'Sécurité échouée', 'ufsc-clubs' ) );
         }
 
@@ -412,7 +412,7 @@ class UFSC_User_Club_Admin {
 
         check_admin_referer( 'ufsc_update_club_region', 'ufsc_nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( __( 'Sécurité échouée', 'ufsc-clubs' ) );
         }
 
@@ -438,7 +438,7 @@ class UFSC_User_Club_Admin {
      * AJAX search users
      */
     public static function ajax_search_users() {
-        if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'ufsc_search_users' ) || ! current_user_can( 'manage_options' ) ) {
+        if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'ufsc_search_users' ) || ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( -1 );
         }
 
@@ -470,7 +470,7 @@ class UFSC_User_Club_Admin {
      * AJAX search clubs
      */
     public static function ajax_search_clubs() {
-        if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'ufsc_search_clubs' ) || ! current_user_can( 'manage_options' ) ) {
+        if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'ufsc_search_clubs' ) || ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( -1 );
         }
 

--- a/includes/core/class-permissions.php
+++ b/includes/core/class-permissions.php
@@ -14,7 +14,7 @@ class UFSC_CL_Permissions {
      */
     public static function ufsc_user_can_edit_club( $club_id ) {
         // Admin users can edit any club
-        if ( current_user_can( 'manage_options' ) ) {
+        if ( current_user_can( 'ufsc_manage' ) ) {
             return true;
         }
         

--- a/includes/core/class-ufsc-pdf-attestations.php
+++ b/includes/core/class-ufsc-pdf-attestations.php
@@ -25,7 +25,7 @@ class UFSC_PDF_Attestations {
             'ufsc-dashboard',
             __( 'Attestations PDF', 'ufsc-clubs' ),
             __( 'Attestations PDF', 'ufsc-clubs' ),
-            'manage_options',
+            'ufsc_manage',
             'ufsc-attestations',
             array( __CLASS__, 'render_admin_page' )
         );
@@ -189,7 +189,7 @@ class UFSC_PDF_Attestations {
 
         check_admin_referer( 'ufsc_upload_attestation', 'ufsc_attestation_nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'ufsc_manage' ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
 

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -150,7 +150,7 @@ class UFSC_Unified_Handlers {
         $target_club_id = isset( $_POST['club_id'] ) ? intval( $_POST['club_id'] ) : $managed_club;
 
         // Ensure current user can manage the target club
-        if ( ! current_user_can( 'manage_options' ) && $managed_club !== $target_club_id ) {
+        if ( ! current_user_can( 'ufsc_manage' ) && $managed_club !== $target_club_id ) {
             set_transient( 'ufsc_error_' . $user_id, __( 'Permissions insuffisantes', 'ufsc-clubs' ), 30 );
             wp_safe_redirect( wp_get_referer() );
             exit; // Abort processing when permission check fails
@@ -327,7 +327,7 @@ class UFSC_Unified_Handlers {
         $target_club_id = isset( $_POST['club_id'] ) ? intval( $_POST['club_id'] ) : $managed_club;
 
         // Ensure the current user can manage the requested club
-        if ( ! current_user_can( 'manage_options' ) && $managed_club !== $target_club_id ) {
+        if ( ! current_user_can( 'ufsc_manage' ) && $managed_club !== $target_club_id ) {
             set_transient( 'ufsc_error_' . $user_id, __( 'Permissions insuffisantes', 'ufsc-clubs' ), 30 );
             wp_safe_redirect( wp_get_referer() );
             exit; // Abort if user doesn't manage this club

--- a/includes/core/class-user-club-mapping.php
+++ b/includes/core/class-user-club-mapping.php
@@ -204,7 +204,7 @@ class UFSC_User_Club_Mapping {
      */
     public static function user_can_manage_club( $user_id, $club_id ) {
         // Les administrateurs peuvent tout gérer.
-        if ( current_user_can( 'manage_options' ) ) {
+        if ( current_user_can( 'ufsc_manage' ) ) {
             return true;
         }
 

--- a/includes/front/class-ufsc-licences-table.php
+++ b/includes/front/class-ufsc-licences-table.php
@@ -229,7 +229,7 @@ class UFSC_Licences_Table {
                 if ( UFSC_Badges::is_active_licence_status( $row->statut ) && ! in_array( $row->statut, array( 'draft', 'pending' ), true ) ) {
                     $actions .= ' <span class="ufsc-edit-note">' . esc_html__( 'coordonnées uniquement', 'ufsc-clubs' ) . '</span>';
                 }
-                if ( ( empty( $row->statut ) || ! UFSC_Badges::is_active_licence_status( $row->statut ) ) && current_user_can( 'manage_options' ) ) {
+                if ( ( empty( $row->statut ) || ! UFSC_Badges::is_active_licence_status( $row->statut ) ) && current_user_can( 'ufsc_manage' ) ) {
                     $actions .= '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" class="ufsc-inline-form">';
                     $actions .= '<input type="hidden" name="action" value="ufsc_delete_licence" />';
                     $actions .= '<input type="hidden" name="licence_id" value="' . intval( $row->id ) . '" />';

--- a/includes/frontend/class-auth-shortcodes.php
+++ b/includes/frontend/class-auth-shortcodes.php
@@ -297,7 +297,7 @@ class UFSC_Auth_Shortcodes {
     public static function handle_login_redirect( $redirect_to, $request, $user ) {
         if ( ! is_wp_error( $user ) ) {
             // Admin users go to admin dashboard
-            if ( user_can( $user, 'manage_options' ) ) {
+            if ( user_can( $user, 'ufsc_manage' ) ) {
                 return admin_url( 'admin.php?page=ufsc-gestion' );
             }
             
@@ -319,7 +319,7 @@ class UFSC_Auth_Shortcodes {
      * Get appropriate dashboard URL for user
      */
     private static function get_user_dashboard_url( $user ) {
-        if ( user_can( $user, 'manage_options' ) ) {
+        if ( user_can( $user, 'ufsc_manage' ) ) {
             return admin_url( 'admin.php?page=ufsc-gestion' );
         }
 

--- a/includes/frontend/class-club-form-handler.php
+++ b/includes/frontend/class-club-form-handler.php
@@ -98,7 +98,7 @@ class UFSC_CL_Club_Form_Handler {
             }
             
             // Set default status for new clubs if not admin
-            if ( ! $is_edit && ! current_user_can( 'manage_options' ) ) {
+            if ( ! $is_edit && ! current_user_can( 'ufsc_manage' ) ) {
                 $statuses = UFSC_SQL::statuses();
                 if ( isset( $statuses['en_attente'] ) ) {
                     $data['statut'] = 'en_attente';
@@ -293,7 +293,7 @@ class UFSC_CL_Club_Form_Handler {
                 return self::create_new_user();
                 
             case 'existing':
-                if ( ! current_user_can( 'manage_options' ) ) {
+                if ( ! current_user_can( 'ufsc_manage' ) ) {
                     return new WP_Error( 'permission_denied', __( 'Permissions insuffisantes pour associer un utilisateur existant.', 'ufsc-clubs' ) );
                 }
                 

--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -421,7 +421,7 @@ class UFSC_CL_Club_Form {
                                 <?php esc_html_e( 'Créer un nouveau compte', 'ufsc-clubs' ); ?>
                             </label>
                             
-                            <?php if ( current_user_can( 'manage_options' ) ): ?>
+                            <?php if ( current_user_can( 'ufsc_manage' ) ): ?>
                             <label class="ufsc-radio-label">
                                 <input type="radio" name="user_association" value="existing" />
                                 <?php esc_html_e( 'Associer à un utilisateur existant', 'ufsc-clubs' ); ?>
@@ -449,7 +449,7 @@ class UFSC_CL_Club_Form {
                     </div>
                     
                     <!-- Existing User Fields (Admin only) -->
-                    <?php if ( current_user_can( 'manage_options' ) ): ?>
+                    <?php if ( current_user_can( 'ufsc_manage' ) ): ?>
                     <div id="existing-user-fields" class="ufsc-conditional-section" style="display: none;">
                         <div class="ufsc-field">
                             <label for="existing_user_id" class="ufsc-label"><?php esc_html_e( 'Utilisateur existant', 'ufsc-clubs' ); ?></label>
@@ -471,7 +471,7 @@ class UFSC_CL_Club_Form {
                 <?php endif; ?>
                 
                 <!-- Admin-only fields -->
-                <?php if ( current_user_can( 'manage_options' ) ): ?>
+                <?php if ( current_user_can( 'ufsc_manage' ) ): ?>
                 <fieldset class="ufsc-form-section ufsc-grid">
                     <legend><?php esc_html_e( 'Administration', 'ufsc-clubs' ); ?></legend>
                     

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -831,7 +831,7 @@ class UFSC_Frontend_Shortcodes {
         $club = self::get_club_data( $atts['club_id'] );
 
         $is_validated = self::is_validated_club( $atts['club_id'] );
-        $is_admin = current_user_can( 'manage_options' );
+        $is_admin = current_user_can( 'ufsc_manage' );
 
         if ( ! $club ) {
             return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
@@ -839,7 +839,7 @@ class UFSC_Frontend_Shortcodes {
                    '</div></div>';
         }
         
-        $is_admin = current_user_can( 'manage_options' );
+        $is_admin = current_user_can( 'ufsc_manage' );
         $can_edit = UFSC_CL_Permissions::ufsc_user_can_edit_club( $atts['club_id'] );
         
         if ( ! $can_edit ) {
@@ -1151,7 +1151,7 @@ class UFSC_Frontend_Shortcodes {
 
         $product_id = (int) get_option( 'ufsc_license_product_id' );
         if ( ! $product_id ) {
-            if ( current_user_can( 'manage_options' ) ) {
+            if ( current_user_can( 'ufsc_manage' ) ) {
                 return '<div class="ufsc-front ufsc-full"><div class="ufsc-message ufsc-error">' .
                     esc_html__( 'Produit licence introuvable. Veuillez configurer l\'ID du produit.', 'ufsc-clubs' ) .
                     '</div></div>';
@@ -1988,7 +1988,7 @@ class UFSC_Frontend_Shortcodes {
         }
         
         $clubs_table = ufsc_get_clubs_table();
-        $is_admin = current_user_can( 'manage_options' );
+        $is_admin = current_user_can( 'ufsc_manage' );
         
         // Verify club exists and user has permission
         $club = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$clubs_table}` WHERE id = %d", $club_id ) );
@@ -2074,7 +2074,7 @@ class UFSC_Frontend_Shortcodes {
         $pk = ufsc_club_col( 'id' );
         
         // Determine editable fields based on user role
-        $is_admin = current_user_can( 'manage_options' );
+        $is_admin = current_user_can( 'ufsc_manage' );
         
         if ( $is_admin ) {
             // Admin can edit all fields
@@ -2127,7 +2127,7 @@ class UFSC_Frontend_Shortcodes {
             return array( 'success' => false, 'message' => __( 'Non autorisé', 'ufsc-clubs' ) );
         }
         
-        $is_admin = current_user_can( 'manage_options' );
+        $is_admin = current_user_can( 'ufsc_manage' );
         global $wpdb;
         
         if ( ! function_exists( 'ufsc_get_clubs_table' ) ) {


### PR DESCRIPTION
## Summary
- replace `manage_options` capability with `ufsc_manage` across admin menus and permission checks
- update access checks in front-end and AJAX handlers to use new capability

## Testing
- `composer install` *(fails: curl error 56 while downloading packages.json)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bded2aa3c0832baf06a42031256f29