### PR TITLE
Restrict front-end edits for validated records

### DIFF
--- a/inc/permissions.php
+++ b/inc/permissions.php
@@ -1,0 +1,30 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Determine allowed fields for an entity based on context and status.
+ *
+ * @param string $entity  Entity type: 'licence' or 'club'.
+ * @param string $context Operation context: 'create', 'update', 'frontend', etc.
+ * @param string $status  Current status of the entity.
+ * @return array List of allowed field keys.
+ */
+function ufsc_allowed_fields( $entity, $context = 'create', $status = '' ) {
+    switch ( $entity ) {
+        case 'licence':
+            $fields = array_keys( UFSC_SQL::get_licence_fields() );
+            if ( in_array( $context, array( 'update', 'frontend' ), true ) && 'valide' === $status ) {
+                $fields = array( 'email', 'tel_fixe', 'tel_mobile' );
+            }
+            return $fields;
+
+        case 'club':
+            $fields = array_keys( UFSC_SQL::get_club_fields() );
+            if ( in_array( $context, array( 'update', 'frontend' ), true ) && 'valide' === $status ) {
+                $fields = array( 'email', 'telephone' );
+            }
+            return $fields;
+    }
+
+    return array();
+}

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -90,6 +90,9 @@ class UFSC_Unified_Handlers {
             return;
         }
 
+        $allowed = ufsc_allowed_fields( 'licence', 'create', 'draft' );
+        $data    = array_intersect_key( $data, array_flip( $allowed ) );
+
         $result = self::save_licence_data( 0, $club_id, $data );
         if ( is_wp_error( $result ) ) {
             self::redirect_with_error( $result->get_error_message() );
@@ -181,6 +184,9 @@ class UFSC_Unified_Handlers {
             self::redirect_with_error( $data->get_error_message(), $licence_id );
             return;
         }
+
+        $allowed = ufsc_allowed_fields( 'licence', 'update', $licence_status );
+        $data    = array_intersect_key( $data, array_flip( $allowed ) );
 
         $result = self::save_licence_data( $licence_id, $club_id, $data );
         if ( is_wp_error( $result ) ) {
@@ -355,7 +361,12 @@ class UFSC_Unified_Handlers {
             }
         }
         $data = array_merge( $data, $upload_result );
-        
+
+        $status  = $data['statut'] ?? '';
+        $context = $club_id ? 'update' : 'create';
+        $allowed = ufsc_allowed_fields( 'club', $context, $status );
+        $data    = array_intersect_key( $data, array_flip( $allowed ) );
+
         // Save club data
         $result = self::save_club_data( $club_id, $data );
         if ( is_wp_error( $result ) ) {
@@ -406,10 +417,9 @@ class UFSC_Unified_Handlers {
             self::store_form_and_redirect( $_POST, array( $data->get_error_message() ), $licence_id );
         }
 
-        if ( 'draft' !== $licence_status ) {
-            $allowed = array( 'email', 'tel_fixe', 'tel_mobile' );
-            $data    = array_intersect_key( $data, array_flip( $allowed ) );
-        }
+        $context = $licence_id > 0 ? 'update' : 'create';
+        $allowed = ufsc_allowed_fields( 'licence', $context, $licence_status );
+        $data    = array_intersect_key( $data, array_flip( $allowed ) );
 
         $result = self::save_licence_data( $licence_id, $club_id, $data );
         if ( is_wp_error( $result ) ) {

--- a/includes/frontend/class-club-form-handler.php
+++ b/includes/frontend/class-club-form-handler.php
@@ -51,17 +51,21 @@ class UFSC_CL_Club_Form_Handler {
         $pk            = $settings['pk_club'];
         $validation_base = $data;
 
+        $current_status = '';
         if ( $is_edit ) {
             $current_status = $wpdb->get_var( $wpdb->prepare( "SELECT statut FROM `{$table}` WHERE `{$pk}` = %d", $club_id ) );
-            if ( $current_status && 'brouillon' !== $current_status ) {
+            if ( $current_status && 'valide' === $current_status ) {
                 $is_restricted = true;
-                $data = array_intersect_key( $data, array_flip( array( 'email', 'telephone' ) ) );
                 $existing      = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$table}` WHERE `{$pk}` = %d", $club_id ), ARRAY_A );
                 if ( $existing ) {
                     $validation_base = array_merge( $existing, $data );
                 }
             }
         }
+
+        $context = $is_edit ? 'update' : 'create';
+        $allowed = ufsc_allowed_fields( 'club', $context, $current_status );
+        $data    = array_intersect_key( $data, array_flip( $allowed ) );
 
         // Validate required fields
         $validation_errors = UFSC_CL_Utils::validate_club_data( $validation_base, $affiliation );

--- a/includes/frontend/class-club-form.php
+++ b/includes/frontend/class-club-form.php
@@ -121,8 +121,9 @@ class UFSC_CL_Club_Form {
         $regions  = UFSC_CL_Utils::regions();
 
         // Determine current status and edit restrictions
-        $status        = $club_data['statut'] ?? '';
-        $is_restricted = $is_edit && ! empty( $status ) && 'brouillon' !== $status;
+        $status          = $club_data['statut'] ?? '';
+        $allowed_fields  = ufsc_allowed_fields( 'club', 'update', $status );
+        $is_restricted   = $is_edit && 'valide' === $status;
 
         // Get default status for new clubs
         $default_status = $is_edit ? $status : self::get_default_status();
@@ -514,11 +515,16 @@ class UFSC_CL_Club_Form {
             </form>
         </div>
 
-        <?php if ( $is_restricted ) : ?>
+        <?php if ( $is_restricted ) :
+            $allowed_selectors   = array_map( function ( $f ) { return '#' . $f; }, $allowed_fields );
+            $allowed_selectors[] = '#ufsc-submit';
+            $allowed_selectors[] = '[type=hidden]';
+            $allowed_selector_str = implode( ', ', $allowed_selectors );
+            ?>
             <script>
                 jQuery(function ($) {
                     $('.ufsc-club-form').find('input, select, textarea, button')
-                        .not('#email, #telephone, #ufsc-submit, [type=hidden]')
+                        .not('<?php echo esc_js( $allowed_selector_str ); ?>')
                         .prop('readonly', true)
                         .prop('disabled', true);
                 });

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -2003,40 +2003,29 @@ class UFSC_Frontend_Shortcodes {
             }
         }
         
-        $update_data = array();
-        
-        if ( $is_admin ) {
-            // Admin can update all fields present in the data
-            $allowed_fields = ['nom', 'sigle', 'email', 'telephone', 'adresse', 'code_postal', 'ville', 'region'];
-            foreach ( $allowed_fields as $field ) {
-                if ( isset( $data[$field] ) ) {
-                    $update_data[$field] = sanitize_text_field( $data[$field] );
-                }
+        $status        = $club->statut ?? '';
+        $context       = $is_admin ? 'admin' : 'update';
+        $allowed_fields = ufsc_allowed_fields( 'club', $context, $status );
+        $update_data    = array();
+        foreach ( $data as $field => $value ) {
+            if ( in_array( $field, $allowed_fields, true ) ) {
+                $update_data[ $field ] = sanitize_text_field( $value );
             }
-            
-            // Handle logo upload for admin
-            if ( ! empty( $_FILES['club_logo']['name'] ) ) {
-                $upload_result = wp_handle_upload( $_FILES['club_logo'], array( 'test_form' => false ) );
-                if ( ! isset( $upload_result['error'] ) ) {
-                    $attachment_id = wp_insert_attachment( array(
-                        'post_title' => sanitize_file_name( $_FILES['club_logo']['name'] ),
-                        'post_content' => '',
-                        'post_status' => 'inherit',
-                        'post_mime_type' => $upload_result['type']
-                    ), $upload_result['file'] );
-                    
-                    if ( $attachment_id ) {
-                        update_option( 'ufsc_club_logo_' . $club_id, $attachment_id );
-                    }
-                }
-            }
-            
-        } else {
-            // Non-admin can only update email and telephone
-            $allowed_fields = ['email', 'telephone'];
-            foreach ( $allowed_fields as $field ) {
-                if ( isset( $data[$field] ) ) {
-                    $update_data[$field] = sanitize_text_field( $data[$field] );
+        }
+
+        // Handle logo upload for admin
+        if ( $is_admin && ! empty( $_FILES['club_logo']['name'] ) ) {
+            $upload_result = wp_handle_upload( $_FILES['club_logo'], array( 'test_form' => false ) );
+            if ( ! isset( $upload_result['error'] ) ) {
+                $attachment_id = wp_insert_attachment( array(
+                    'post_title'   => sanitize_file_name( $_FILES['club_logo']['name'] ),
+                    'post_content' => '',
+                    'post_status'  => 'inherit',
+                    'post_mime_type' => $upload_result['type'],
+                ), $upload_result['file'] );
+
+                if ( $attachment_id ) {
+                    update_option( 'ufsc_club_logo_' . $club_id, $attachment_id );
                 }
             }
         }
@@ -2075,14 +2064,9 @@ class UFSC_Frontend_Shortcodes {
         
         // Determine editable fields based on user role
         $is_admin = current_user_can( 'ufsc_manage' );
-        
-        if ( $is_admin ) {
-            // Admin can edit all fields
-            $allowed_fields = array_keys( UFSC_Column_Map::get_clubs_columns() );
-        } else {
-            // Non-admin can only edit email and telephone
-            $allowed_fields = array( 'email', 'telephone' );
-        }
+        $status   = $wpdb->get_var( $wpdb->prepare( "SELECT statut FROM `{$table}` WHERE `{$pk}` = %d", $club_id ) );
+        $context  = $is_admin ? 'admin' : 'update';
+        $allowed_fields = ufsc_allowed_fields( 'club', $context, $status );
         
         $update_data = array();
         foreach ( $allowed_fields as $field ) {
@@ -2137,7 +2121,9 @@ class UFSC_Frontend_Shortcodes {
         $table = ufsc_get_clubs_table();
         
         // Determine allowed fields based on user permissions
-        $allowed_fields = $is_admin ? null : array( 'email', 'telephone' );
+        $club_status   = $wpdb->get_var( $wpdb->prepare( "SELECT statut FROM `{$table}` WHERE id = %d", $club_id ) );
+        $context       = $is_admin ? 'admin' : 'update';
+        $allowed_fields = ufsc_allowed_fields( 'club', $context, $club_status );
         
         $update_data = array();
         

--- a/templates/frontend/licence-form.php
+++ b/templates/frontend/licence-form.php
@@ -6,9 +6,14 @@ $included_limit = isset( $wc_settings['included_licenses'] ) ? (int) $wc_setting
 $included_count = UFSC_Licence_Form::get_included_count();
 $club_id       = ufsc_get_user_club_id( get_current_user_id() );
 $licence_status = $licence->statut ?? 'draft';
-$is_restricted  = 'draft' !== $licence_status;
-$lock_attr      = $is_restricted ? ' readonly disabled' : '';
-$lock_only_dis  = $is_restricted ? ' disabled' : '';
+$allowed_fields = ufsc_allowed_fields( 'licence', 'update', $licence_status );
+$is_restricted  = 'valide' === $licence_status;
+$lock_attr      = function ( $field ) use ( $allowed_fields ) {
+    return in_array( $field, $allowed_fields, true ) ? '' : ' readonly disabled';
+};
+$lock_only_dis  = function ( $field ) use ( $allowed_fields ) {
+    return in_array( $field, $allowed_fields, true ) ? '' : ' disabled';
+};
 ?>
 <div class="ufsc-front ufsc-full">
 <form method="post" class="ufsc-licence-form cart" data-licence-status="<?php echo esc_attr( $licence_status ); ?>">
@@ -25,11 +30,11 @@ $lock_only_dis  = $is_restricted ? ' disabled' : '';
     <div class="ufsc-grid">
         <div class="ufsc-field">
             <label for="prenom"><?php esc_html_e( 'Pr\u00e9nom', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="prenom" name="prenom" value="<?php echo esc_attr( $licence->prenom ?? '' ); ?>"<?php echo $lock_attr; ?> />
+            <input type="text" id="prenom" name="prenom" value="<?php echo esc_attr( $licence->prenom ?? '' ); ?>"<?php echo $lock_attr( 'prenom' ); ?> />
         </div>
         <div class="ufsc-field">
             <label for="nom"><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="nom" name="nom" value="<?php echo esc_attr( $licence->nom ?? '' ); ?>"<?php echo $lock_attr; ?> />
+            <input type="text" id="nom" name="nom" value="<?php echo esc_attr( $licence->nom ?? '' ); ?>"<?php echo $lock_attr( 'nom' ); ?> />
         </div>
         <div class="ufsc-field ufsc-field-full">
             <label for="email">Email</label>
@@ -45,11 +50,11 @@ $lock_only_dis  = $is_restricted ? ' disabled' : '';
         </div>
         <div class="ufsc-field">
             <label for="date_naissance"><?php esc_html_e( 'Date de naissance', 'ufsc-clubs' ); ?></label>
-            <input type="date" id="date_naissance" name="date_naissance" value="<?php echo esc_attr( $licence->date_naissance ?? '' ); ?>"<?php echo $lock_attr; ?> />
+            <input type="date" id="date_naissance" name="date_naissance" value="<?php echo esc_attr( $licence->date_naissance ?? '' ); ?>"<?php echo $lock_attr( 'date_naissance' ); ?> />
         </div>
         <div class="ufsc-field">
             <label for="role"><?php esc_html_e( 'R\u00f4le', 'ufsc-clubs' ); ?></label>
-            <select id="role" name="role"<?php echo $lock_only_dis; ?>>
+            <select id="role" name="role"<?php echo $lock_only_dis( 'role' ); ?>>
                 <option value=""<?php selected( $licence->role ?? '', '' ); ?>><?php esc_html_e( 'S\u00e9lectionner', 'ufsc-clubs' ); ?></option>
                 <option value="president"<?php selected( $licence->role ?? '', 'president' ); ?>><?php esc_html_e( 'Pr\u00e9sident', 'ufsc-clubs' ); ?></option>
                 <option value="secretaire"<?php selected( $licence->role ?? '', 'secretaire' ); ?>><?php esc_html_e( 'Secr\u00e9taire', 'ufsc-clubs' ); ?></option>
@@ -59,28 +64,28 @@ $lock_only_dis  = $is_restricted ? ' disabled' : '';
             </select>
         </div>
         <div class="ufsc-field">
-            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_postier" name="reduction_postier" value="1" <?php checked( $licence->reduction_postier ?? 0, 1 ); ?><?php echo $lock_only_dis; ?> /> <?php esc_html_e( 'R\u00e9duction postier', 'ufsc-clubs' ); ?></label>
+            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_postier" name="reduction_postier" value="1" <?php checked( $licence->reduction_postier ?? 0, 1 ); ?><?php echo $lock_only_dis( 'reduction_postier' ); ?> /> <?php esc_html_e( 'R\u00e9duction postier', 'ufsc-clubs' ); ?></label>
         </div>
         <div class="ufsc-field ufsc-field-identifiant-laposte ufsc-field-full" style="display:none;">
             <label for="identifiant_laposte"><?php esc_html_e( 'Identifiant La Poste', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="identifiant_laposte" name="identifiant_laposte" value="<?php echo esc_attr( $licence->identifiant_laposte ?? '' ); ?>"<?php echo $lock_attr; ?> />
+            <input type="text" id="identifiant_laposte" name="identifiant_laposte" value="<?php echo esc_attr( $licence->identifiant_laposte ?? '' ); ?>"<?php echo $lock_attr( 'identifiant_laposte' ); ?> />
         </div>
         <div class="ufsc-field">
-            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_benevole" name="reduction_benevole" value="1" <?php checked( $licence->reduction_benevole ?? 0, 1 ); ?><?php echo $lock_only_dis; ?> /> <?php esc_html_e( 'R\u00e9duction b\u00e9n\u00e9vole', 'ufsc-clubs' ); ?></label>
+            <label class="ufsc-checkbox"><input type="checkbox" id="reduction_benevole" name="reduction_benevole" value="1" <?php checked( $licence->reduction_benevole ?? 0, 1 ); ?><?php echo $lock_only_dis( 'reduction_benevole' ); ?> /> <?php esc_html_e( 'R\u00e9duction b\u00e9n\u00e9vole', 'ufsc-clubs' ); ?></label>
         </div>
         <div class="ufsc-field">
-            <label class="ufsc-checkbox"><input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1" <?php checked( $licence->licence_delegataire ?? 0, 1 ); ?><?php echo $lock_only_dis; ?> /> <?php esc_html_e( 'Licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
+            <label class="ufsc-checkbox"><input type="checkbox" id="licence_delegataire" name="licence_delegataire" value="1" <?php checked( $licence->licence_delegataire ?? 0, 1 ); ?><?php echo $lock_only_dis( 'licence_delegataire' ); ?> /> <?php esc_html_e( 'Licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
         </div>
         <div class="ufsc-field ufsc-field-numero-delegataire ufsc-field-full" style="display:none;">
             <label for="numero_licence_delegataire"><?php esc_html_e( 'Num\u00e9ro de licence d\u00e9l\u00e9gataire', 'ufsc-clubs' ); ?></label>
-            <input type="text" id="numero_licence_delegataire" name="numero_licence_delegataire" value="<?php echo esc_attr( $licence->numero_licence_delegataire ?? '' ); ?>"<?php echo $lock_attr; ?> />
+            <input type="text" id="numero_licence_delegataire" name="numero_licence_delegataire" value="<?php echo esc_attr( $licence->numero_licence_delegataire ?? '' ); ?>"<?php echo $lock_attr( 'numero_licence_delegataire' ); ?> />
         </div>
         <div class="ufsc-field ufsc-field-full">
             <label for="note"><?php esc_html_e( 'Note', 'ufsc-clubs' ); ?></label>
-            <textarea id="note" name="note" rows="3"<?php echo $lock_attr; ?>><?php echo esc_textarea( $licence->note ?? '' ); ?></textarea>
+            <textarea id="note" name="note" rows="3"<?php echo $lock_attr( 'note' ); ?>><?php echo esc_textarea( $licence->note ?? '' ); ?></textarea>
         </div>
         <div class="ufsc-field">
-            <label class="ufsc-checkbox"><input type="checkbox" id="is_included" name="is_included" value="1" <?php checked( $licence->is_included ?? 0, 1 ); ?><?php echo $lock_only_dis; ?> /> <?php esc_html_e( 'Inclure dans quota', 'ufsc-clubs' ); ?></label>
+            <label class="ufsc-checkbox"><input type="checkbox" id="is_included" name="is_included" value="1" <?php checked( $licence->is_included ?? 0, 1 ); ?><?php echo $lock_only_dis( 'is_included' ); ?> /> <?php esc_html_e( 'Inclure dans quota', 'ufsc-clubs' ); ?></label>
         </div>
     </div>
     <div class="ufsc-form-actions">

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -72,6 +72,7 @@ require_once UFSC_CL_DIR.'inc/common/regions.php';
 require_once UFSC_CL_DIR.'inc/common/tables.php';
 require_once UFSC_CL_DIR.'inc/settings.php';
 require_once UFSC_CL_DIR.'inc/form-license-sanitizer.php';
+require_once UFSC_CL_DIR.'inc/permissions.php';
 require_once UFSC_CL_DIR.'inc/woocommerce/settings-woocommerce.php';
 require_once UFSC_CL_DIR.'inc/woocommerce/hooks.php';
 require_once UFSC_CL_DIR.'inc/woocommerce/admin-actions.php';


### PR DESCRIPTION
## Summary
- add ufsc_allowed_fields utility for field permissions
- enforce allowed fields during licence/club saves and API updates
- disable non-contact fields on front-end forms when status is `valide`

## Testing
- `php -l inc/permissions.php && php -l includes/core/class-unified-handlers.php && php -l includes/frontend/class-club-form-handler.php && php -l includes/frontend/class-club-form.php && php -l templates/frontend/licence-form.php && php -l includes/api/class-rest-api.php && php -l includes/frontend/class-frontend-shortcodes.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `composer phpcs` *(fails: phpcs not found)*
- `composer phpstan` *(fails: phpstan not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a1a1614832b8d219088ac05523a