### PR TITLE
Refonte UI admin des Documents du club — tableau, actions et media uploader

### DIFF
--- a/assets/js/ufsc-admin-club-documents.js
+++ b/assets/js/ufsc-admin-club-documents.js
@@ -1,0 +1,52 @@
+(function($){
+    'use strict';
+
+    function toggleFileActions($row, enabled, url) {
+        var safeUrl = url || '#';
+        $row.find('.ufsc-doc-view, .ufsc-doc-download').attr('href', safeUrl).prop('disabled', !enabled);
+        if (enabled) {
+            $row.find('.ufsc-doc-view, .ufsc-doc-download').removeAttr('disabled');
+        }
+    }
+
+    $(document).on('click', '.ufsc-doc-replace', function(e){
+        e.preventDefault();
+
+        var $row = $(this).closest('.ufsc-doc-row');
+        var frame = wp.media({
+            title: (window.ufscClubDocsL10n && ufscClubDocsL10n.chooseFile) || 'Choisir un fichier',
+            button: { text: (window.ufscClubDocsL10n && ufscClubDocsL10n.useFile) || 'Utiliser ce fichier' },
+            multiple: false
+        });
+
+        frame.on('select', function(){
+            var attachment = frame.state().get('selection').first().toJSON();
+            $row.find('.ufsc-doc-attachment-id').val(attachment.id);
+            $row.find('.ufsc-doc-remove-flag').val('0');
+
+            $row.find('.ufsc-doc-badge.no-file').remove();
+            $row.find('.ufsc-doc-file-name').text(attachment.title || attachment.filename || 'Fichier').show();
+            $row.find('.ufsc-doc-file-meta').text((attachment.filesizeHuman || '') + (attachment.dateFormatted ? ' · ' + attachment.dateFormatted : '')).show();
+
+            toggleFileActions($row, true, attachment.url || '#');
+        });
+
+        frame.open();
+    });
+
+    $(document).on('click', '.ufsc-doc-remove', function(e){
+        e.preventDefault();
+
+        var $row = $(this).closest('.ufsc-doc-row');
+        $row.find('.ufsc-doc-attachment-id').val('');
+        $row.find('.ufsc-doc-remove-flag').val('1');
+        $row.find('.ufsc-doc-file-name').text('');
+        $row.find('.ufsc-doc-file-meta').text('');
+
+        if (!$row.find('.ufsc-doc-badge.no-file').length) {
+            $row.find('td').eq(1).prepend('<span class="ufsc-doc-badge no-file"><span class="dashicons dashicons-warning" style="font-size:14px;width:14px;height:14px"></span>Aucun fichier</span>');
+        }
+
+        toggleFileActions($row, false, '#');
+    });
+})(jQuery);

--- a/assets/js/ufsc-admin-club-documents.js
+++ b/assets/js/ufsc-admin-club-documents.js
@@ -27,6 +27,7 @@
             $row.find('.ufsc-doc-badge.no-file').remove();
             $row.find('.ufsc-doc-file-name').text(attachment.title || attachment.filename || 'Fichier').show();
             $row.find('.ufsc-doc-file-meta').text((attachment.filesizeHuman || '') + (attachment.dateFormatted ? ' · ' + attachment.dateFormatted : '')).show();
+            $row.find('.ufsc-doc-replace').text('Remplacer');
 
             toggleFileActions($row, true, attachment.url || '#');
         });
@@ -46,6 +47,8 @@
         if (!$row.find('.ufsc-doc-badge.no-file').length) {
             $row.find('td').eq(1).prepend('<span class="ufsc-doc-badge no-file"><span class="dashicons dashicons-warning" style="font-size:14px;width:14px;height:14px"></span>Aucun fichier</span>');
         }
+
+        $row.find('.ufsc-doc-replace').text((window.ufscClubDocsL10n && ufscClubDocsL10n.addFile) || 'Ajouter');
 
         toggleFileActions($row, false, '#');
     });

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -101,6 +101,7 @@ final class UFSC_CL_Bootstrap {
 
         // SQL Admin CRUD actions (pages cachées mais enregistrées pour les actions directes)
         add_action( 'admin_menu', array( 'UFSC_SQL_Admin', 'register_hidden_pages' ) );
+        add_action( 'admin_enqueue_scripts', array( 'UFSC_SQL_Admin', 'enqueue_admin_assets' ) );
         add_action( 'admin_post_ufsc_sql_save_club', array( 'UFSC_SQL_Admin', 'handle_save_club' ) );
         add_action( 'admin_post_ufsc_sql_delete_club', array( 'UFSC_SQL_Admin', 'handle_delete_club' ) );
         add_action( 'admin_post_ufsc_sql_save_licence', array( 'UFSC_SQL_Admin', 'handle_save_licence' ) );


### PR DESCRIPTION
### Motivation
- Remplacer la liste verticale existante par une présentation admin professionnelle et compacte pour la section « Documents du club » sans toucher aux clés de stockage ni à la logique métier existante. 
- Améliorer l’UX pour voir/télécharger/remplacer/supprimer un document depuis la fiche club en admin en utilisant le media uploader natif de WordPress. 
- Préserver la compatibilité (pas de changement front, pas de nouvelle table, pas de refactor global) et limiter l’impact sur la performance.

### Description
- Remplacement du rendu des documents par un tableau `widefat striped` avec colonnes Document / Fichier (nom + taille + date) / Statut / Actions, et badges visuels légers en CSS inline (fichier modifié: `includes/admin/class-sql-admin.php`).
- Ajout d’un helper de statuts `get_club_document_status_options()` et affichage des statuts existants (mêmes valeurs) ; CSS minimal inline pour badges afin d’éviter une feuille lourde (modification dans `includes/admin/class-sql-admin.php`).
- Intégration de `wp_enqueue_media()` et d’un script admin léger `assets/js/ufsc-admin-club-documents.js` pour ouvrir `wp.media`, sélectionner un attachement, remplir `*_attachment_id` et gérer un flag `*_remove` pour suppression côté formulaire (nouveau fichier JS et localisation du script dans `includes/admin/class-sql-admin.php`).
- Sauvegarde étendue sans changer les clés : vérification du nonce `ufsc_club_docs_nonce`, vérification des capacités, puis traitement des champs `doc_*_attachment_id` et `doc_*_remove` (mise à jour via `update_post_meta` / `delete_post_meta`) et conservation de la logique de statuts (sauvegarde via `update_option('ufsc_club_{doc_key}_status_{club_id}', ...)`).

### Testing
- Vérification syntaxique PHP : `php -l includes/admin/class-sql-admin.php` — succès. 
- Vérification basique JS : chargement avec `node -e "new Function(require('fs').readFileSync('assets/js/ufsc-admin-club-documents.js','utf8'))"` — succès.
- Commit local effectué et changements inclus : `includes/admin/class-sql-admin.php` (modifié) et `assets/js/ufsc-admin-club-documents.js` (ajouté), prêt pour validation fonctionnelle en environnement WordPress (remplacer/supprimer/voir/télécharger/statut à valider en WP).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a37a1f1944832bb0b654271066823b)