### PR TITLE
Add plugin load guard and clean admin menu registration

### DIFF
--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -99,7 +99,7 @@ class UFSC_CL_Admin_Menu {
         
         echo '<div class="wrap">';
 
-        include UFSC_CL_DIR . 'templates/partials/notice.php';
+        require_once UFSC_CL_DIR . 'templates/partials/notice.php';
 
         // Header moderne
         echo '<div class="ufsc-header">';
@@ -587,98 +587,8 @@ class UFSC_CL_Admin_Menu {
     }
 }
 
-// Global render callbacks
-if ( ! function_exists( 'ufsc_render_dashboard' ) ) {
-    function ufsc_render_dashboard() {
-        UFSC_CL_Admin_Menu::render_dashboard();
-    }
-}
-
-if ( ! function_exists( 'ufsc_render_clubs_page' ) ) {
-    function ufsc_render_clubs_page() {
-        UFSC_SQL_Admin::render_clubs();
-    }
-}
-
-if ( ! function_exists( 'ufsc_render_licences_page' ) ) {
-    function ufsc_render_licences_page() {
-        UFSC_SQL_Admin::render_licences();
-    }
-}
-
 // Ensure export page renderer is available
 require_once UFSC_CL_DIR . 'includes/admin/page-ufsc-exports.php';
-
-
-// Register admin menu with a closure
-add_action( 'admin_menu', function () {
-    $cap  = 'ufsc_manage';
-    $slug = 'ufsc-gestion';
-
-    add_menu_page(
-        __( 'UFSC Gestion', 'ufsc-clubs' ),
-        __( 'UFSC Gestion', 'ufsc-clubs' ),
-        $cap,
-        $slug,
-        'ufsc_render_dashboard',
-        'dashicons-groups',
-        58
-    );
-
-    add_submenu_page(
-        $slug,
-        __( 'Tableau de bord', 'ufsc-clubs' ),
-        __( 'Tableau de bord', 'ufsc-clubs' ),
-        $cap,
-        $slug,
-        'ufsc_render_dashboard'
-    );
-
-    add_submenu_page(
-        $slug,
-        __( 'Clubs', 'ufsc-clubs' ),
-        __( 'Clubs', 'ufsc-clubs' ),
-        $cap,
-        'ufsc-clubs',
-        'ufsc_render_clubs_page'
-    );
-
-    add_submenu_page(
-        $slug,
-        __( 'Licences', 'ufsc-clubs' ),
-        __( 'Licences', 'ufsc-clubs' ),
-        $cap,
-        'ufsc-licences',
-        'ufsc_render_licences_page'
-    );
-
-    add_submenu_page(
-        $slug,
-        __( 'Exports/Imports', 'ufsc-clubs' ),
-        __( 'Exports/Imports', 'ufsc-clubs' ),
-        $cap,
-        'ufsc-exports',
-        'ufsc_render_exports_page'
-    );
-
-    add_submenu_page(
-        $slug,
-        __( 'Réglages SQL', 'ufsc-clubs' ),
-        __( 'Réglages SQL', 'ufsc-clubs' ),
-        $cap,
-        'ufsc-sql-settings',
-        array( 'UFSC_SQL_Admin', 'render_settings' )
-    );
-
-    add_submenu_page(
-        $slug,
-        __( 'Réglages', 'ufsc-clubs' ),
-        __( 'Réglages', 'ufsc-clubs' ),
-        $cap,
-        'ufsc-settings',
-        array( 'UFSC_Settings_Page', 'render' )
-    );
-}, 10 );
 
 // Register frontend assets during wp_enqueue_scripts so they can be enqueued later.
 add_action( 'wp_enqueue_scripts', array( 'UFSC_CL_Admin_Menu', 'register_front' ) );

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -46,24 +46,25 @@ class UFSC_SQL_Admin {
         // Enregistrer les pages cachées pour les actions directes (mentionnées dans les specs)
         $parent_slug = 'ufsc-gestion';
 
+        add_submenu_page(
+            $parent_slug,
+            __('Clubs (SQL)', 'ufsc-clubs'),
+            __('Clubs (SQL)', 'ufsc-clubs'),
+            'ufsc_manage',
+            'ufsc-sql-clubs',
+            array(__CLASS__, 'render_clubs')
+        );
+        add_submenu_page(
+            $parent_slug,
+            __('Licences (SQL)', 'ufsc-clubs'),
+            __('Licences (SQL)', 'ufsc-clubs'),
+            'ufsc_manage',
+            'ufsc-sql-licences',
+            array(__CLASS__, 'render_licences')
+        );
 
-        add_submenu_page($parent_slug, __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), 'manage_options', 'ufsc-clubs', array(__CLASS__, 'render_clubs'));
-        add_submenu_page($parent_slug, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), 'manage_options', 'ufsc-licences', array(__CLASS__, 'render_licences'));
-        // Alias pour compatibilité avec la spec (licenses vs licences)
-        add_submenu_page($parent_slug, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), 'manage_options', 'ufsc-licenses', array(__CLASS__, 'render_licences'));
-
-        add_submenu_page($parent_slug, __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), 'ufsc_manage', 'ufsc-sql-clubs', array(__CLASS__, 'render_clubs'));
-        add_submenu_page($parent_slug, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), 'ufsc_manage', 'ufsc-sql-licences', array(__CLASS__, 'render_licences'));
-        // Alias pour compatibilité avec la spec (licenses vs licences)
-        add_submenu_page($parent_slug, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), 'ufsc_manage', 'ufsc-sql-licenses', array(__CLASS__, 'render_licences'));
-
-
-        remove_submenu_page($parent_slug, 'ufsc-clubs');
-        remove_submenu_page($parent_slug, 'ufsc-licences');
-        remove_submenu_page($parent_slug, 'ufsc-licenses');
         remove_submenu_page($parent_slug, 'ufsc-sql-clubs');
         remove_submenu_page($parent_slug, 'ufsc-sql-licences');
-        remove_submenu_page($parent_slug, 'ufsc-sql-licenses');
     }
 
     /* ---------------- Menus complets (obsolète - remplacé par menu unifié) ---------------- */

--- a/includes/core/class-email-notifications.php
+++ b/includes/core/class-email-notifications.php
@@ -310,7 +310,7 @@ class UFSC_Email_Notifications {
         if ( file_exists( $template_file ) ) {
             ob_start();
             extract( $data );
-            include $template_file;
+            require_once $template_file;
             return ob_get_clean();
         }
 

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1459,10 +1459,10 @@ class UFSC_Frontend_Shortcodes {
             if ( 'edit' === $action && $licence_id ) {
                 $licence = self::get_licence( $atts['club_id'], $licence_id );
             }
-            include UFSC_CL_DIR . 'templates/frontend/licence-form.php';
+            require_once UFSC_CL_DIR . 'templates/frontend/licence-form.php';
         } else {
             $licences = self::get_club_licences( $atts['club_id'], array( 'per_page' => 100 ) );
-            include UFSC_CL_DIR . 'templates/frontend/licences-list.php';
+            require_once UFSC_CL_DIR . 'templates/frontend/licences-list.php';
         }
         return ob_get_clean();
     }

--- a/templates/front/dashboard-club.php
+++ b/templates/front/dashboard-club.php
@@ -9,7 +9,7 @@ $settings = UFSC_SQL::get_settings();
 $table    = $settings['table_clubs'];
 $club     = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE id = %d", $club_id ) );
 
-include UFSC_CL_DIR . 'templates/partials/notice.php';
+require_once UFSC_CL_DIR . 'templates/partials/notice.php';
 ?>
 
 <div class="ufsc-dashboard-header">

--- a/templates/frontend/licence-form.php
+++ b/templates/frontend/licence-form.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
-include UFSC_CL_DIR . 'templates/partials/notice.php';
+require_once UFSC_CL_DIR . 'templates/partials/notice.php';
 $wc_settings    = ufsc_get_woocommerce_settings();
 $included_limit = isset( $wc_settings['included_licenses'] ) ? (int) $wc_settings['included_licenses'] : 10;
 $included_count = UFSC_Licence_Form::get_included_count();

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -8,6 +8,11 @@
  */
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+if ( defined( 'UFSC_PLUGIN_LOADED' ) ) {
+    return;
+}
+define( 'UFSC_PLUGIN_LOADED', true );
+
 define( 'UFSC_CL_VERSION', '1.5.7' );
 define( 'UFSC_CL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UFSC_CL_URL', plugin_dir_url( __FILE__ ) );
@@ -77,6 +82,8 @@ require_once UFSC_CL_DIR.'inc/woocommerce/hooks.php';
 require_once UFSC_CL_DIR.'inc/woocommerce/admin-actions.php';
 require_once UFSC_CL_DIR.'inc/woocommerce/cart-integration.php';
 require_once UFSC_CL_DIR.'includes/woo/class-ufsc-woo-sync.php';
+
+add_action('admin_menu', ['UFSC_CL_Admin_Menu','register']);
 
 register_activation_hook(__FILE__, ['UFSC_DB_Migrations','activate']);
 add_action('plugins_loaded', ['UFSC_DB_Migrations','maybe_upgrade']);


### PR DESCRIPTION
## Summary
- guard against multiple plugin loads with `UFSC_PLUGIN_LOADED` constant
- register admin menu once and switch includes to `require_once`
- streamline hidden SQL pages to use canonical slugs

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*
- `php -l ufsc-clubs-licences-sql.php includes/admin/class-admin-menu.php templates/frontend/licence-form.php templates/front/dashboard-club.php includes/core/class-email-notifications.php includes/frontend/class-frontend-shortcodes.php includes/admin/class-sql-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68be1a1ed88c832b97f8e41229026306