### PR TITLE
Refactor settings page function and cleanup admin menu

### DIFF
--- a/inc/admin/menu.php
+++ b/inc/admin/menu.php
@@ -58,7 +58,7 @@ function ufsc_register_admin_menu() {
         __( 'Paramètres', 'ufsc-clubs' ),
         'ufsc_manage',
         'ufsc-gestion-parametres',
-        'ufsc_render_settings_page'
+        'ufsc_render_core_settings_page'
     );
     
     // WooCommerce submenu

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -54,7 +54,7 @@ function ufsc_save_settings( $settings ) {
 /**
  * Render settings page
  */
-function ufsc_render_settings_page() {
+function ufsc_render_core_settings_page() {
     // Handle form submission
     if ( isset( $_POST['ufsc_save_settings'] ) && check_admin_referer( 'ufsc_gestion_settings' ) ) {
         $settings = array();

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -609,11 +609,6 @@ if ( ! function_exists( 'ufsc_render_licences_page' ) ) {
 // Ensure export page renderer is available
 require_once UFSC_CL_DIR . 'includes/admin/page-ufsc-exports.php';
 
-if ( ! function_exists( 'ufsc_render_settings_page' ) ) {
-    function ufsc_render_settings_page() {
-        UFSC_Settings_Page::render();
-    }
-}
 
 // Register admin menu with a closure
 add_action( 'admin_menu', function () {
@@ -672,7 +667,7 @@ add_action( 'admin_menu', function () {
         __( 'Réglages', 'ufsc-clubs' ),
         $cap,
         'ufsc-settings',
-        'ufsc_render_settings_page'
+        array( 'UFSC_Settings_Page', 'render' )
     );
 }, 10 );
 


### PR DESCRIPTION
## Summary
- Rename `ufsc_render_settings_page` to `ufsc_render_core_settings_page` and update references
- Remove legacy conditional wrapper and call `UFSC_Settings_Page::render` directly in admin menu

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf84d1778832b86a658b101e49916