### PR TITLE
Add admin-managed season settings and improve licence region handling

### DIFF
--- a/inc/common/season.php
+++ b/inc/common/season.php
@@ -24,6 +24,12 @@ if ( ! function_exists( 'ufsc_get_season_for_date' ) ) {
 
 if ( ! function_exists( 'ufsc_get_current_season' ) ) {
 	function ufsc_get_current_season() {
+		$stored = get_option( 'ufsc_current_season', '' );
+		$stored = is_string( $stored ) ? sanitize_text_field( $stored ) : '';
+		if ( preg_match( '/^(\d{4})-(\d{4})$/', $stored, $matches ) && ( (int) $matches[2] ) === ( (int) $matches[1] + 1 ) ) {
+			return $stored;
+		}
+
 		return ufsc_get_season_for_date( current_time( 'timestamp' ) );
 	}
 }
@@ -39,6 +45,12 @@ if ( ! function_exists( 'ufsc_get_current_season_label' ) ) {
 
 if ( ! function_exists( 'ufsc_get_next_season' ) ) {
 	function ufsc_get_next_season() {
+		$stored = get_option( 'ufsc_next_season', '' );
+		$stored = is_string( $stored ) ? sanitize_text_field( $stored ) : '';
+		if ( preg_match( '/^(\d{4})-(\d{4})$/', $stored, $matches ) && ( (int) $matches[2] ) === ( (int) $matches[1] + 1 ) ) {
+			return $stored;
+		}
+
 		$current = ufsc_get_current_season();
 		if ( preg_match( '/^(\d{4})-(\d{4})$/', $current, $m ) ) {
 			return sprintf( '%d-%d', (int) $m[1] + 1, (int) $m[2] + 1 );
@@ -64,6 +76,11 @@ if ( ! function_exists( 'ufsc_get_renewal_window_day_month' ) ) {
 
 if ( ! function_exists( 'ufsc_get_renewal_window_start_ts' ) ) {
 	function ufsc_get_renewal_window_start_ts() {
+		$stored_ts = absint( get_option( 'ufsc_renewal_window_start_ts', 0 ) );
+		if ( $stored_ts > 0 ) {
+			return $stored_ts;
+		}
+
 		$current = ufsc_get_current_season();
 		$end     = 0;
 

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -1382,8 +1382,12 @@ class UFSC_SQL_Admin
             }
         }
 
-        if (! empty($filter_region) && in_array('region', $licence_columns, true)) {
-            $where_conditions[] = $wpdb->prepare("l.region = %s", $filter_region);
+        if ( ! empty( $filter_region ) ) {
+            if ( $has_club_id && in_array( 'region', $club_columns, true ) ) {
+                $where_conditions[] = $wpdb->prepare( "c.region = %s", $filter_region );
+            } elseif ( in_array( 'region', $licence_columns, true ) ) {
+                $where_conditions[] = $wpdb->prepare( "l.region = %s", $filter_region );
+            }
         }
 
         $scope_condition = '';
@@ -1427,7 +1431,9 @@ class UFSC_SQL_Admin
             self::build_select_column('l', 'nom', $licence_columns),
             self::build_select_column('l', 'date_naissance', $licence_columns),
             self::build_select_column('l', 'club_id', $licence_columns),
-            self::build_select_column('l', 'region', $licence_columns),
+            ( $join_sql && in_array( 'region', $club_columns, true ) )
+                ? "COALESCE(NULLIF(c.region, ''), " . self::build_select_column( 'l', 'region', $licence_columns ) . ") AS region"
+                : self::build_select_column('l', 'region', $licence_columns),
             self::build_select_column('l', 'statut', $licence_columns),
             self::build_select_column('l', 'payment_status', $licence_columns),
             self::build_select_column('l', 'paid', $licence_columns),
@@ -1630,7 +1636,7 @@ class UFSC_SQL_Admin
                 echo '<td><strong>' . esc_html($name) . '</strong></td>';
                 echo '<td>' . esc_html($r->date_naissance) . '</td>';
                 echo '<td>' . $club_display . '</td>';
-                echo '<td>' . esc_html($r->region) . '</td>';
+                echo '<td>' . esc_html( '' !== trim( (string) ( $r->region ?? '' ) ) ? $r->region : '—' ) . '</td>';
                 echo '<td>';
 
                 // Display status badge with colored dot


### PR DESCRIPTION
### Motivation
- Provide a clear admin place to set the current season, renewal open date and optional next season used by existing helpers, without touching front code. 
- Ensure season values are centrally stored and validated to avoid ad-hoc derivation across requests while preserving existing fallback logic. 
- Fix missing/empty `region` values in the admin licence list by preferring club-region when available.

### Description
- Add a `Gestion des saisons` block to the existing `UFSC Gestion → Paramètres WooCommerce` page with inputs saved to `ufsc_current_season`, `ufsc_next_season` and `ufsc_renewal_window_start_ts`, including permission and nonce checks and sanitation of inputs. 
- Add `ufsc_is_valid_season_label()` and `ufsc_admin_date_to_wp_timestamp()` helpers and server-side validation (format `YYYY-YYYY` with year2 = year1 + 1) and proper WP timezone date->timestamp conversion. 
- Make existing helpers prefer admin options: `ufsc_get_current_season()` reads `ufsc_current_season` if valid, `ufsc_get_next_season()` reads `ufsc_next_season` if valid, and `ufsc_get_renewal_window_start_ts()` reads `ufsc_renewal_window_start_ts` if set, otherwise falling back to the historical behavior. 
- Improve admin licences list to use `c.region` when available, select `COALESCE(NULLIF(c.region, ''), l.region) AS region` in the query, and display `—` when region is empty, avoiding front/template changes. 
- Files modified: `inc/woocommerce/settings-woocommerce.php`, `inc/common/season.php`, `includes/admin/class-sql-admin.php`.

### Testing
- Ran syntax checks: `php -l inc/woocommerce/settings-woocommerce.php` (no syntax errors). 
- Ran syntax checks: `php -l inc/common/season.php` (no syntax errors). 
- Ran syntax checks: `php -l includes/admin/class-sql-admin.php` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a37778d990832b8bbc4af9597380f9)