### PR TITLE
Add payment traceability UI and robust, idempotent licence payment handling

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -2112,6 +2112,70 @@ class UFSC_SQL_Admin
         }
     }
 
+    private static function render_payment_traceability_block( $licence_id, $readonly = false )
+    {
+        if ( ! class_exists( 'UFSC_Licence_Payments' ) ) {
+            return;
+        }
+
+        $snapshot = UFSC_Licence_Payments::get_payment_snapshot( $licence_id );
+        $trace    = UFSC_Licence_Payments::get_latest_trace( $licence_id );
+        $readonly_attr = $readonly ? 'readonly disabled' : '';
+
+        $payment_source   = isset( $snapshot->payment_source ) ? (string) $snapshot->payment_source : '';
+        $payment_method   = isset( $snapshot->payment_method ) ? (string) $snapshot->payment_method : '';
+        $payment_gateway  = isset( $snapshot->payment_gateway ) ? (string) $snapshot->payment_gateway : '';
+        $payment_ref      = isset( $snapshot->payment_reference ) ? (string) $snapshot->payment_reference : '';
+        $payment_date     = isset( $snapshot->payment_date ) ? (string) $snapshot->payment_date : '';
+        $payment_amount   = isset( $trace->payment_amount ) && null !== $trace->payment_amount ? (string) $trace->payment_amount : '';
+        $payment_currency = isset( $trace->currency ) ? (string) $trace->currency : 'EUR';
+        $exception_reason = isset( $snapshot->payment_exception_reason ) ? (string) $snapshot->payment_exception_reason : '';
+        $wc_order_id      = isset( $snapshot->wc_order_id ) ? (int) $snapshot->wc_order_id : 0;
+        $wc_item_id       = isset( $snapshot->wc_order_item_id ) ? (int) $snapshot->wc_order_item_id : 0;
+        $wc_txn_id        = isset( $snapshot->wc_transaction_id ) ? (string) $snapshot->wc_transaction_id : '';
+
+        echo '<div class="ufsc-payment-traceability" style="margin-top:20px;padding:15px;border:1px solid #dcdcde;background:#fff;">';
+        echo '<h3 style="margin-top:0;">' . esc_html__( 'Traçabilité du paiement', 'ufsc-clubs' ) . '</h3>';
+        echo '<p class="description">' . esc_html__( 'Bloc de suivi administratif et comptable du rattachement paiement/licence.', 'ufsc-clubs' ) . '</p>';
+
+        echo '<table class="widefat striped" style="margin-bottom:12px;"><tbody>';
+        echo '<tr><th style="width:240px;">' . esc_html__( 'Source technique', 'ufsc-clubs' ) . '</th><td>' . esc_html( UFSC_Licence_Payments::get_readable_payment_source( $payment_source ) ) . ' <code>' . esc_html( $payment_source ?: '-' ) . '</code></td></tr>';
+        echo '<tr><th>' . esc_html__( 'Gateway', 'ufsc-clubs' ) . '</th><td>' . esc_html( UFSC_Licence_Payments::get_readable_payment_gateway( $payment_gateway ) ) . ' <code>' . esc_html( $payment_gateway ?: '-' ) . '</code></td></tr>';
+        echo '<tr><th>' . esc_html__( 'Mode de règlement (métier)', 'ufsc-clubs' ) . '</th><td>' . esc_html( UFSC_Licence_Payments::get_readable_payment_method( $payment_method ) ) . ' <code>' . esc_html( $payment_method ?: '-' ) . '</code></td></tr>';
+        echo '<tr><th>' . esc_html__( 'Référence paiement', 'ufsc-clubs' ) . '</th><td>' . esc_html( $payment_ref ?: '-' ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Commande WooCommerce liée', 'ufsc-clubs' ) . '</th><td>' . ( $wc_order_id ? '#' . esc_html( (string) $wc_order_id ) : '-' ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Order item WooCommerce', 'ufsc-clubs' ) . '</th><td>' . ( $wc_item_id ? esc_html( (string) $wc_item_id ) : '-' ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Transaction', 'ufsc-clubs' ) . '</th><td>' . esc_html( $wc_txn_id ?: '-' ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Montant', 'ufsc-clubs' ) . '</th><td>' . esc_html( '' !== $payment_amount ? $payment_amount . ' ' . $payment_currency : '-' ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Date de paiement', 'ufsc-clubs' ) . '</th><td>' . esc_html( $payment_date ?: '-' ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Exception admin', 'ufsc-clubs' ) . '</th><td>' . esc_html( $exception_reason ?: '-' ) . '</td></tr>';
+        echo '</tbody></table>';
+
+        if ( ! $readonly ) {
+            echo '<div class="ufsc-grid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;">';
+            echo '<div><label>' . esc_html__( 'Méthode paiement (admin)', 'ufsc-clubs' ) . '</label><select name="ufsc_payment_method" ' . $readonly_attr . '>';
+            $method_options = array(
+                'virement_bancaire' => __( 'Virement bancaire', 'ufsc-clubs' ),
+                'carte_bancaire'    => __( 'Carte bancaire', 'ufsc-clubs' ),
+                'cheque'            => __( 'Chèque', 'ufsc-clubs' ),
+                'especes'           => __( 'Espèces', 'ufsc-clubs' ),
+                'autre'             => __( 'Autre', 'ufsc-clubs' ),
+            );
+            foreach ( $method_options as $key => $label ) {
+                echo '<option value="' . esc_attr( $key ) . '" ' . selected( $payment_method ?: 'virement_bancaire', $key, false ) . '>' . esc_html( $label ) . '</option>';
+            }
+            echo '</select></div>';
+            echo '<div><label>' . esc_html__( 'Référence', 'ufsc-clubs' ) . '</label><input type="text" name="ufsc_payment_reference" value="' . esc_attr( $payment_ref ) . '" ' . $readonly_attr . ' /></div>';
+            echo '<div><label>' . esc_html__( 'Date', 'ufsc-clubs' ) . '</label><input type="text" name="ufsc_payment_date" value="' . esc_attr( $payment_date ) . '" placeholder="YYYY-mm-dd HH:ii:ss" ' . $readonly_attr . ' /></div>';
+            echo '<div><label>' . esc_html__( 'Montant', 'ufsc-clubs' ) . '</label><input type="text" name="ufsc_payment_amount" value="' . esc_attr( $payment_amount ) . '" ' . $readonly_attr . ' /></div>';
+            echo '</div>';
+            echo '<p style="margin-top:8px;"><label>' . esc_html__( 'Motif exception admin (obligatoire si validation sans paiement)', 'ufsc-clubs' ) . '</label><input type="text" name="ufsc_payment_exception_reason" value="' . esc_attr( $exception_reason ) . '" ' . $readonly_attr . ' /></p>';
+            echo '<p><label>' . esc_html__( 'Note de rapprochement', 'ufsc-clubs' ) . '</label><textarea name="ufsc_payment_admin_note" rows="2" ' . $readonly_attr . '></textarea></p>';
+        }
+
+        echo '</div>';
+    }
+
     private static function render_field_licence($k, $conf, $val, $readonly = false)
     {
         $label         = $conf[0];
@@ -2306,10 +2370,15 @@ class UFSC_SQL_Admin
 
         $manual_exception_reason = isset( $_POST['ufsc_payment_exception_reason'] ) ? sanitize_text_field( wp_unslash( $_POST['ufsc_payment_exception_reason'] ) ) : '';
 
-        if ( isset( $data['statut'] ) && 'valide' === $data['statut'] && $id && class_exists( 'UFSC_Licence_Payments' ) ) {
-            $snapshot = UFSC_Licence_Payments::get_payment_snapshot( $id );
-            if ( $snapshot && ! UFSC_Licence_Payments::can_validate_licence( $snapshot, $manual_exception_reason ) ) {
-                self::maybe_redirect( admin_url('admin.php?page=ufsc-sql-licences&action=edit&id=' . $id . '&error=' . urlencode( __( 'Validation bloquée: rattachez un paiement ou renseignez un motif d\'exception.', 'ufsc-clubs' ) ) ) );
+        if ( isset( $data['statut'] ) && 'valide' === $data['statut'] && class_exists( 'UFSC_Licence_Payments' ) ) {
+            if ( $id ) {
+                $snapshot = UFSC_Licence_Payments::get_payment_snapshot( $id );
+                if ( $snapshot && ! UFSC_Licence_Payments::can_validate_licence( $snapshot, $manual_exception_reason ) ) {
+                    self::maybe_redirect( admin_url('admin.php?page=ufsc-sql-licences&action=edit&id=' . $id . '&error=' . urlencode( __( 'Validation bloquée: rattachez un paiement ou renseignez un motif d\'exception.', 'ufsc-clubs' ) ) ) );
+                    return;
+                }
+            } elseif ( ! $is_paid_submission && '' === trim( $manual_exception_reason ) ) {
+                self::maybe_redirect( admin_url('admin.php?page=ufsc-sql-licences&action=new&error=' . urlencode( __( 'Validation bloquée: créez d\'abord la licence en brouillon/en attente puis rattachez un paiement.', 'ufsc-clubs' ) ) ) );
                 return;
             }
         }

--- a/includes/core/class-ufsc-licence-payments.php
+++ b/includes/core/class-ufsc-licence-payments.php
@@ -129,6 +129,53 @@ class UFSC_Licence_Payments {
 		return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$table}` WHERE id = %d", $licence_id ) );
 	}
 
+	public static function get_latest_trace( $licence_id ) {
+		global $wpdb;
+		$table = self::get_table_name();
+		$licence_id = absint( $licence_id );
+		if ( $licence_id <= 0 ) {
+			return null;
+		}
+		return $wpdb->get_row( $wpdb->prepare(
+			"SELECT * FROM `{$table}` WHERE licence_id = %d AND is_deleted = 0 ORDER BY id DESC LIMIT 1",
+			$licence_id
+		) );
+	}
+
+	public static function get_readable_payment_method( $method ) {
+		$map = array(
+			'carte_bancaire'   => __( 'Carte bancaire', 'ufsc-clubs' ),
+			'virement_bancaire'=> __( 'Virement bancaire', 'ufsc-clubs' ),
+			'autre'            => __( 'Autre', 'ufsc-clubs' ),
+			'cheque'           => __( 'Chèque', 'ufsc-clubs' ),
+			'especes'          => __( 'Espèces', 'ufsc-clubs' ),
+		);
+		$method = sanitize_key( (string) $method );
+		return $map[ $method ] ?? ucfirst( str_replace( '_', ' ', $method ) );
+	}
+
+	public static function get_readable_payment_source( $source ) {
+		$map = array(
+			'woocommerce' => __( 'WooCommerce', 'ufsc-clubs' ),
+			'manuel'      => __( 'Saisie manuelle admin', 'ufsc-clubs' ),
+		);
+		$source = sanitize_key( (string) $source );
+		return $map[ $source ] ?? ucfirst( str_replace( '_', ' ', $source ) );
+	}
+
+	public static function get_readable_payment_gateway( $gateway ) {
+		$map = array(
+			'monetico' => __( 'Monetico Paiement', 'ufsc-clubs' ),
+			'bacs'     => __( 'WooCommerce - Virement bancaire', 'ufsc-clubs' ),
+			'manual'   => __( 'Manuel', 'ufsc-clubs' ),
+			'manuel'   => __( 'Manuel', 'ufsc-clubs' ),
+			'cheque'   => __( 'WooCommerce - Chèque', 'ufsc-clubs' ),
+			'cod'      => __( 'WooCommerce - Paiement à la livraison', 'ufsc-clubs' ),
+		);
+		$gateway = sanitize_key( (string) $gateway );
+		return $map[ $gateway ] ?? strtoupper( (string) $gateway );
+	}
+
 	public static function can_validate_licence( $licence_row, $exception_reason = '' ) {
 		$payment_status = strtolower( (string) ( $licence_row->payment_status ?? '' ) );
 		$link_status    = strtolower( (string) ( $licence_row->payment_link_status ?? '' ) );
@@ -178,11 +225,8 @@ class UFSC_Licence_Payments {
 		}
 
 		$transaction_id = method_exists( $order, 'get_transaction_id' ) ? (string) $order->get_transaction_id() : '';
-		$gateway = method_exists( $order, 'get_payment_method' ) ? (string) $order->get_payment_method() : '';
-		$method  = 'cb';
-		if ( in_array( $gateway, array( 'bacs', 'cheque', 'cod' ), true ) ) {
-			$method = $gateway;
-		}
+		$gateway        = method_exists( $order, 'get_payment_method' ) ? (string) $order->get_payment_method() : '';
+		$context        = self::normalize_woocommerce_payment_context( $gateway );
 
 		foreach ( $order->get_items() as $item ) {
 			$item_licence_ids = function_exists( 'ufsc_get_item_licence_ids' ) ? ufsc_get_item_licence_ids( $item ) : array();
@@ -198,11 +242,11 @@ class UFSC_Licence_Payments {
 						'action'            => 'woo_paid',
 						'payment_status'    => 'paid',
 						'payment_source'    => 'woocommerce',
-						'payment_method'    => $method,
-						'payment_gateway'   => $gateway,
+						'payment_method'    => $context['payment_method'],
+						'payment_gateway'   => $context['payment_gateway'],
 						'payment_reference' => (string) $order->get_order_number(),
 						'payment_date'      => current_time( 'mysql' ),
-						'payment_amount'    => (float) $item->get_total(),
+						'payment_amount'    => self::normalize_amount( $item->get_total() ),
 						'currency'          => (string) $order->get_currency(),
 						'wc_order_id'       => (int) $order->get_id(),
 						'wc_order_item_id'  => (int) $item->get_id(),
@@ -218,6 +262,8 @@ class UFSC_Licence_Payments {
 		if ( ! $order || ! is_a( $order, 'WC_Order' ) ) {
 			return;
 		}
+		$gateway = method_exists( $order, 'get_payment_method' ) ? (string) $order->get_payment_method() : '';
+		$context = self::normalize_woocommerce_payment_context( $gateway );
 		foreach ( (array) $licence_ids as $licence_id ) {
 			$licence_id = absint( $licence_id );
 			if ( $licence_id <= 0 ) {
@@ -229,8 +275,8 @@ class UFSC_Licence_Payments {
 					'action'            => 'woo_unpaid',
 					'payment_status'    => 'non_rattache',
 					'payment_source'    => 'woocommerce',
-					'payment_method'    => 'cb',
-					'payment_gateway'   => (string) $order->get_payment_method(),
+					'payment_method'    => $context['payment_method'],
+					'payment_gateway'   => $context['payment_gateway'],
 					'payment_reference' => (string) $order->get_order_number(),
 					'payment_date'      => current_time( 'mysql' ),
 					'wc_order_id'       => (int) $order->get_id(),
@@ -266,6 +312,13 @@ class UFSC_Licence_Payments {
 			'created_by'            => get_current_user_id(),
 		);
 		$data = wp_parse_args( $payload, $defaults );
+		$data['payment_status'] = sanitize_key( (string) $data['payment_status'] );
+		$data['payment_source'] = sanitize_key( (string) $data['payment_source'] );
+		$data['payment_method'] = sanitize_key( (string) $data['payment_method'] );
+		$data['payment_gateway'] = sanitize_key( (string) $data['payment_gateway'] );
+		$data['payment_reference'] = sanitize_text_field( (string) $data['payment_reference'] );
+		$data['currency'] = strtoupper( sanitize_text_field( (string) $data['currency'] ) );
+		$data['payment_amount'] = self::normalize_amount( $data['payment_amount'] );
 		$data['created_at'] = current_time( 'mysql' );
 		$data['licence_id'] = $licence_id;
 		$data['fingerprint'] = hash( 'sha256', wp_json_encode( array(
@@ -276,16 +329,27 @@ class UFSC_Licence_Payments {
 			$data['payment_method'],
 			$data['payment_gateway'],
 			$data['payment_reference'],
+			$data['payment_date'],
+			$data['payment_amount'],
+			$data['currency'],
 			$data['wc_order_id'],
 			$data['wc_order_item_id'],
 			$data['wc_transaction_id'],
+			$data['admin_note'],
+			$data['reconciliation_status'],
+			$data['reconciliation_note'],
+			$data['exception_reason'],
 		) ) );
 
-		$wpdb->query( $wpdb->prepare(
+		// Append-only history with idempotence: keep existing row when same fingerprint is replayed.
+		$amount_sql   = null === $data['payment_amount'] ? 'NULL' : (string) round( (float) $data['payment_amount'], 2 );
+		$order_id_sql = empty( $data['wc_order_id'] ) ? 'NULL' : (string) absint( $data['wc_order_id'] );
+		$item_id_sql  = empty( $data['wc_order_item_id'] ) ? 'NULL' : (string) absint( $data['wc_order_item_id'] );
+		$sql          = $wpdb->prepare(
 			"INSERT INTO `{$table}`
 			(licence_id, action, payment_status, payment_source, payment_method, payment_gateway, payment_reference, payment_date, payment_amount, currency, wc_order_id, wc_order_item_id, wc_transaction_id, admin_note, reconciliation_status, reconciliation_note, exception_reason, created_by, created_at, fingerprint, is_deleted)
-			VALUES (%d,%s,%s,%s,%s,%s,%s,%s,%f,%s,%d,%d,%s,%s,%s,%s,%s,%d,%s,%s,0)
-			ON DUPLICATE KEY UPDATE created_at = VALUES(created_at)",
+			VALUES (%d,%s,%s,%s,%s,%s,%s,%s,{$amount_sql},%s,{$order_id_sql},{$item_id_sql},%s,%s,%s,%s,%s,%d,%s,%s,0)
+			ON DUPLICATE KEY UPDATE id = id",
 			$licence_id,
 			$data['action'],
 			$data['payment_status'],
@@ -294,10 +358,7 @@ class UFSC_Licence_Payments {
 			$data['payment_gateway'],
 			$data['payment_reference'],
 			$data['payment_date'],
-			(float) $data['payment_amount'],
 			$data['currency'],
-			(int) $data['wc_order_id'],
-			(int) $data['wc_order_item_id'],
 			$data['wc_transaction_id'],
 			$data['admin_note'],
 			$data['reconciliation_status'],
@@ -306,7 +367,8 @@ class UFSC_Licence_Payments {
 			(int) $data['created_by'],
 			$data['created_at'],
 			$data['fingerprint']
-		) );
+		);
+		$wpdb->query( $sql );
 
 		self::update_licence_summary( $licence_id, $data );
 	}
@@ -318,6 +380,11 @@ class UFSC_Licence_Payments {
 		global $wpdb;
 		$table = ufsc_get_licences_table();
 		$columns = function_exists( 'ufsc_table_columns' ) ? ufsc_table_columns( $table ) : $wpdb->get_col( "DESCRIBE `{$table}`" );
+		$current = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$table}` WHERE id = %d", $licence_id ) );
+		if ( self::should_preserve_existing_summary( $current, $data ) ) {
+			return;
+		}
+
 		$summary = array(
 			'payment_link_status'           => $data['payment_status'],
 			'payment_status'                => in_array( $data['payment_status'], array( 'paid', 'paye', 'paye_manuellement' ), true ) ? 'paid' : $data['payment_status'],
@@ -326,9 +393,9 @@ class UFSC_Licence_Payments {
 			'payment_gateway'               => $data['payment_gateway'],
 			'payment_reference'             => $data['payment_reference'],
 			'payment_date'                  => $data['payment_date'],
-			'wc_order_id'                   => (int) $data['wc_order_id'],
-			'wc_order_item_id'              => (int) $data['wc_order_item_id'],
-			'wc_transaction_id'             => $data['wc_transaction_id'],
+			'wc_order_id'                   => ! empty( $data['wc_order_id'] ) ? (int) $data['wc_order_id'] : null,
+			'wc_order_item_id'              => ! empty( $data['wc_order_item_id'] ) ? (int) $data['wc_order_item_id'] : null,
+			'wc_transaction_id'             => '' !== (string) $data['wc_transaction_id'] ? $data['wc_transaction_id'] : null,
 			'payment_linked_by'             => (int) $data['created_by'],
 			'payment_linked_at'             => current_time( 'mysql' ),
 			'payment_reconciliation_status' => $data['reconciliation_status'],
@@ -344,6 +411,75 @@ class UFSC_Licence_Payments {
 		if ( ! empty( $update ) ) {
 			$wpdb->update( $table, $update, array( 'id' => $licence_id ) );
 		}
+	}
+
+	private static function should_preserve_existing_summary( $current, $incoming ) {
+		if ( ! $current ) {
+			return false;
+		}
+
+		$incoming_status = strtolower( (string) ( $incoming['payment_status'] ?? '' ) );
+		$incoming_source = strtolower( (string) ( $incoming['payment_source'] ?? '' ) );
+
+		// Keep a stronger existing summary when an unpaid Woo event is replayed later.
+		if ( 'non_rattache' !== $incoming_status ) {
+			return false;
+		}
+
+		$current_link_status = strtolower( (string) ( $current->payment_link_status ?? '' ) );
+		if ( in_array( $current_link_status, array( 'paye_manuellement', 'exonere' ), true ) ) {
+			return true;
+		}
+
+		if ( ! empty( $current->payment_exception_reason ) && empty( $incoming['exception_reason'] ) ) {
+			return true;
+		}
+
+		if ( ! empty( $current->payment_reconciliation_status ) && empty( $incoming['reconciliation_status'] ) ) {
+			return true;
+		}
+
+		if ( 'woocommerce' === $incoming_source && 'manuel' === strtolower( (string) ( $current->payment_source ?? '' ) ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static function normalize_woocommerce_payment_context( $gateway ) {
+		$gateway = sanitize_key( (string) $gateway );
+		if ( in_array( $gateway, array( 'bacs', 'bank_transfer', 'virement', 'virement_bancaire' ), true ) ) {
+			return array(
+				'payment_method'  => 'virement_bancaire',
+				'payment_gateway' => 'bacs',
+			);
+		}
+		if ( false !== strpos( $gateway, 'monetico' ) ) {
+			return array(
+				'payment_method'  => 'carte_bancaire',
+				'payment_gateway' => 'monetico',
+			);
+		}
+
+		return array(
+			'payment_method'  => 'carte_bancaire',
+			'payment_gateway' => $gateway,
+		);
+	}
+
+	private static function normalize_amount( $amount ) {
+		if ( null === $amount || '' === $amount ) {
+			return null;
+		}
+
+		if ( is_string( $amount ) ) {
+			$amount = str_replace( ',', '.', trim( $amount ) );
+		}
+		if ( ! is_numeric( $amount ) ) {
+			return null;
+		}
+
+		return round( (float) $amount, 2 );
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Expose administrative traceability for payments linked to licences and make payment recording resilient to replayed events while preserving stronger existing summaries.

### Description
- Add `render_payment_traceability_block()` to the admin licence editor to display payment snapshot, latest trace and editable admin fields for manual linkage.
- Add helpers to `UFSC_Licence_Payments` (`get_latest_trace`, `get_readable_*`, `normalize_woocommerce_payment_context`, `normalize_amount`) and sanitize/normalize incoming payment data.
- Change WooCommerce sync and unpaid handling to use normalized payment context and amounts, expand fingerprinting fields, and write traces append-only with idempotence (`ON DUPLICATE KEY UPDATE id = id`).
- Update licence summary logic to preserve stronger existing summaries via `should_preserve_existing_summary()` and write nullable summary fields correctly; adjust admin validation flow to require proper creation/linking for new licences.

### Testing
- Ran PHP syntax checks (`php -l`) on modified files with no errors.
- Executed the plugin PHPUnit suite (`vendor/bin/phpunit`) where present and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d97d38bffc832b98c8526430ef74a9)