### PR TITLE
Redirect legacy admin slugs

### DIFF
--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -1,15 +1,25 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+add_action('admin_init', function () {
+    if (!is_admin()) return;
+    $page = isset($_GET['page']) ? sanitize_key($_GET['page']) : '';
+    $legacy = [
+        'ufsc-gestion-clubs'       => 'ufsc-clubs',
+        'ufsc-gestion-licences'    => 'ufsc-licences',
+        'ufsc-gestion-parametres'  => 'ufsc-settings',
+        'ufsc-gestion-woocommerce' => 'ufsc-settings',
+        'ufsc-attestations'        => 'ufsc-settings',
+    ];
+    if ($page && isset($legacy[$page])) {
+        wp_safe_redirect(admin_url('admin.php?page=' . $legacy[$page]));
+        exit;
+    }
+});
+
 class UFSC_CL_Admin_Menu {
     public static function register(){
         // Menu principal unifié UFSC
-        $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
-        if ( 'ufsc-attestations' === $page ) {
-            wp_safe_redirect( admin_url( 'admin.php?page=ufsc-gestion' ) );
-            exit;
-        }
-
         add_menu_page(
             __( 'UFSC Gestion', 'ufsc-clubs' ),
             __( 'UFSC Gestion', 'ufsc-clubs' ),


### PR DESCRIPTION
## Summary
- Redirect old UFSC admin page slugs using `admin_init`

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bded26df68832ba80e479fd64315f5