### PR TITLE
Centralize status badges and quota utilities

### DIFF
--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -236,11 +236,10 @@ class UFSC_CL_Admin_Menu {
         
         if (!empty($dashboard_data['recent_licenses'])) {
             foreach ($dashboard_data['recent_licenses'] as $license) {
-                $status_class = self::get_status_class($license->statut);
                 echo '<div class="activity-item">';
                 echo '<span class="activity-date">'.esc_html(mysql2date('d/m/Y', $license->date_inscription)).'</span>';
                 echo '<span class="activity-desc">Nouvelle licence: <strong>'.esc_html($license->prenom.' '.$license->nom).'</strong></span>';
-                echo '<span class="activity-status ufsc-status-badge ufsc-status-'.$status_class.'"><span class="ufsc-status-dot"></span>'.esc_html(UFSC_SQL::statuses()[$license->statut] ?? $license->statut).'</span>';
+                echo '<span class="activity-status">'.UFSC_Status::badge( $license->statut ).'</span>';
                 echo '</div>';
             }
         } else {
@@ -360,27 +359,6 @@ class UFSC_CL_Admin_Menu {
         set_transient($cache_key, $data, 10 * MINUTE_IN_SECONDS);
         
         return $data;
-    }
-
-    /**
-     * Get status CSS class for display
-     */
-    private static function get_status_class($status) {
-        $status_map = array(
-            'valide' => 'valid',
-            'validee' => 'valid',
-            'active' => 'valid',
-            'en_attente' => 'pending',
-            'attente' => 'pending',
-            'pending' => 'pending',
-            'a_regler' => 'pending',
-            'refuse' => 'rejected',
-            'rejected' => 'rejected',
-            'desactive' => 'inactive',
-            'inactive' => 'inactive'
-        );
-        
-        return isset($status_map[$status]) ? $status_map[$status] : 'inactive';
     }
 
     /**

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -8,38 +8,6 @@ if ( ! is_admin() ) {
 
 class UFSC_SQL_Admin {
 
-    /**
-     * Generate status badge with colored dot
-     */
-    private static function get_status_badge($status, $label = '') {
-        if (empty($label)) {
-            $label = UFSC_SQL::statuses()[$status] ?? $status;
-        }
-        
-        // Map status to CSS class
-        $status_map = array(
-            'valide' => 'valid',
-            'validee' => 'valid',
-            'active' => 'valid',
-            'en_attente' => 'pending',
-            'attente' => 'pending',
-            'pending' => 'pending',
-            'a_regler' => 'pending',
-            'refuse' => 'rejected',
-            'rejected' => 'rejected',
-            'desactive' => 'inactive',
-            'inactive' => 'inactive',
-            'off' => 'inactive'
-        );
-        
-        $css_class = isset($status_map[$status]) ? $status_map[$status] : 'inactive';
-        
-        return '<span class="ufsc-status-badge ufsc-status-' . esc_attr($css_class) . '">' .
-               '<span class="ufsc-status-dot"></span>' .
-               esc_html($label) .
-               '</span>';
-    }
-
     /* ---------------- Menus cachés pour accès direct ---------------- */
     public static function register_hidden_pages()
     {
@@ -940,11 +908,6 @@ class UFSC_SQL_Admin {
         
         if ( $rows ){
             foreach($rows as $r){
-                $map = array('valide'=>'success','a_regler'=>'info','desactive'=>'off','en_attente'=>'wait');
-                $cls = isset($map[$r->statut]) ? $map[$r->statut] : 'info';
-                $status_label = UFSC_SQL::statuses()[$r->statut] ?? $r->statut;
-                $badge = UFSC_CL_Utils::esc_badge( $status_label, $cls );
-                
                 $view_url = admin_url('admin.php?page=ufsc-licences&action=view&id='.$r->$pk);
                 $edit_url = admin_url('admin.php?page=ufsc-licences&action=edit&id='.$r->$pk);
                 $del_url  = wp_nonce_url( admin_url('admin-post.php?action=ufsc_sql_delete_licence&id='.$r->$pk), 'ufsc_sql_delete_licence' );
@@ -960,8 +923,8 @@ class UFSC_SQL_Admin {
                 echo '<td>'.esc_html($r->region).'</td>';
                 echo '<td>';
                 
-                // Display status badge with colored dot
-                echo self::get_status_badge($r->statut);
+                // Display status badge using unified status helper
+                echo UFSC_Status::badge( $r->statut );
                 
                 echo '</td>';
                 echo '<td>'.esc_html($r->date_inscription ?: '').'</td>';

--- a/includes/core/class-ufsc-status.php
+++ b/includes/core/class-ufsc-status.php
@@ -1,0 +1,230 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * UFSC Status utilities
+ * Provides mapping between status keys and their labels, icons and colors.
+ */
+class UFSC_Status {
+    /**
+     * Canonical status configuration.
+     *
+     * @var array
+     */
+    private static $statuses = array(
+        'draft'    => array(
+            'label' => 'Brouillon',
+            'icon'  => '📝',
+            'color' => 'info',
+        ),
+        'pending'  => array(
+            'label' => 'En attente',
+            'icon'  => '⏳',
+            'color' => 'warning',
+        ),
+        'active'   => array(
+            'label' => 'Active',
+            'icon'  => '✅',
+            'color' => 'success',
+        ),
+        'expired'  => array(
+            'label' => 'Expirée',
+            'icon'  => '⌛',
+            'color' => 'danger',
+        ),
+        'rejected' => array(
+            'label' => 'Refusée',
+            'icon'  => '❌',
+            'color' => 'danger',
+        ),
+        'inactive' => array(
+            'label' => 'Désactivée',
+            'icon'  => '⛔',
+            'color' => 'danger',
+        ),
+    );
+
+    /**
+     * Map various raw statuses to canonical keys.
+     *
+     * @var array
+     */
+    private static $aliases = array(
+        // Draft
+        'brouillon' => 'draft',
+        // Pending
+        'en_attente' => 'pending',
+        'attente'    => 'pending',
+        'a_regler'   => 'pending',
+        'pending'    => 'pending',
+        'non_payee'  => 'pending',
+        // Active / Valid
+        'valide'   => 'active',
+        'validee'  => 'active',
+        'active'   => 'active',
+        'applied'  => 'active',
+        // Rejected
+        'refuse'   => 'rejected',
+        'rejected' => 'rejected',
+        // Inactive
+        'desactive' => 'inactive',
+        'inactive'  => 'inactive',
+        'off'       => 'inactive',
+    );
+
+    /**
+     * Normalize a status value to its canonical key.
+     *
+     * @param string $status Raw status.
+     * @return string Canonical status key.
+     */
+    public static function normalize( $status ) {
+        $status = strtolower( trim( $status ) );
+        if ( isset( self::$aliases[ $status ] ) ) {
+            return self::$aliases[ $status ];
+        }
+        return $status;
+    }
+
+    /**
+     * Retrieve status configuration.
+     *
+     * @param string $status Status key.
+     * @return array Configuration array with label, icon and color.
+     */
+    public static function get( $status ) {
+        $status = self::normalize( $status );
+        return self::$statuses[ $status ] ?? self::$statuses['draft'];
+    }
+
+    /**
+     * Get status label.
+     */
+    public static function label( $status ) {
+        $info = self::get( $status );
+        return $info['label'];
+    }
+
+    /**
+     * Get status icon.
+     */
+    public static function icon( $status ) {
+        $info = self::get( $status );
+        return $info['icon'];
+    }
+
+    /**
+     * Get status color.
+     */
+    public static function color( $status ) {
+        $info = self::get( $status );
+        return $info['color'];
+    }
+
+    /**
+     * Get database status variants for a given status.
+     *
+     * @param string $status Canonical or raw status.
+     * @return array Array of database status values.
+     */
+    public static function db_statuses( $status ) {
+        $canonical = self::normalize( $status );
+        $map = array(
+            'draft'    => array( 'brouillon' ),
+            'pending'  => array( 'en_attente', 'attente', 'pending', 'a_regler', 'non_payee' ),
+            'active'   => array( 'valide', 'validee', 'active', 'applied' ),
+            'expired'  => array( 'expired' ),
+            'rejected' => array( 'refuse', 'rejected' ),
+            'inactive' => array( 'desactive', 'inactive', 'off' ),
+        );
+        return $map[ $canonical ] ?? array( $canonical );
+    }
+
+    /**
+     * Render a badge for the provided status.
+     *
+     * @param string $status Status key.
+     * @return string HTML badge.
+     */
+    public static function badge( $status ) {
+        $info  = self::get( $status );
+        $class = 'ufsc-badge ufsc-badge-' . $info['color'];
+        return '<span class="' . esc_attr( $class ) . '" aria-label="' . esc_attr( $info['label'] ) . '">' . esc_html( $info['icon'] . ' ' . $info['label'] ) . '</span>';
+    }
+}
+
+/**
+ * Count licences for a club optionally filtered by status.
+ *
+ * @param int         $club_id Club identifier.
+ * @param string|null $status  Optional status to filter.
+ * @return int Number of licences.
+ */
+function ufsc_count_licences( $club_id, $status = null ) {
+    global $wpdb;
+    $settings       = UFSC_SQL::get_settings();
+    $table          = $settings['table_licences'];
+    $sql            = "SELECT COUNT(*) FROM `{$table}` WHERE club_id = %d AND deleted_at IS NULL";
+    $params         = array( (int) $club_id );
+
+    if ( $status ) {
+        $statuses    = UFSC_Status::db_statuses( $status );
+        $placeholders = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+        $sql         .= " AND statut IN ({$placeholders})";
+        $params      = array_merge( $params, $statuses );
+    }
+
+    return (int) $wpdb->get_var( $wpdb->prepare( $sql, $params ) );
+}
+
+/**
+ * Get total licence quota for a club.
+ *
+ * @param int $club_id Club identifier.
+ * @return int Quota value.
+ */
+function ufsc_get_quota_total( $club_id ) {
+    global $wpdb;
+    $settings    = UFSC_SQL::get_settings();
+    $clubs_table = $settings['table_clubs'];
+    $quota       = $wpdb->get_var( $wpdb->prepare( "SELECT quota_licences FROM `{$clubs_table}` WHERE id = %d", (int) $club_id ) );
+    return (int) $quota;
+}
+
+/**
+ * Get number of licences already used for a club.
+ *
+ * @param int $club_id Club identifier.
+ * @return int Used licences count.
+ */
+function ufsc_get_quota_used( $club_id ) {
+    return ufsc_count_licences( $club_id );
+}
+
+/**
+ * Get remaining licence quota for a club.
+ *
+ * @param int $club_id Club identifier.
+ * @return int Remaining quota.
+ */
+function ufsc_get_quota_remaining( $club_id ) {
+    $total = ufsc_get_quota_total( $club_id );
+    $used  = ufsc_get_quota_used( $club_id );
+    return max( 0, $total - $used );
+}
+
+/**
+ * Convenience helper returning quota information.
+ *
+ * @param int $club_id Club identifier.
+ * @return array { total, used, remaining }
+ */
+function ufsc_get_quota_info( $club_id ) {
+    $total = ufsc_get_quota_total( $club_id );
+    $used  = ufsc_get_quota_used( $club_id );
+    return array(
+        'total'     => $total,
+        'used'      => $used,
+        'remaining' => max( 0, $total - $used ),
+    );
+}

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -258,7 +258,7 @@ class UFSC_Frontend_Shortcodes {
 
         $club_name  = self::get_club_name( $atts['club_id'] );
         $wc_settings = ufsc_get_woocommerce_settings();
-        $quota_info = self::get_club_quota_info( $atts['club_id'] );
+        $quota_info = ufsc_get_quota_info( $atts['club_id'] );
 
 
         ob_start();
@@ -470,9 +470,7 @@ class UFSC_Frontend_Shortcodes {
                                 $formatted = $value ? esc_html( date_i18n( 'd/m/Y', strtotime( $value ) ) ) : '';
                                 break;
                             case 'licence_status':
-                                $label_value = self::get_licence_status_label( $value );
-                                $class = self::get_licence_status_badge_class( $value );
-                                $formatted = '<span class="ufsc-badge ' . esc_attr( $class ) . '">' . esc_html( $label_value ) . '</span>';
+                                $formatted = UFSC_Status::badge( $value );
                                 break;
                             case 'payment_status':
                                 $formatted = self::render_payment_status_badge( $value );
@@ -1134,7 +1132,7 @@ class UFSC_Frontend_Shortcodes {
                    '</div></div>';
         }
 
-        $quota_info  = self::get_club_quota_info( $atts['club_id'] );
+        $quota_info  = ufsc_get_quota_info( $atts['club_id'] );
         $form_data   = array();
         $form_errors = array();
 
@@ -1821,63 +1819,6 @@ class UFSC_Frontend_Shortcodes {
         return ufsc_is_validated_licence( $licence_id );
     }
 
-    /**
-     * Get licence status label
-     */
-    private static function get_licence_status_label( $status ) {
-        $map = array(
-            'brouillon' => 'draft',
-            'non_payee' => 'pending',
-            'paid'      => 'pending',
-            'validated' => 'active',
-            'applied'   => 'active',
-            'rejected'  => 'rejected',
-        );
-
-        $status = strtolower( $status );
-        if ( isset( $map[ $status ] ) ) {
-            $status = $map[ $status ];
-        }
-
-        $labels = array(
-            'draft'    => __( 'Brouillon', 'ufsc-clubs' ),
-            'pending'  => __( 'En attente', 'ufsc-clubs' ),
-            'active'   => __( 'Active', 'ufsc-clubs' ),
-            'expired'  => __( 'Expirée', 'ufsc-clubs' ),
-            'rejected' => __( 'Refusée', 'ufsc-clubs' ),
-        );
-
-        return $labels[ $status ] ?? $status;
-    }
-
-    /**
-     * Map licence status to badge class
-     */
-    private static function get_licence_status_badge_class( $status ) {
-        $map = array(
-            'brouillon' => 'draft',
-            'non_payee' => 'pending',
-            'paid'      => 'pending',
-            'validated' => 'active',
-            'applied'   => 'active',
-            'rejected'  => 'rejected',
-        );
-
-        $status = strtolower( $status );
-        if ( isset( $map[ $status ] ) ) {
-            $status = $map[ $status ];
-        }
-
-        $classes = array(
-            'draft'    => '-draft',
-            'pending'  => '-pending',
-            'active'   => '-ok',
-            'expired'  => '-expired',
-            'rejected' => '-rejected',
-        );
-
-        return $classes[ $status ] ?? '-draft';
-    }
 
     /**
      * Render payment status badge
@@ -1895,44 +1836,6 @@ class UFSC_Frontend_Shortcodes {
         return '<span class="ufsc-badge ' . esc_attr( $class ) . '">' . esc_html( $status ) . '</span>';
     }
 
-    /**
-     * Get club quota information
-     *
-     * Retrieves the total allowed licences for the club, the number of
-     * licences currently used and calculates the remaining quota. Values
-     * are fetched directly from the UFSC SQL tables.
-     *
-     * @param int $club_id Club ID
-     * @return array{total:int,used:int,remaining:int}
-     */
-    private static function get_club_quota_info( $club_id ) {
-        global $wpdb;
-
-        if ( ! class_exists( 'UFSC_SQL' ) ) {
-            return array( 'total' => 0, 'used' => 0, 'remaining' => 0 );
-        }
-
-        $settings        = UFSC_SQL::get_settings();
-        $clubs_table     = $settings['table_clubs'];
-        $licences_table  = $settings['table_licences'];
-        $quota_col       = function_exists( 'ufsc_club_col' ) ? ufsc_club_col( 'quota_licences' ) : 'quota_licences';
-
-        $quota_total = (int) $wpdb->get_var( $wpdb->prepare(
-            "SELECT `{$quota_col}` FROM `{$clubs_table}` WHERE id = %d",
-            $club_id
-        ) );
-
-        $used = (int) $wpdb->get_var( $wpdb->prepare(
-            "SELECT COUNT(*) FROM `{$licences_table}` WHERE club_id = %d AND deleted_at IS NULL",
-            $club_id
-        ) );
-
-        return array(
-            'total'     => $quota_total,
-            'used'      => $used,
-            'remaining' => max( 0, $quota_total - $used )
-        );
-    }
 
     /**
      * Render club documents list for frontend display
@@ -2261,7 +2164,7 @@ class UFSC_Frontend_Shortcodes {
             return array( 'success' => false, 'message' => __( 'Adresse email invalide.', 'ufsc-clubs' ) );
         }
 
-        $quota_info   = self::get_club_quota_info( $club_id );
+        $quota_info   = ufsc_get_quota_info( $club_id );
         $needs_payment = $quota_info['remaining'] <= 0;
 
         global $wpdb;

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -29,6 +29,7 @@ require_once UFSC_CL_DIR.'includes/core/class-uploads.php';
 require_once UFSC_CL_DIR.'includes/front/class-ufsc-media.php';
 require_once UFSC_CL_DIR.'includes/core/class-permissions.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-badges.php';
+require_once UFSC_CL_DIR.'includes/core/class-ufsc-status.php';
 require_once UFSC_CL_DIR.'includes/core/class-ufsc-pdf-attestations.php';
 require_once UFSC_CL_DIR.'includes/lib/class-simple-pdf.php';
 require_once UFSC_CL_DIR.'includes/core/class-unified-handlers.php';


### PR DESCRIPTION
## Summary
- add `UFSC_Status` with status label/icon/color mappings and quota helpers
- use `UFSC_Status::badge` in admin interfaces and shortcode outputs
- fetch quota info through new `ufsc_get_quota_*` helpers and count licences consistently

## Testing
- `php -l includes/admin/class-sql-admin.php`
- `php -l includes/admin/class-admin-menu.php`
- `php -l includes/frontend/class-frontend-shortcodes.php`
- `php -l includes/front/class-ufsc-stats.php`
- `php -l includes/core/class-ufsc-status.php`
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a1bcfa0832bafe6328f54592c8e