### PR TITLE
Improve tab activation accessibility

### DIFF
--- a/assets/frontend/js/frontend.js
+++ b/assets/frontend/js/frontend.js
@@ -29,12 +29,14 @@ jQuery(document).ready(function($) {
             $('input[name="redirect_to"]').val(currentUrl);
         }
 
-        function activateTab(section, focusPanel, updateUrl) {
+        function activateTab(section, focusPanel, updateUrl, push) {
             focusPanel = focusPanel !== false;
             updateUrl = updateUrl !== false;
+            push = push === true;
 
             var $tab = $tabs.filter('[data-section="' + section + '"]');
-            var $panel = $('#ufsc-section-' + section);
+            var panelId = $tab.attr('aria-controls');
+            var $panel = panelId ? $('#' + panelId) : $();
 
             if (!$tab.length || !$panel.length) {
                 return;
@@ -60,7 +62,11 @@ jQuery(document).ready(function($) {
                 var url = new URL(window.location.href);
                 url.searchParams.set('tab', section);
                 url.hash = section;
-                history.replaceState(null, '', url.toString());
+                if (push) {
+                    history.pushState(null, '', url.toString());
+                } else {
+                    history.replaceState(null, '', url.toString());
+                }
             }
 
             updateRedirectFields();
@@ -68,36 +74,17 @@ jQuery(document).ready(function($) {
 
         $triggers.on('click', function(e) {
             e.preventDefault();
-
-
             var section = $(this).data('section');
-
-            // Update nav buttons
-            $('.ufsc-nav-btn').removeClass('active');
-            $(this).addClass('active');
-
-            // Show corresponding section
-            $('.ufsc-dashboard-section').removeClass('active');
-            $('#ufsc-section-' + section).addClass('active');
-
-            // Update URL with hash and tab parameter
-            if (history.pushState) {
-                var url = new URL(window.location.href);
-                url.hash = section;
-                url.searchParams.set('tab', section);
-                history.pushState(null, '', url.toString());
-            }
-
-            // Focus management for accessibility
-            $('#ufsc-section-' + section).focus();
+            activateTab(section, true, true, true);
         });
 
-        // Handle URL hash or tab parameter on page load
         var params = new URLSearchParams(window.location.search);
-        var target = params.get('tab') || window.location.hash.substring(1);
-        if (target && $('.ufsc-nav-btn[data-section="' + target + '"]').length) {
-            activateTab(target, true, false);
+        var initial = params.get('tab') || window.location.hash.substring(1);
+        if (!initial || !$tabs.filter('[data-section="' + initial + '"]').length) {
+            initial = $tabs.first().data('section');
         }
+
+        activateTab(initial, false, false);
 
         $tabs.on('keydown', function(e) {
             var index = $tabs.index(this);
@@ -123,15 +110,6 @@ jQuery(document).ready(function($) {
             e.preventDefault();
             activateTab($tabs.eq(newIndex).data('section'), false);
         });
-
-        var params = new URLSearchParams(window.location.search);
-        var initial = params.get('tab') || window.location.hash.substring(1);
-        if (!initial || !$tabs.filter('[data-section="' + initial + '"]').length) {
-            initial = $tabs.first().data('section');
-
-        }
-
-        activateTab(initial, false, false);
 
         $(window).on('popstate', function() {
             var p = new URLSearchParams(window.location.search);

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -105,10 +105,13 @@ class UFSC_Frontend_Shortcodes {
                    '</div></div>';
         }
 
-        $sections   = explode( ',', $atts['show_sections'] );
+        $sections     = explode( ',', $atts['show_sections'] );
         $dashboard_id = uniqid( 'ufsc-dashboard-' );
         $tab_prefix   = $dashboard_id . '-tab-';
         $panel_prefix = $dashboard_id . '-section-';
+
+        $requested_tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : '';
+        $active_section = in_array( $requested_tab, $sections, true ) ? $requested_tab : $sections[0];
 
         ob_start();
         ?>
@@ -135,22 +138,26 @@ class UFSC_Frontend_Shortcodes {
 
             <div class="ufsc-dashboard-nav" role="tablist">
                 <?php if ( in_array( 'licences', $sections ) ) : ?>
-                    <button class="ufsc-nav-btn active" role="tab" id="<?php echo esc_attr( $tab_prefix . 'licences' ); ?>" aria-controls="<?php echo esc_attr( $panel_prefix . 'licences' ); ?>" aria-selected="true" tabindex="0" data-section="licences">
+                    <?php $is_active = ( 'licences' === $active_section ); ?>
+                    <button class="ufsc-nav-btn<?php echo $is_active ? ' active' : ''; ?>" role="tab" id="<?php echo esc_attr( $tab_prefix . 'licences' ); ?>" aria-controls="<?php echo esc_attr( $panel_prefix . 'licences' ); ?>" aria-selected="<?php echo $is_active ? 'true' : 'false'; ?>" tabindex="<?php echo $is_active ? '0' : '-1'; ?>" data-section="licences">
                         <?php esc_html_e( 'Mes Licences', 'ufsc-clubs' ); ?>
                     </button>
                 <?php endif; ?>
                 <?php if ( in_array( 'stats', $sections ) ) : ?>
-                    <button class="ufsc-nav-btn" role="tab" id="<?php echo esc_attr( $tab_prefix . 'stats' ); ?>" aria-controls="<?php echo esc_attr( $panel_prefix . 'stats' ); ?>" aria-selected="false" tabindex="-1" data-section="stats">
+                    <?php $is_active = ( 'stats' === $active_section ); ?>
+                    <button class="ufsc-nav-btn<?php echo $is_active ? ' active' : ''; ?>" role="tab" id="<?php echo esc_attr( $tab_prefix . 'stats' ); ?>" aria-controls="<?php echo esc_attr( $panel_prefix . 'stats' ); ?>" aria-selected="<?php echo $is_active ? 'true' : 'false'; ?>" tabindex="<?php echo $is_active ? '0' : '-1'; ?>" data-section="stats">
                         <?php esc_html_e( 'Statistiques', 'ufsc-clubs' ); ?>
                     </button>
                 <?php endif; ?>
                 <?php if ( in_array( 'profile', $sections ) ) : ?>
-                    <button class="ufsc-nav-btn" role="tab" id="<?php echo esc_attr( $tab_prefix . 'profile' ); ?>" aria-controls="<?php echo esc_attr( $panel_prefix . 'profile' ); ?>" aria-selected="false" tabindex="-1" data-section="profile">
+                    <?php $is_active = ( 'profile' === $active_section ); ?>
+                    <button class="ufsc-nav-btn<?php echo $is_active ? ' active' : ''; ?>" role="tab" id="<?php echo esc_attr( $tab_prefix . 'profile' ); ?>" aria-controls="<?php echo esc_attr( $panel_prefix . 'profile' ); ?>" aria-selected="<?php echo $is_active ? 'true' : 'false'; ?>" tabindex="<?php echo $is_active ? '0' : '-1'; ?>" data-section="profile">
                         <?php esc_html_e( 'Mon Club', 'ufsc-clubs' ); ?>
                     </button>
                 <?php endif; ?>
                 <?php if ( in_array( 'add_licence', $sections ) ) : ?>
-                    <button class="ufsc-nav-btn" role="tab" id="<?php echo esc_attr( $tab_prefix . 'add_licence' ); ?>" aria-controls="<?php echo esc_attr( $panel_prefix . 'add_licence' ); ?>" aria-selected="false" tabindex="-1" data-section="add_licence">
+                    <?php $is_active = ( 'add_licence' === $active_section ); ?>
+                    <button class="ufsc-nav-btn<?php echo $is_active ? ' active' : ''; ?>" role="tab" id="<?php echo esc_attr( $tab_prefix . 'add_licence' ); ?>" aria-controls="<?php echo esc_attr( $panel_prefix . 'add_licence' ); ?>" aria-selected="<?php echo $is_active ? 'true' : 'false'; ?>" tabindex="<?php echo $is_active ? '0' : '-1'; ?>" data-section="add_licence">
                         <?php esc_html_e( 'Ajouter une Licence', 'ufsc-clubs' ); ?>
                     </button>
                 <?php endif; ?>
@@ -158,25 +165,29 @@ class UFSC_Frontend_Shortcodes {
 
             <div class="ufsc-dashboard-content">
                 <?php if ( in_array( 'licences', $sections ) ) : ?>
-                    <div id="<?php echo esc_attr( $panel_prefix . 'licences' ); ?>" class="ufsc-dashboard-section active" role="tabpanel" aria-labelledby="<?php echo esc_attr( $tab_prefix . 'licences' ); ?>" tabindex="0">
+                    <?php $is_active = ( 'licences' === $active_section ); ?>
+                    <div id="<?php echo esc_attr( $panel_prefix . 'licences' ); ?>" class="ufsc-dashboard-section<?php echo $is_active ? ' active' : ''; ?>" role="tabpanel" aria-labelledby="<?php echo esc_attr( $tab_prefix . 'licences' ); ?>" tabindex="0" <?php echo $is_active ? '' : 'hidden'; ?>>
                         <?php echo self::render_club_licences( array( 'club_id' => $club_id ) ); ?>
                     </div>
                 <?php endif; ?>
 
                 <?php if ( in_array( 'stats', $sections ) ) : ?>
-                    <div id="<?php echo esc_attr( $panel_prefix . 'stats' ); ?>" class="ufsc-dashboard-section" role="tabpanel" aria-labelledby="<?php echo esc_attr( $tab_prefix . 'stats' ); ?>" tabindex="0" hidden>
+                    <?php $is_active = ( 'stats' === $active_section ); ?>
+                    <div id="<?php echo esc_attr( $panel_prefix . 'stats' ); ?>" class="ufsc-dashboard-section<?php echo $is_active ? ' active' : ''; ?>" role="tabpanel" aria-labelledby="<?php echo esc_attr( $tab_prefix . 'stats' ); ?>" tabindex="0" <?php echo $is_active ? '' : 'hidden'; ?>>
                         <?php echo self::render_club_stats( array( 'club_id' => $club_id ) ); ?>
                     </div>
                 <?php endif; ?>
 
                 <?php if ( in_array( 'profile', $sections ) ) : ?>
-                    <div id="<?php echo esc_attr( $panel_prefix . 'profile' ); ?>" class="ufsc-dashboard-section" role="tabpanel" aria-labelledby="<?php echo esc_attr( $tab_prefix . 'profile' ); ?>" tabindex="0" hidden>
+                    <?php $is_active = ( 'profile' === $active_section ); ?>
+                    <div id="<?php echo esc_attr( $panel_prefix . 'profile' ); ?>" class="ufsc-dashboard-section<?php echo $is_active ? ' active' : ''; ?>" role="tabpanel" aria-labelledby="<?php echo esc_attr( $tab_prefix . 'profile' ); ?>" tabindex="0" <?php echo $is_active ? '' : 'hidden'; ?>>
                         <?php echo self::render_club_profile( array( 'club_id' => $club_id ) ); ?>
                     </div>
                 <?php endif; ?>
 
                 <?php if ( in_array( 'add_licence', $sections ) ) : ?>
-                    <div id="<?php echo esc_attr( $panel_prefix . 'add_licence' ); ?>" class="ufsc-dashboard-section" role="tabpanel" aria-labelledby="<?php echo esc_attr( $tab_prefix . 'add_licence' ); ?>" tabindex="0" hidden>
+                    <?php $is_active = ( 'add_licence' === $active_section ); ?>
+                    <div id="<?php echo esc_attr( $panel_prefix . 'add_licence' ); ?>" class="ufsc-dashboard-section<?php echo $is_active ? ' active' : ''; ?>" role="tabpanel" aria-labelledby="<?php echo esc_attr( $tab_prefix . 'add_licence' ); ?>" tabindex="0" <?php echo $is_active ? '' : 'hidden'; ?>>
                         <?php echo self::render_add_licence( array( 'club_id' => $club_id ) ); ?>
                     </div>
                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- Use `aria-controls` to select dashboard tab panels
- Initialize tabs from existing query or hash parameters
- Render requested tab active on initial PHP output

## Testing
- ⚠️ `composer install` *(curl error 56: CONNECT tunnel failed)*
- ⚠️ `composer phpcs` *(phpcs: not found)*
- ⚠️ `composer phpstan` *(phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a13f234832b9030e9c70f1924d0