### PR TITLE
Fix SQL settings saving by unslashing POST data

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -98,7 +98,7 @@ class UFSC_SQL_Admin {
     /* ---------------- Réglages ---------------- */
     public static function render_settings(){
         if ( isset($_POST['ufsc_sql_save']) && check_admin_referer('ufsc_sql_settings') ){
-            $in = UFSC_CL_Utils::sanitize_text_arr( $_POST );
+            $in = UFSC_CL_Utils::sanitize_text_arr( wp_unslash( $_POST ) );
             $opts = UFSC_SQL::get_settings();
             $opts['table_clubs'] = $in['table_clubs'];
             $opts['table_licences'] = $in['table_licences'];


### PR DESCRIPTION
## Summary
- Sanitize SQL settings POST array with `wp_unslash` before saving

## Testing
- `php /tmp/test_settings.php | head -n 20`
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be00ce0f7c832ba826c0e8296ba485