### PR TITLE
Remove legacy option in favor of unified settings

### DIFF
--- a/includes/core/class-sql.php
+++ b/includes/core/class-sql.php
@@ -134,17 +134,6 @@ class UFSC_SQL {
     }
     public static function get_settings(){
         $opts = get_option( 'ufsc_sql_settings', array() );
-
-        // Migrate legacy option if it exists.
-        if ( empty( $opts ) ) {
-            $legacy = get_option( 'ufsc_gestion_settings', array() );
-            if ( ! empty( $legacy ) ) {
-                $opts = $legacy;
-                update_option( 'ufsc_sql_settings', $opts );
-                delete_option( 'ufsc_gestion_settings' );
-            }
-        }
-
         $settings = wp_parse_args( $opts, self::default_settings() );
         return apply_filters( 'ufsc_sql_settings', $settings );
     }

--- a/includes/core/class-ufsc-db-migrations.php
+++ b/includes/core/class-ufsc-db-migrations.php
@@ -83,6 +83,7 @@ class UFSC_DB_Migrations {
         }
 
         self::maybe_upgrade();
+        self::migrate_settings();
     }
 
     /**
@@ -113,6 +114,22 @@ class UFSC_DB_Migrations {
         self::maybe_add_index( $licences_table, 'birthdate' );
 
         update_option( self::OPTION_KEY, self::VERSION );
+        self::migrate_settings();
+    }
+
+    /**
+     * Migrate legacy settings option to the unified one and remove leftovers.
+     */
+    public static function migrate_settings() {
+        $legacy  = get_option( 'ufsc_gestion_settings', array() );
+        $current = get_option( 'ufsc_sql_settings', array() );
+
+        if ( ! empty( $legacy ) ) {
+            $current = wp_parse_args( $current, $legacy );
+            update_option( 'ufsc_sql_settings', $current );
+        }
+
+        delete_option( 'ufsc_gestion_settings' );
     }
 
     /**


### PR DESCRIPTION
## Summary
- Use `ufsc_sql_settings` exclusively in `UFSC_SQL::get_settings`
- Add activation/upgrade routine to migrate and delete `ufsc_gestion_settings`

## Testing
- `composer install` *(failed: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpcs includes/core/class-sql.php includes/core/class-ufsc-db-migrations.php` *(failed: No such file or directory)*
- `vendor/bin/phpstan analyse --no-progress includes/core/class-sql.php includes/core/class-ufsc-db-migrations.php` *(failed: No such file or directory)*
- `wp option get ufsc_sql_settings` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0698b4a4832bbc9eaa48b435060d