### PR TITLE
Reuse attachable draft licences, preserve identity on generation, and add targeted debug logging

### DIFF
--- a/inc/woocommerce/hooks.php
+++ b/inc/woocommerce/hooks.php
@@ -20,6 +20,37 @@ function ufsc_wc_log( $action, $context = array(), $level = 'info' ) {
 }
 
 /**
+ * Enable targeted licence sync debug logs.
+ *
+ * Toggle with UFSC_WC_DEBUG_LICENCE_SYNC constant or `ufsc_wc_debug_licence_sync` filter.
+ *
+ * @return bool
+ */
+function ufsc_wc_debug_enabled() {
+	$enabled = defined( 'UFSC_WC_DEBUG_LICENCE_SYNC' ) && UFSC_WC_DEBUG_LICENCE_SYNC;
+
+	/**
+	 * Filter to toggle targeted Woo licence sync debug logs.
+	 *
+	 * @param bool $enabled Current debug state.
+	 */
+	return (bool) apply_filters( 'ufsc_wc_debug_licence_sync', $enabled );
+}
+
+/**
+ * Write targeted debug logs only when enabled.
+ *
+ * @param string $action  Event/action key.
+ * @param array  $context Context payload.
+ * @return void
+ */
+function ufsc_wc_debug_log( $action, $context = array() ) {
+	if ( ufsc_wc_debug_enabled() ) {
+		ufsc_wc_log( $action, $context, 'info' );
+	}
+}
+
+/**
  * Initialize WooCommerce hooks
  */
 function ufsc_init_woocommerce_hooks() {
@@ -489,6 +520,21 @@ function ufsc_wc_generate_missing_licence_rows( $order, $item, $club_id, $missin
 		return $created;
 	}
 
+	$existing_draft_ids = ufsc_wc_find_attachable_draft_licence_ids( $club_id, $missing, $season, $order, $item );
+	if ( ! empty( $existing_draft_ids ) ) {
+		ufsc_wc_debug_log(
+			'ufsc_wc_existing_draft_licences_found',
+			array(
+				'order_id'     => (int) $order->get_id(),
+				'order_item_id'=> (int) $item->get_id(),
+				'club_id'      => (int) $club_id,
+				'requested'    => (int) $missing,
+				'matched_ids'  => $existing_draft_ids,
+			)
+		);
+		return $existing_draft_ids;
+	}
+
 	$table   = ufsc_get_licences_table();
 	$columns = function_exists( 'ufsc_table_columns' ) ? (array) ufsc_table_columns( $table ) : $wpdb->get_col( "DESCRIBE `{$table}`" );
 
@@ -498,14 +544,18 @@ function ufsc_wc_generate_missing_licence_rows( $order, $item, $club_id, $missin
 		if ( in_array( 'club_id', $columns, true ) ) {
 			$data['club_id'] = (int) $club_id;
 		}
+		$nom    = trim( (string) $item->get_meta( 'ufsc_nom', true ) );
+		$prenom = trim( (string) $item->get_meta( 'ufsc_prenom', true ) );
+		$birth  = trim( (string) $item->get_meta( 'ufsc_date_naissance', true ) );
+
 		if ( in_array( 'nom', $columns, true ) ) {
-			$data['nom'] = '';
+			$data['nom'] = $nom;
 		}
 		if ( in_array( 'prenom', $columns, true ) ) {
-			$data['prenom'] = '';
+			$data['prenom'] = $prenom;
 		}
-		if ( in_array( 'email', $columns, true ) ) {
-			$data['email'] = '';
+		if ( in_array( 'date_naissance', $columns, true ) && '' !== $birth ) {
+			$data['date_naissance'] = $birth;
 		}
 		if ( in_array( 'statut', $columns, true ) ) {
 			$data['statut'] = 'en_attente';
@@ -546,6 +596,22 @@ function ufsc_wc_generate_missing_licence_rows( $order, $item, $club_id, $missin
 			$data['note'] = sprintf( 'Commande WooCommerce #%d - Item #%d', $order->get_id(), $item->get_id() );
 		}
 
+		$has_min_identity = ( '' !== $nom && '' !== $prenom && '' !== $birth );
+		if ( ! $has_min_identity ) {
+			ufsc_wc_debug_log(
+				'ufsc_licence_generation_refused_missing_required_identity',
+				array(
+					'order_id'      => (int) $order->get_id(),
+					'order_item_id' => (int) $item->get_id(),
+					'club_id'       => (int) $club_id,
+					'missing_nom'   => '' === $nom ? 1 : 0,
+					'missing_prenom'=> '' === $prenom ? 1 : 0,
+					'missing_birth' => '' === $birth ? 1 : 0,
+				)
+			);
+			break;
+		}
+
 		if ( empty( $data ) || ! isset( $data['club_id'] ) ) {
 			ufsc_wc_log( 'ufsc_licence_generation_missing_required_columns', array( 'order_id' => $order->get_id(), 'item_id' => $item->get_id() ), 'error' );
 			break;
@@ -578,6 +644,130 @@ function ufsc_wc_generate_missing_licence_rows( $order, $item, $club_id, $missin
 	}
 
 	return $created;
+}
+
+/**
+ * Find payable draft licences that can be attached to an order item.
+ *
+ * @param int    $club_id Club ID.
+ * @param int    $limit   Max IDs required.
+ * @param string $season  Current season.
+ * @return int[]
+ */
+function ufsc_wc_find_attachable_draft_licence_ids( $club_id, $limit, $season = '', $order = null, $item = null ) {
+	global $wpdb;
+
+	$club_id = absint( $club_id );
+	$limit   = absint( $limit );
+	if ( $club_id <= 0 || $limit <= 0 || ! function_exists( 'ufsc_get_licences_table' ) ) {
+		return array();
+	}
+
+	$table   = ufsc_get_licences_table();
+	$columns = function_exists( 'ufsc_table_columns' ) ? (array) ufsc_table_columns( $table ) : $wpdb->get_col( "DESCRIBE `{$table}`" );
+	if ( empty( $columns ) || ! in_array( 'id', $columns, true ) || ! in_array( 'club_id', $columns, true ) ) {
+		return array();
+	}
+
+	$where              = array( 'club_id = %d' );
+	$args               = array( $club_id );
+	$strict_guards_used = false;
+
+	if ( in_array( 'statut', $columns, true ) ) {
+		$where[] = "(statut IS NULL OR statut = '' OR statut IN ('brouillon','draft','non_payee','a_regler','en_attente'))";
+	}
+
+	if ( in_array( 'payment_status', $columns, true ) ) {
+		$where[] = "(payment_status IS NULL OR payment_status = '' OR payment_status IN ('unpaid','pending','non_payee'))";
+	}
+
+	foreach ( array( 'paid', 'payee', 'is_paid' ) as $paid_col ) {
+		if ( in_array( $paid_col, $columns, true ) ) {
+			$where[] = "{$paid_col} = 0";
+		}
+	}
+
+	if ( in_array( 'order_id', $columns, true ) ) {
+		$where[] = '(order_id IS NULL OR order_id = 0)';
+	}
+
+	if ( in_array( 'order_item_id', $columns, true ) ) {
+		$where[] = '(order_item_id IS NULL OR order_item_id = 0)';
+	}
+
+	if ( '' !== $season && in_array( 'paid_season', $columns, true ) ) {
+		$where[] = '(paid_season IS NULL OR paid_season = %s OR paid_season = \'\')';
+		$args[]  = $season;
+	}
+
+	$order_user_id = ( $order && is_a( $order, 'WC_Order' ) ) ? absint( $order->get_user_id() ) : 0;
+	if ( $order_user_id > 0 ) {
+		foreach ( array( 'user_id', 'wp_user_id', 'responsable_id', 'created_by' ) as $user_col ) {
+			if ( in_array( $user_col, $columns, true ) ) {
+				$where[]            = "{$user_col} = %d";
+				$args[]             = $order_user_id;
+				$strict_guards_used = true;
+				break;
+			}
+		}
+	}
+
+	$max_age_days = (int) apply_filters( 'ufsc_wc_attachable_draft_max_age_days', 30, $club_id, $order, $item );
+	if ( $max_age_days > 0 ) {
+		$max_age_days = min( 365, $max_age_days );
+		foreach ( array( 'date_creation', 'created_at', 'date_inscription' ) as $date_col ) {
+			if ( in_array( $date_col, $columns, true ) ) {
+				$where[]            = "{$date_col} >= DATE_SUB(NOW(), INTERVAL %d DAY)";
+				$args[]             = $max_age_days;
+				$strict_guards_used = true;
+				break;
+			}
+		}
+	}
+
+	if ( in_array( 'is_draft_payable', $columns, true ) ) {
+		$where[]            = 'is_draft_payable = 1';
+		$strict_guards_used = true;
+	} elseif ( in_array( 'draft_payable', $columns, true ) ) {
+		$where[]            = 'draft_payable = 1';
+		$strict_guards_used = true;
+	}
+
+	if ( in_array( 'note', $columns, true ) ) {
+		$where[] = "note NOT LIKE 'Commande WooCommerce #%'";
+	}
+
+	$sql   = "SELECT id FROM `{$table}` WHERE " . implode( ' AND ', $where ) . ' ORDER BY id ASC LIMIT %d';
+	$args[] = $limit + 1; // detect ambiguous overflow safely.
+	$query = $wpdb->prepare( $sql, $args );
+	$ids   = array_values( array_unique( array_filter( array_map( 'absint', (array) $wpdb->get_col( $query ) ) ) ) );
+
+	if ( count( $ids ) > $limit ) {
+		ufsc_wc_debug_log(
+			'ufsc_attachable_drafts_ambiguous_overflow',
+			array(
+				'club_id'            => $club_id,
+				'requested'          => $limit,
+				'found'              => count( $ids ),
+				'strict_guards_used' => $strict_guards_used ? 1 : 0,
+			)
+		);
+		return array();
+	}
+
+	if ( ! $strict_guards_used && count( $ids ) > 1 ) {
+		ufsc_wc_debug_log(
+			'ufsc_attachable_drafts_refused_without_strict_guard',
+			array(
+				'club_id'   => $club_id,
+				'requested' => $limit,
+				'found'     => count( $ids ),
+			)
+		);
+		return array();
+	}
+
+	return $ids;
 }
 
 /**
@@ -621,8 +811,125 @@ function ufsc_wc_link_licence_ids_to_order_item( $order, $item, $licence_ids ) {
 	}
 
 	foreach ( $licence_ids as $licence_id ) {
-		$wpdb->update( $table, $data, array( 'id' => absint( $licence_id ) ), $type, array( '%d' ) );
+		$current_id = absint( $licence_id );
+		if ( $current_id <= 0 ) {
+			continue;
+		}
+
+		$existing = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$table}` WHERE id = %d", $current_id ) );
+		if ( ! $existing ) {
+			continue;
+		}
+
+		$has_order_id_col      = isset( $existing->order_id );
+		$has_order_item_id_col = isset( $existing->order_item_id );
+		$matches_order_id      = $has_order_id_col && (int) $existing->order_id === (int) $order->get_id();
+		$matches_order_item_id = $has_order_item_id_col && (int) $existing->order_item_id === (int) $item->get_id();
+		$already_linked        = false;
+
+		if ( $has_order_id_col && $has_order_item_id_col ) {
+			$already_linked = $matches_order_id && $matches_order_item_id;
+		} elseif ( $has_order_id_col ) {
+			$already_linked = $matches_order_id;
+		} elseif ( $has_order_item_id_col ) {
+			$already_linked = $matches_order_item_id;
+		}
+
+		if ( $already_linked ) {
+			ufsc_wc_debug_log(
+				'ufsc_licence_order_link_skipped_already_linked',
+				array(
+					'licence_id'    => $current_id,
+					'order_id'      => (int) $order->get_id(),
+					'order_item_id' => (int) $item->get_id(),
+				)
+			);
+			ufsc_wc_sync_reused_draft_payment_state( $current_id );
+			continue;
+		}
+
+		$wpdb->update( $table, $data, array( 'id' => $current_id ), $type, array( '%d' ) );
+		ufsc_wc_debug_log(
+			'ufsc_licence_order_link_updated',
+			array(
+				'licence_id'    => $current_id,
+				'order_id'      => (int) $order->get_id(),
+				'order_item_id' => (int) $item->get_id(),
+				'club_id'       => $club_id ? (int) $club_id : 0,
+			)
+		);
+		ufsc_wc_sync_reused_draft_payment_state( $current_id );
 	}
+}
+
+/**
+ * Ensure reused draft licences are aligned with paid-order state.
+ *
+ * @param int $licence_id Licence ID.
+ * @return void
+ */
+function ufsc_wc_sync_reused_draft_payment_state( $licence_id ) {
+	global $wpdb;
+
+	$licence_id = absint( $licence_id );
+	if ( $licence_id <= 0 || ! function_exists( 'ufsc_get_licences_table' ) ) {
+		return;
+	}
+
+	$table   = ufsc_get_licences_table();
+	$columns = function_exists( 'ufsc_table_columns' ) ? (array) ufsc_table_columns( $table ) : $wpdb->get_col( "DESCRIBE `{$table}`" );
+	if ( empty( $columns ) ) {
+		return;
+	}
+
+	$row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$table}` WHERE id = %d", $licence_id ) );
+	if ( ! $row ) {
+		return;
+	}
+
+	$current_status = function_exists( 'ufsc_normalize_license_status' )
+		? ufsc_normalize_license_status( $row->statut ?? '' )
+		: strtolower( trim( (string) ( $row->statut ?? '' ) ) );
+	if ( in_array( $current_status, array( 'valide', 'refuse', 'desactive' ), true ) ) {
+		return;
+	}
+
+	$data    = array();
+	$formats = array();
+
+	if ( in_array( 'payment_status', $columns, true ) && (string) ( $row->payment_status ?? '' ) !== 'paid' ) {
+		$data['payment_status'] = 'paid';
+		$formats[]              = '%s';
+	}
+
+	foreach ( array( 'paid', 'payee', 'is_paid' ) as $paid_col ) {
+		if ( in_array( $paid_col, $columns, true ) && (int) ( $row->{$paid_col} ?? 0 ) !== 1 ) {
+			$data[ $paid_col ] = 1;
+			$formats[]         = '%d';
+		}
+	}
+
+	if ( in_array( 'paid_date', $columns, true ) && empty( $row->paid_date ) ) {
+		$data['paid_date'] = current_time( 'mysql' );
+		$formats[]         = '%s';
+	}
+
+	if ( in_array( $current_status, array( 'brouillon', 'non_payee', 'a_regler' ), true ) ) {
+		if ( in_array( 'statut', $columns, true ) && (string) ( $row->statut ?? '' ) !== 'en_attente' ) {
+			$data['statut'] = 'en_attente';
+			$formats[]      = '%s';
+		}
+		if ( in_array( 'status', $columns, true ) && (string) ( $row->status ?? '' ) !== 'en_attente' ) {
+			$data['status'] = 'en_attente';
+			$formats[]      = '%s';
+		}
+	}
+
+	if ( empty( $data ) ) {
+		return;
+	}
+
+	$wpdb->update( $table, $data, array( 'id' => $licence_id ), $formats, array( '%d' ) );
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Avoid creating duplicate licence rows by reusing existing payable draft licences when possible. 
- Preserve minimal identity data (`nom`, `prenom`, `date_naissance`) when generating new licence rows so records are useful and complete. 
- Prevent accidental overwrites of licence/order links and keep payment state consistent for reused drafts. 
- Add a targeted debug switch for tracing licence-sync and reuse decisions without noisy global logging. 

### Description
- Added `ufsc_wc_debug_enabled()` and `ufsc_wc_debug_log()` to enable targeted debug logs controlled by the `UFSC_WC_DEBUG_LICENCE_SYNC` constant or the `ufsc_wc_debug_licence_sync` filter. 
- Implemented `ufsc_wc_find_attachable_draft_licence_ids()` to query and return candidate draft licence IDs using multiple guards (status, payment flags, order linkage, age, `is_draft_payable`) and ambiguity checks. 
- Updated `ufsc_wc_generate_missing_licence_rows()` to attempt to reuse existing draft IDs before creating new rows and to populate `nom`, `prenom`, and `date_naissance`, and to require a minimal identity set before creating licences. 
- Hardened `ufsc_wc_link_licence_ids_to_order_item()` to validate existing rows, skip already-linked rows, log actions, and call `ufsc_wc_sync_reused_draft_payment_state()` to align reused draft payment fields and statuses with the paid order. 

### Testing
- Ran PHP syntax checks (`php -l`) across modified files and confirmed no syntax errors. 
- Executed the existing PHPUnit test suite (`vendor/bin/phpunit`) and confirmed the suite passed with no regressions. 
- Performed automated static analysis/linting and found no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d94d886c68832baaade9bad4de987b)