### PR TITLE
Refactor admin menu registration

### DIFF
--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -96,7 +96,6 @@ final class UFSC_CL_Bootstrap {
         register_activation_hook( __FILE__, array( $this, 'on_activate' ) );
         register_deactivation_hook( __FILE__, array( $this, 'on_deactivate' ) );
 
-        add_action( 'admin_menu', array( 'UFSC_CL_Admin_Menu', 'register' ) );
         add_action( 'admin_enqueue_scripts', array( 'UFSC_CL_Admin_Menu', 'enqueue_admin' ) );
 
         // SQL Admin CRUD actions (pages cachées mais enregistrées pour les actions directes)


### PR DESCRIPTION
## Summary
- register admin menu using closure with ufsc_manage capability
- add global render callbacks and include exports renderer
- remove obsolete admin_menu hook from bootstrap

## Testing
- `php -l includes/admin/class-admin-menu.php`
- `php -l ufsc-clubs-licences-sql.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bded24d298832b8e9f855d6713e3e7