### PR TITLE
Disable legacy admin menu hook

### DIFF
--- a/inc/admin/menu.php
+++ b/inc/admin/menu.php
@@ -286,5 +286,5 @@ function ufsc_get_licences_count() {
 }
 
 // Register the menu
-add_action( 'admin_menu', 'ufsc_register_admin_menu' );
+// add_action( 'admin_menu', 'ufsc_register_admin_menu' );
 

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -76,7 +76,6 @@ require_once UFSC_CL_DIR.'inc/woocommerce/settings-woocommerce.php';
 require_once UFSC_CL_DIR.'inc/woocommerce/hooks.php';
 require_once UFSC_CL_DIR.'inc/woocommerce/admin-actions.php';
 require_once UFSC_CL_DIR.'inc/woocommerce/cart-integration.php';
-// require_once UFSC_CL_DIR.'inc/admin/menu.php'; // Removed - using unified menu system in includes/admin/class-admin-menu.php
 require_once UFSC_CL_DIR.'includes/woo/class-ufsc-woo-sync.php';
 
 register_activation_hook(__FILE__, ['UFSC_DB_Migrations','activate']);


### PR DESCRIPTION
## Summary
- Comment out legacy `add_action` hook in `inc/admin/menu.php`
- Remove obsolete reference to `inc/admin/menu.php` from plugin bootstrap

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `composer phpcs` *(fails: phpcs not found)*
- `composer phpstan` *(fails: phpstan not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bded234910832b9d6d9c790e461199