### PR TITLE
Add palette variables and accessible UI components

### DIFF
--- a/assets/admin/css/admin.css
+++ b/assets/admin/css/admin.css
@@ -3,6 +3,29 @@
  * Styles for admin area including badges, tables, and forms
  */
 
+:root {
+    --ufsc-color-navy: #1C2143;
+    --ufsc-color-steel: #2E3A8C;
+    --ufsc-color-light-gray: #F3F5F9;
+    --ufsc-color-white: #ffffff;
+    --ufsc-color-red: #E31E24;
+}
+
+.ufsc-badge {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    background: var(--ufsc-color-light-gray);
+    color: var(--ufsc-color-navy);
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.ufsc-badge:focus {
+    outline: 2px solid var(--ufsc-color-steel);
+    outline-offset: 2px;
+}
+
 /* Status badges with colored dots */
 .ufsc-status-badge {
     display: inline-flex;
@@ -11,10 +34,15 @@
     border-radius: 12px;
     font-size: 12px;
     font-weight: 500;
-    background: #f1f1f1;
-    color: #444;
-    border: 1px solid #ddd;
+    background: var(--ufsc-color-light-gray);
+    color: var(--ufsc-color-navy);
+    border: 1px solid var(--ufsc-color-light-gray);
     white-space: nowrap;
+}
+
+.ufsc-status-badge:focus {
+    outline: 2px solid var(--ufsc-color-steel);
+    outline-offset: 2px;
 }
 
 .ufsc-status-badge .ufsc-status-dot {
@@ -53,7 +81,7 @@
 }
 
 .ufsc-status-badge.ufsc-status-rejected .ufsc-status-dot {
-    background: #dc3545;
+    background: var(--ufsc-color-red);
 }
 
 .ufsc-status-badge.ufsc-status-inactive {
@@ -184,7 +212,7 @@
 }
 
 .ufsc-admin-notice.notice-error {
-    border-left-color: #dc3232;
+    border-left-color: var(--ufsc-color-red);
 }
 
 .ufsc-admin-notice.notice-warning {
@@ -258,7 +286,7 @@
 .ufsc-form-field.required label::after,
 .ufsc-field.required label::after {
     content: " *";
-    color: #dc3232;
+    color: var(--ufsc-color-red);
 }
 
 /* Validation error styling */
@@ -268,13 +296,13 @@
 .ufsc-field.error input,
 .ufsc-field.error select,
 .ufsc-field.error textarea {
-    border-color: #dc3232;
-    box-shadow: 0 0 0 1px #dc3232;
+    border-color: var(--ufsc-color-red);
+    box-shadow: 0 0 0 1px var(--ufsc-color-red);
 }
 
 .ufsc-form-field .error-message,
 .ufsc-field .error-message {
-    color: #dc3232;
+    color: var(--ufsc-color-red);
     font-size: 12px;
     margin-top: 4px;
 }
@@ -288,8 +316,8 @@
 }
 
 .ufsc-dashboard-card {
-    background: #fff;
-    border: 1px solid #c3c4c7;
+    background: var(--ufsc-color-white);
+    border: 1px solid var(--ufsc-color-light-gray);
     border-radius: 4px;
     padding: 20px;
     text-align: center;
@@ -299,6 +327,12 @@
 
 .ufsc-dashboard-card:hover {
     box-shadow: 0 2px 5px rgba(0,0,0,.1);
+}
+
+.ufsc-dashboard-card:focus,
+.ufsc-dashboard-card:focus-within {
+    outline: 2px solid var(--ufsc-color-steel);
+    outline-offset: 2px;
 }
 
 .ufsc-dashboard-card .card-value {

--- a/assets/admin/js/admin.js
+++ b/assets/admin/js/admin.js
@@ -81,7 +81,7 @@ jQuery(document).ready(function($) {
     // Loading states for forms
     $('form').on('submit', function() {
         var $submitBtn = $(this).find('button[type="submit"], input[type="submit"]');
-        $submitBtn.prop('disabled', true).text('Enregistrement...');
+        $submitBtn.attr('aria-busy', 'true').text('Enregistrement...');
     });
     
     // Club selector with auto-region population
@@ -121,7 +121,7 @@ jQuery(document).ready(function($) {
         var originalStatus = $select.data('original-status');
         
         // Show loading state
-        $select.prop('disabled', true);
+        $select.attr('aria-busy', 'true');
         
         $.ajax({
             url: ajaxurl,
@@ -156,7 +156,7 @@ jQuery(document).ready(function($) {
                 showToast('Erreur de communication', 'error');
             },
             complete: function() {
-                $select.prop('disabled', false);
+                $select.removeAttr('aria-busy');
             }
         });
     });
@@ -183,7 +183,7 @@ jQuery(document).ready(function($) {
         }
         
         // Show loading state
-        $btn.prop('disabled', true).text('Envoi en cours...');
+        $btn.attr('aria-busy', 'true').text('Envoi en cours...');
         
         $.ajax({
             url: ajaxurl,
@@ -208,7 +208,7 @@ jQuery(document).ready(function($) {
                 showToast('Erreur de communication', 'error');
             },
             complete: function() {
-                $btn.prop('disabled', false).text('Envoyer au paiement');
+                $btn.removeAttr('aria-busy').text('Envoyer au paiement');
             }
         });
     });

--- a/assets/frontend/css/frontend.css
+++ b/assets/frontend/css/frontend.css
@@ -6,6 +6,11 @@
     --ufsc-font-size-heading: 1.4rem;
     --ufsc-font-weight-regular: 400;
     --ufsc-font-weight-semibold: 600;
+    --ufsc-color-navy: #1C2143;
+    --ufsc-color-steel: #2E3A8C;
+    --ufsc-color-light-gray: #F3F5F9;
+    --ufsc-color-white: #ffffff;
+    --ufsc-color-red: #E31E24;
 }
 
 /* // UFSC: Premium Grid System */
@@ -39,8 +44,8 @@
 
 /* // UFSC: Premium Card System */
 .ufsc-card {
-    background: #ffffff;
-    border: 1px solid #e1e5e9;
+    background: var(--ufsc-color-white);
+    border: 1px solid var(--ufsc-color-light-gray);
     border-radius: 8px;
     padding: 1.5rem;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
@@ -52,11 +57,16 @@
     transform: translateY(-2px);
 }
 
+.ufsc-card:focus-within {
+    outline: 2px solid var(--ufsc-color-steel);
+    outline-offset: 2px;
+}
+
 .ufsc-card h3 {
     margin: 0 0 1rem 0;
     font-size: 1.1rem;
     font-weight: 600;
-    color: #2c3e50;
+    color: var(--ufsc-color-navy);
 }
 
 /* // UFSC: Button System */
@@ -74,24 +84,53 @@
     transition: all 0.2s ease;
 }
 
-.ufsc-btn-primary {
-    background: #3498db;
-    color: white;
+.ufsc-btn:focus {
+    outline: 2px solid var(--ufsc-color-steel);
+    outline-offset: 2px;
 }
 
-.ufsc-btn-primary:hover {
-    background: #2980b9;
-    color: white;
+.ufsc-btn-primary {
+    background: var(--ufsc-color-steel);
+    color: var(--ufsc-color-white);
+}
+
+.ufsc-btn-primary:hover,
+.ufsc-btn-primary:focus {
+    background: var(--ufsc-color-navy);
+    color: var(--ufsc-color-white);
 }
 
 .ufsc-btn-secondary {
-    background: #95a5a6;
-    color: white;
+    background: var(--ufsc-color-light-gray);
+    color: var(--ufsc-color-navy);
 }
 
-.ufsc-btn-secondary:hover {
-    background: #7f8c8d;
-    color: white;
+.ufsc-btn-secondary:hover,
+.ufsc-btn-secondary:focus {
+    background: var(--ufsc-color-steel);
+    color: var(--ufsc-color-white);
+}
+
+/* // UFSC: Badge System */
+.ufsc-badge {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    background: var(--ufsc-color-light-gray);
+    color: var(--ufsc-color-navy);
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.ufsc-badge:focus {
+    outline: 2px solid var(--ufsc-color-steel);
+    outline-offset: 2px;
+}
+
+/* // UFSC: Tabs */
+.ufsc-nav-btn:focus {
+    outline: 2px solid var(--ufsc-color-steel);
+    outline-offset: 2px;
 }
 
 /* Dashboard Layout */
@@ -506,7 +545,7 @@
 
 .ufsc-alert-error {
     background: #f8d7da;
-    border-left-color: #dc3545;
+    border-left-color: var(--ufsc-color-red);
     color: #721c24;
 }
 
@@ -598,8 +637,8 @@
 }
 
 .ufsc-btn-small.-danger {
-    background: #dc3545;
-    border-color: #dc3545;
+    background: var(--ufsc-color-red);
+    border-color: var(--ufsc-color-red);
 }
 
 .ufsc-btn-small.-danger:hover {
@@ -1734,12 +1773,12 @@ textarea:focus {
 .ufsc-form-field.has-error input,
 .ufsc-form-field.has-error textarea,
 .ufsc-form-field.has-error select {
-    border-color: #dc3545;
-    box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.1);
+    border-color: var(--ufsc-color-red);
+    box-shadow: 0 0 0 3px rgba(227, 30, 36, 0.1);
 }
 
 .ufsc-field-error {
-    color: #dc3545;
+    color: var(--ufsc-color-red);
     font-size: 0.8rem;
     margin-top: 0.25rem;
     display: block;

--- a/assets/frontend/js/frontend.js
+++ b/assets/frontend/js/frontend.js
@@ -260,7 +260,7 @@ jQuery(document).ready(function($) {
             var $submitBtn = $form.find('button[type="submit"], input[type="submit"]');
             
             // Add loading state
-            $submitBtn.prop('disabled', true);
+            $submitBtn.attr('aria-busy', 'true');
             $form.addClass('ufsc-loading');
             
             // Store original text
@@ -409,7 +409,7 @@ jQuery(document).ready(function($) {
             }
 
             // UI feedback
-            $btn.addClass('ufsc-loading').prop('disabled', true);
+            $btn.addClass('ufsc-loading').attr('aria-busy', 'true');
             $btn.text(ufsc_frontend_vars.strings.exporting);
 
             var xhr = new XMLHttpRequest();
@@ -457,14 +457,14 @@ jQuery(document).ready(function($) {
                     }
                 }
 
-                $btn.removeClass('ufsc-loading').prop('disabled', false);
+                $btn.removeClass('ufsc-loading').removeAttr('aria-busy');
                 $btn.text(originalText);
                 $btn.data('exporting', false);
             };
 
             xhr.onerror = function() {
                 alert(ufsc_frontend_vars.strings.ajax_error);
-                $btn.removeClass('ufsc-loading').prop('disabled', false);
+                $btn.removeClass('ufsc-loading').removeAttr('aria-busy');
                 $btn.text(originalText);
                 $btn.data('exporting', false);
             };

--- a/assets/frontend/js/ufsc-club-form.js
+++ b/assets/frontend/js/ufsc-club-form.js
@@ -228,11 +228,11 @@
             const $submitBtn = $(this).find('button[type="submit"]');
             const originalText = $submitBtn.text();
             
-            $submitBtn.prop('disabled', true).text('Enregistrement...');
-            
-            // Re-enable after a timeout as fallback
+            $submitBtn.attr('aria-busy', 'true').text('Enregistrement...');
+
+            // Remove busy state after a timeout as fallback
             setTimeout(function() {
-                $submitBtn.prop('disabled', false).text(originalText);
+                $submitBtn.removeAttr('aria-busy').text(originalText);
             }, 30000);
         });
         

--- a/assets/js/ufsc-license-form.js
+++ b/assets/js/ufsc-license-form.js
@@ -336,8 +336,8 @@
         $('form').on('submit', function() {
             const form = $(this);
             const buttons = form.find('button[type="submit"]');
-            
-            buttons.prop('disabled', true).each(function() {
+
+            buttons.attr('aria-busy', 'true').each(function() {
                 const btn = $(this);
                 const originalText = btn.text();
                 btn.data('original-text', originalText);

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -151,26 +151,26 @@ class UFSC_CL_Admin_Menu {
         echo '<div class="ufsc-dashboard-cards">';
         
         // Clubs KPIs
-        echo '<div class="ufsc-dashboard-card">';
+        echo '<div class="ufsc-dashboard-card" role="group" tabindex="0" aria-label="'.esc_attr__('Clubs Total','ufsc-clubs').'">';
         echo '<div class="card-label">'.esc_html__('Clubs Total','ufsc-clubs').'</div>';
         echo '<div class="card-value">'.esc_html($dashboard_data['clubs_total']).'</div>';
         echo '<div class="card-description">'.sprintf(esc_html__('%d actifs','ufsc-clubs'), $dashboard_data['clubs_active']).'</div>';
         echo '</div>';
         
         // Licenses by status
-        echo '<div class="ufsc-dashboard-card">';
+        echo '<div class="ufsc-dashboard-card" role="group" tabindex="0" aria-label="'.esc_attr__('Licences Validées','ufsc-clubs').'">';
         echo '<div class="card-label">'.esc_html__('Licences Validées','ufsc-clubs').'</div>';
         echo '<div class="card-value" style="color: #00a32a;">'.esc_html($dashboard_data['licenses_valid']).'</div>';
         echo '<div class="card-description">'.sprintf(esc_html__('sur %d total','ufsc-clubs'), $dashboard_data['licenses_total']).'</div>';
         echo '</div>';
         
-        echo '<div class="ufsc-dashboard-card">';
+        echo '<div class="ufsc-dashboard-card" role="group" tabindex="0" aria-label="'.esc_attr__('En Attente','ufsc-clubs').'">';
         echo '<div class="card-label">'.esc_html__('En Attente','ufsc-clubs').'</div>';
         echo '<div class="card-value" style="color: #f0b000;">'.esc_html($dashboard_data['licenses_pending']).'</div>';
         echo '<div class="card-description">'.esc_html__('paiement requis','ufsc-clubs').'</div>';
         echo '</div>';
         
-        echo '<div class="ufsc-dashboard-card">';
+        echo '<div class="ufsc-dashboard-card" role="group" tabindex="0" aria-label="'.esc_attr__('Licences Refusées','ufsc-clubs').'">';
         echo '<div class="card-label">'.esc_html__('Licences Refusées','ufsc-clubs').'</div>';
         echo '<div class="card-value" style="color: #d63638;">'.esc_html($dashboard_data['licenses_rejected']).'</div>';
         echo '<div class="card-description">'.esc_html__('révision nécessaire','ufsc-clubs').'</div>';
@@ -178,7 +178,7 @@ class UFSC_CL_Admin_Menu {
         
         // Expiring licenses (if available)
         if (isset($dashboard_data['licenses_expiring_soon'])) {
-            echo '<div class="ufsc-dashboard-card">';
+            echo '<div class="ufsc-dashboard-card" role="group" tabindex="0" aria-label="'.esc_attr__('Expirent < 30j','ufsc-clubs').'">';
             echo '<div class="card-label">'.esc_html__('Expirent < 30j','ufsc-clubs').'</div>';
             echo '<div class="card-value" style="color: #f56e28;">'.esc_html($dashboard_data['licenses_expiring_soon']).'</div>';
             echo '<div class="card-description">'.esc_html__('renouvellement requis','ufsc-clubs').'</div>';

--- a/includes/core/class-badge-helper.php
+++ b/includes/core/class-badge-helper.php
@@ -72,7 +72,7 @@ class UFSC_Badge_Helper {
         $class = isset( $options['class'] ) ? $options['class'] : $config['class'];
         
         return sprintf(
-            '<span class="ufsc-badge %s" data-status="%s">%s</span>',
+            '<span class="ufsc-badge %s" data-status="%s" role="status">%s</span>',
             esc_attr( $class ),
             esc_attr( $status ),
             esc_html( $label )
@@ -91,7 +91,7 @@ class UFSC_Badge_Helper {
         $class = isset( $options['class'] ) ? $options['class'] : $config['class'];
         
         return sprintf(
-            '<span class="ufsc-badge %s" data-region="%s">%s</span>',
+            '<span class="ufsc-badge %s" data-region="%s" role="status">%s</span>',
             esc_attr( $class ),
             esc_attr( $region ),
             esc_html( $region )
@@ -114,7 +114,7 @@ class UFSC_Badge_Helper {
         $class = isset( $options['class'] ) ? $options['class'] : $config['class'];
         
         return sprintf(
-            '<span class="ufsc-badge %s" data-doc-status="%s">%s</span>',
+            '<span class="ufsc-badge %s" data-doc-status="%s" role="status">%s</span>',
             esc_attr( $class ),
             esc_attr( $status ),
             esc_html( $label )
@@ -127,11 +127,16 @@ class UFSC_Badge_Helper {
      */
     public static function enqueue_styles() {
         add_action( 'wp_enqueue_scripts', function() {
-            wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
+            $post = get_post();
+            if ( $post && ( has_shortcode( $post->post_content, 'ufsc_login_form' ) || has_shortcode( $post->post_content, 'ufsc_user_status' ) ) ) {
+                wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
+            }
         } );
 
-        add_action( 'admin_enqueue_scripts', function() {
-            wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
+        add_action( 'admin_enqueue_scripts', function( $hook ) {
+            if ( strpos( (string) $hook, 'ufsc' ) !== false ) {
+                wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
+            }
         } );
     }
 

--- a/includes/frontend/class-affiliation-form.php
+++ b/includes/frontend/class-affiliation-form.php
@@ -29,6 +29,11 @@ class UFSC_Affiliation_Form {
             return;
         }
 
+        $post = get_post();
+        if ( ! $post || ! has_shortcode( $post->post_content, 'ufsc_affiliation_form' ) ) {
+            return;
+        }
+
         wp_enqueue_script(
             'ufsc-affiliation',
             UFSC_CL_URL . 'assets/js/ufsc-affiliation.js',


### PR DESCRIPTION
## Summary
- define shared color variables in admin and frontend styles
- add accessible card, badge, button and tab styles with focus indicators
- keep submit buttons enabled and gate asset loading to shortcode pages

## Testing
- `composer phpcs` *(fails: phpcs: not found)*
- `composer phpstan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a1d0fe0832b8180334aec885779