### PR TITLE
Hide extraneous SQL submenu entries

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -61,6 +61,9 @@ class UFSC_SQL_Admin {
         remove_submenu_page($parent_slug, 'ufsc-clubs');
         remove_submenu_page($parent_slug, 'ufsc-licences');
         remove_submenu_page($parent_slug, 'ufsc-licenses');
+        remove_submenu_page($parent_slug, 'ufsc-sql-clubs');
+        remove_submenu_page($parent_slug, 'ufsc-sql-licences');
+        remove_submenu_page($parent_slug, 'ufsc-sql-licenses');
     }
 
     /* ---------------- Menus complets (obsolète - remplacé par menu unifié) ---------------- */

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -105,7 +105,7 @@ final class UFSC_CL_Bootstrap {
         add_action( 'admin_enqueue_scripts', array( 'UFSC_CL_Admin_Menu', 'enqueue_admin' ) );
 
         // SQL Admin CRUD actions (pages cachées mais enregistrées pour les actions directes)
-        add_action( 'admin_menu', array( 'UFSC_SQL_Admin', 'register_hidden_pages' ) );
+        add_action( 'admin_menu', array( 'UFSC_SQL_Admin', 'register_hidden_pages' ), 99 );
         add_action( 'admin_post_ufsc_sql_save_club', array( 'UFSC_SQL_Admin', 'handle_save_club' ) );
         add_action( 'admin_post_ufsc_sql_delete_club', array( 'UFSC_SQL_Admin', 'handle_delete_club' ) );
         add_action( 'admin_post_ufsc_sql_save_licence', array( 'UFSC_SQL_Admin', 'handle_save_licence' ) );


### PR DESCRIPTION
## Summary
- hide legacy SQL submenu slugs via additional `remove_submenu_page` calls
- run SQL hidden pages registration after other menus by setting `admin_menu` priority 99

## Testing
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*
- `php /tmp/test.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdfc8c9e0c832baaddb3d0105dccf4