### PR TITLE
Grant ufsc_manage capability to administrators

### DIFF
--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -82,6 +82,13 @@ require_once UFSC_CL_DIR.'includes/woo/class-ufsc-woo-sync.php';
 register_activation_hook(__FILE__, ['UFSC_DB_Migrations','activate']);
 add_action('plugins_loaded', ['UFSC_DB_Migrations','maybe_upgrade']);
 
+register_activation_hook(__FILE__, function() {
+    if ($r = get_role('administrator')) $r->add_cap('ufsc_manage');
+});
+add_action('admin_init', function() {
+    if ($r = get_role('administrator')) $r->add_cap('ufsc_manage');
+});
+
 UFSC_Export_Clubs::init();
 UFSC_Export_Licences::init();
 


### PR DESCRIPTION
## Summary
- Ensure administrator role receives `ufsc_manage` capability on plugin activation and admin init

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bded27f9b8832bb855e2a83fddc041