### PR TITLE
feat: centralize SQL settings management

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -36,16 +36,7 @@ function ufsc_get_settings() {
  * @return bool True on success
  */
 function ufsc_save_settings( $settings ) {
-    // Sanitize table names
-    if ( isset( $settings['table_clubs'] ) ) {
-        $settings['table_clubs'] = ufsc_sanitize_table_name( $settings['table_clubs'] );
-    }
-
-    if ( isset( $settings['table_licences'] ) ) {
-        $settings['table_licences'] = ufsc_sanitize_table_name( $settings['table_licences'] );
-    }
-
-    return update_option( 'ufsc_sql_settings', $settings );
+    return UFSC_SQL::update_settings( $settings );
 }
 
 /**

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -98,12 +98,14 @@ class UFSC_SQL_Admin {
     /* ---------------- Réglages ---------------- */
     public static function render_settings(){
         if ( isset($_POST['ufsc_sql_save']) && check_admin_referer('ufsc_sql_settings') ){
-            $in = UFSC_CL_Utils::sanitize_text_arr( wp_unslash( $_POST ) );
-            $opts = UFSC_SQL::get_settings();
-            $opts['table_clubs'] = $in['table_clubs'];
-            $opts['table_licences'] = $in['table_licences'];
-            update_option('ufsc_sql_settings',$opts);
-            echo '<div class="updated"><p>'.esc_html__('Réglages enregistrés.','ufsc-clubs').'</p></div>';
+            $in   = UFSC_CL_Utils::sanitize_text_arr( wp_unslash( $_POST ) );
+            $opts = array(
+                'table_clubs'    => ufsc_sanitize_table_name( $in['table_clubs'] ),
+                'table_licences' => ufsc_sanitize_table_name( $in['table_licences'] ),
+            );
+
+            UFSC_SQL::update_settings( $opts );
+            echo '<div class="updated"><p>' . esc_html__( 'Réglages enregistrés.', 'ufsc-clubs' ) . '</p></div>';
         }
         $s = UFSC_SQL::get_settings();
         echo '<div class="wrap"><h1>'.esc_html__('Réglages (SQL)','ufsc-clubs').'</h1><form method="post">';

--- a/includes/core/class-sql.php
+++ b/includes/core/class-sql.php
@@ -148,6 +148,27 @@ class UFSC_SQL {
         $settings = wp_parse_args( $opts, self::default_settings() );
         return apply_filters( 'ufsc_sql_settings', $settings );
     }
+
+    /**
+     * Update settings while preserving existing values.
+     *
+     * @param array $settings New settings to merge.
+     * @return bool True on success.
+     */
+    public static function update_settings( $settings ) {
+        $current = self::get_settings();
+        $merged  = array_merge( $current, $settings );
+
+        if ( isset( $merged['table_clubs'] ) ) {
+            $merged['table_clubs'] = ufsc_sanitize_table_name( $merged['table_clubs'] );
+        }
+
+        if ( isset( $merged['table_licences'] ) ) {
+            $merged['table_licences'] = ufsc_sanitize_table_name( $merged['table_licences'] );
+        }
+
+        return update_option( 'ufsc_sql_settings', $merged );
+    }
     
     public static function statuses(){ 
         $s = self::get_settings(); 


### PR DESCRIPTION
## Summary
- sanitize SQL table names before persisting admin settings
- centralize configuration storage through `UFSC_SQL::update_settings`
- streamline settings save helper to avoid overwriting existing values

## Testing
- `composer install` (fails: CONNECT tunnel failed, response 403)
- `composer phpcs` (fails: phpcs not found)
- `composer phpstan` (fails: phpstan not found)


------
https://chatgpt.com/codex/tasks/task_e_68be0699cbb4832b937e0f8d74989d64