### PR TITLE
Renforcer les flux corbeille/restauration de licences et aligner le filtrage front

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -1689,8 +1689,12 @@ class UFSC_SQL_Admin
                 $raw_values = function_exists( 'ufsc_get_licence_status_raw_values_for_norm' )
                     ? ufsc_get_licence_status_raw_values_for_norm( $normalized_filter )
                     : array( $normalized_filter );
-                $placeholders       = implode( ', ', array_fill( 0, count( $raw_values ), '%s' ) );
-                $where_conditions[] = $wpdb->prepare( "l.statut IN ({$placeholders})", ...$raw_values );
+                if ( empty( $raw_values ) ) {
+                    $where_conditions[] = '1 = 0';
+                } else {
+                    $placeholders       = implode( ', ', array_fill( 0, count( $raw_values ), '%s' ) );
+                    $where_conditions[] = $wpdb->prepare( "l.statut IN ({$placeholders})", ...$raw_values );
+                }
             }
         }
 
@@ -2824,7 +2828,7 @@ class UFSC_SQL_Admin
 
     public static function handle_delete_licence()
     {
-        if (! current_user_can('read')) {
+        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) ) {
             wp_die(__('Accès refusé.', 'ufsc-clubs'));
         }
 
@@ -2833,7 +2837,7 @@ class UFSC_SQL_Admin
     }
 
     public static function handle_trash_licence( $check_nonce = true ) {
-        if ( ! is_user_logged_in() ) {
+        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         if ( $check_nonce ) {
@@ -2845,22 +2849,18 @@ class UFSC_SQL_Admin
         $t  = $s['table_licences'];
         $pk = $s['pk_licence'];
         $id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+        if ( $id <= 0 ) {
+            self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode( __( 'ID de licence invalide', 'ufsc-clubs' ) ) ) ) );
+            return;
+        }
 
         // Fetch the club ID for the licence to validate permissions
         $club_id = 0;
         if ($id && (! function_exists('ufsc_table_has_column') || ufsc_table_has_column($t, 'club_id'))) {
             $club_id = (int) $wpdb->get_var($wpdb->prepare("SELECT club_id FROM {$t} WHERE {$pk} = %d", $id));
         }
-        $user_id = get_current_user_id();
         if ( $club_id ) {
             UFSC_Scope::assert_club_in_scope( $club_id );
-        }
-
-        // Verify capability and club ownership before proceeding
-        if (! current_user_can('manage_options') && ufsc_get_user_club_id($user_id) !== $club_id) {
-            set_transient('ufsc_error_' . $user_id, __('Permissions insuffisantes', 'ufsc-clubs'), 30);
-            self::maybe_redirect(wp_get_referer());
-            return; // Abort if user lacks rights on this club
         }
 
         if ($id) {
@@ -2881,15 +2881,26 @@ class UFSC_SQL_Admin
                 self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode( __( 'Corbeille indisponible: colonne deleted_at absente.', 'ufsc-clubs' ) ) ) ) );
                 return;
             }
+            $already_trashed = isset( $licence->deleted_at ) && ! empty( $licence->deleted_at ) && '0000-00-00 00:00:00' !== $licence->deleted_at;
+            if ( $already_trashed ) {
+                self::maybe_redirect( self::build_licences_redirect_url( array( 'updated' => 1 ) ) );
+                return;
+            }
+
+            $update_data = array(
+                'deleted_at' => current_time( 'mysql' ),
+            );
+            $update_formats = array( '%s' );
+            if ( in_array( 'deleted_by', $columns, true ) ) {
+                $update_data['deleted_by'] = get_current_user_id();
+                $update_formats[] = '%d';
+            }
 
             $result = $wpdb->update(
                 $t,
-                array(
-                    'deleted_at' => current_time( 'mysql' ),
-                    'deleted_by' => get_current_user_id(),
-                ),
+                $update_data,
                 array( $pk => $id ),
-                array( '%s', '%d' ),
+                $update_formats,
                 array( '%d' )
             );
             if ($result !== false) {
@@ -2907,7 +2918,7 @@ class UFSC_SQL_Admin
     }
 
     public static function handle_restore_licence() {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         check_admin_referer( 'ufsc_sql_restore_licence' );
@@ -2918,36 +2929,43 @@ class UFSC_SQL_Admin
         $pk = $s['pk_licence'];
         $id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
         if ( $id <= 0 ) {
-            self::maybe_redirect(admin_url('admin.php?page=ufsc-sql-licences&error=' . urlencode(__('ID de licence invalide', 'ufsc-clubs'))));
+            self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode(__('ID de licence invalide', 'ufsc-clubs')) ) ) );
             return;
         }
-        $in_trash = (int) $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT COUNT(*) FROM {$t} WHERE {$pk} = %d AND deleted_at IS NOT NULL AND deleted_at != '0000-00-00 00:00:00'",
-                $id
-            )
-        );
-        if ( $in_trash <= 0 ) {
+        $columns = self::get_table_columns( $t );
+        if ( ! in_array( 'deleted_at', $columns, true ) ) {
+            self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode( __( 'Corbeille indisponible: colonne deleted_at absente.', 'ufsc-clubs' ) ) ) ) );
+            return;
+        }
+        $licence = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$t} WHERE {$pk} = %d", $id ) );
+        if ( ! $licence ) {
+            self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode( __( 'Licence introuvable', 'ufsc-clubs' ) ) ) ) );
+            return;
+        }
+        if ( isset( $licence->club_id ) && (int) $licence->club_id > 0 ) {
+            UFSC_Scope::assert_club_in_scope( (int) $licence->club_id );
+        }
+        $in_trash = isset( $licence->deleted_at ) && ! empty( $licence->deleted_at ) && '0000-00-00 00:00:00' !== $licence->deleted_at;
+        if ( ! $in_trash ) {
             self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode( __( 'La licence n’est pas en corbeille.', 'ufsc-clubs' ) ) ) ) );
             return;
         }
 
-        $result = $wpdb->query(
-            $wpdb->prepare(
-                "UPDATE {$t}
-                 SET deleted_at = NULL, deleted_by = NULL
-                 WHERE {$pk} = %d
-                 AND deleted_at IS NOT NULL
-                 AND deleted_at != '0000-00-00 00:00:00'",
-                $id
-            )
+        $update_data = array(
+            'deleted_at' => null,
         );
+        $update_formats = array( '%s' );
+        if ( in_array( 'deleted_by', $columns, true ) ) {
+            $update_data['deleted_by'] = null;
+            $update_formats[] = '%d';
+        }
+        $result = $wpdb->update( $t, $update_data, array( $pk => $id ), $update_formats, array( '%d' ) );
         self::debug_log_licences( 'restore', array( 'licence_id' => $id, 'actor' => get_current_user_id(), 'result' => $result ) );
         self::maybe_redirect( self::build_licences_redirect_url( array( 'updated' => 1 ) ) );
     }
 
     public static function handle_force_delete_licence() {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         check_admin_referer( 'ufsc_sql_force_delete_licence' );
@@ -2958,16 +2976,24 @@ class UFSC_SQL_Admin
         $pk = $s['pk_licence'];
         $id = isset( $_GET['id'] ) ? (int) $_GET['id'] : 0;
         if ( $id <= 0 ) {
-            self::maybe_redirect(admin_url('admin.php?page=ufsc-sql-licences&error=' . urlencode(__('ID de licence invalide', 'ufsc-clubs'))));
+            self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode(__('ID de licence invalide', 'ufsc-clubs')) ) ) );
             return;
         }
-        $in_trash = (int) $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT COUNT(*) FROM {$t} WHERE {$pk} = %d AND deleted_at IS NOT NULL AND deleted_at != '0000-00-00 00:00:00'",
-                $id
-            )
-        );
-        if ( $in_trash <= 0 ) {
+        $columns = self::get_table_columns( $t );
+        if ( ! in_array( 'deleted_at', $columns, true ) ) {
+            self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode( __( 'Corbeille indisponible: colonne deleted_at absente.', 'ufsc-clubs' ) ) ) ) );
+            return;
+        }
+        $licence = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$t} WHERE {$pk} = %d", $id ) );
+        if ( ! $licence ) {
+            self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode( __( 'Licence introuvable', 'ufsc-clubs' ) ) ) ) );
+            return;
+        }
+        if ( isset( $licence->club_id ) && (int) $licence->club_id > 0 ) {
+            UFSC_Scope::assert_club_in_scope( (int) $licence->club_id );
+        }
+        $in_trash = isset( $licence->deleted_at ) && ! empty( $licence->deleted_at ) && '0000-00-00 00:00:00' !== $licence->deleted_at;
+        if ( ! $in_trash ) {
             self::maybe_redirect( self::build_licences_redirect_url( array( 'error' => urlencode( __( 'Suppression définitive refusée : la licence doit être en corbeille.', 'ufsc-clubs' ) ) ) ) );
             return;
         }
@@ -4329,6 +4355,9 @@ class UFSC_SQL_Admin
         if (! isset($_POST['bulk_action']) || empty($_POST['bulk_action'])) {
             return;
         }
+        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
 
         if (! isset($_POST['licence_ids']) || empty($_POST['licence_ids'])) {
             add_action('admin_notices', function () {
@@ -4340,8 +4369,9 @@ class UFSC_SQL_Admin
 
         $settings = UFSC_SQL::get_settings();
         $table    = $settings['table_licences'];
+        $pk       = $settings['pk_licence'];
         $action   = sanitize_text_field($_POST['bulk_action']);
-        $item_ids = array_map('intval', $_POST['licence_ids']);
+        $item_ids = array_values( array_filter( array_map( 'intval', (array) $_POST['licence_ids'] ) ) );
         switch ($action) {
             case 'validate':
                 self::bulk_validate_items($item_ids, $table);
@@ -4353,10 +4383,10 @@ class UFSC_SQL_Admin
                 self::bulk_pending_items($item_ids, $table);
                 break;
             case 'delete':
-                self::bulk_delete_items($item_ids, $table);
+                self::bulk_delete_items($item_ids, $table, $pk);
                 break;
             case 'restore':
-                self::bulk_restore_items($item_ids, $table);
+                self::bulk_restore_items($item_ids, $table, $pk);
                 break;
         }
 
@@ -4450,7 +4480,7 @@ class UFSC_SQL_Admin
         });
     }
 
-    private static function bulk_delete_items($item_ids, $table)
+    private static function bulk_delete_items($item_ids, $table, $pk)
     {
         global $wpdb;
 
@@ -4461,21 +4491,36 @@ class UFSC_SQL_Admin
             return;
         }
         foreach ($item_ids as $item_id) {
-            $row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", (int) $item_id ) );
+            $row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE {$pk} = %d", (int) $item_id ) );
+            if ( ! $row ) {
+                continue;
+            }
+            if ( isset( $row->club_id ) && (int) $row->club_id > 0 ) {
+                UFSC_Scope::assert_club_in_scope( (int) $row->club_id );
+            }
             if ( $row && '' !== self::get_licence_delete_block_reason( $row ) ) {
                 $blocked++;
                 continue;
             }
+            if ( isset( $row->deleted_at ) && ! empty( $row->deleted_at ) && '0000-00-00 00:00:00' !== $row->deleted_at ) {
+                continue;
+            }
+
+            $update_data = array(
+                'deleted_at' => current_time( 'mysql' ),
+            );
+            $update_formats = array( '%s' );
+            if ( in_array( 'deleted_by', $columns, true ) ) {
+                $update_data['deleted_by'] = get_current_user_id();
+                $update_formats[] = '%d';
+            }
 
             $result = $wpdb->update(
                 $table,
-                array(
-                    'deleted_at' => current_time( 'mysql' ),
-                    'deleted_by' => get_current_user_id(),
-                ),
-                ['id' => $item_id],
-                ['%s', '%d'],
-                ['%d']
+                $update_data,
+                array( $pk => $item_id ),
+                $update_formats,
+                array( '%d' )
             );
             if ( false !== $result ) {
                 $deleted++;
@@ -4496,7 +4541,7 @@ class UFSC_SQL_Admin
         });
     }
 
-    private static function bulk_restore_items($item_ids, $table) {
+    private static function bulk_restore_items($item_ids, $table, $pk) {
         global $wpdb;
         $columns = self::get_table_columns( $table );
         if ( ! in_array( 'deleted_at', $columns, true ) ) {
@@ -4504,16 +4549,27 @@ class UFSC_SQL_Admin
         }
         $restored = 0;
         foreach ( $item_ids as $item_id ) {
-            $result = $wpdb->query(
-                $wpdb->prepare(
-                    "UPDATE {$table}
-                     SET deleted_at = NULL, deleted_by = NULL
-                     WHERE id = %d
-                     AND deleted_at IS NOT NULL
-                     AND deleted_at != '0000-00-00 00:00:00'",
-                    (int) $item_id
-                )
+            $row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE {$pk} = %d", (int) $item_id ) );
+            if ( ! $row ) {
+                continue;
+            }
+            if ( isset( $row->club_id ) && (int) $row->club_id > 0 ) {
+                UFSC_Scope::assert_club_in_scope( (int) $row->club_id );
+            }
+            if ( ! isset( $row->deleted_at ) || empty( $row->deleted_at ) || '0000-00-00 00:00:00' === $row->deleted_at ) {
+                continue;
+            }
+
+            $update_data = array(
+                'deleted_at' => null,
             );
+            $update_formats = array( '%s' );
+            if ( in_array( 'deleted_by', $columns, true ) ) {
+                $update_data['deleted_by'] = null;
+                $update_formats[] = '%d';
+            }
+
+            $result = $wpdb->update( $table, $update_data, array( $pk => (int) $item_id ), $update_formats, array( '%d' ) );
             if ( false !== $result ) {
                 $restored++;
             }

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1679,7 +1679,12 @@ class UFSC_Frontend_Shortcodes {
             $select_fields = "*, `statut` AS licence_statut";
         }
 
-        return $wpdb->get_row( $wpdb->prepare( "SELECT {$select_fields} FROM `{$table}` WHERE id = %d AND club_id = %d", $licence_id, $club_id ) );
+        $where = "id = %d AND club_id = %d";
+        if ( in_array( 'deleted_at', $columns, true ) ) {
+            $where .= " AND (deleted_at IS NULL OR deleted_at = '0000-00-00 00:00:00')";
+        }
+
+        return $wpdb->get_row( $wpdb->prepare( "SELECT {$select_fields} FROM `{$table}` WHERE {$where}", $licence_id, $club_id ) );
     }
 
     // Helper methods
@@ -1829,9 +1834,13 @@ class UFSC_Frontend_Shortcodes {
             $raw_values = function_exists( 'ufsc_get_licence_status_raw_values_for_norm' )
                 ? ufsc_get_licence_status_raw_values_for_norm( $args['status'] )
                 : array( $args['status'] );
-            $placeholders = implode( ', ', array_fill( 0, count( $raw_values ), '%s' ) );
-            $clauses[]    = "`statut` IN ({$placeholders})";
-            $values       = array_merge( $values, $raw_values );
+            if ( empty( $raw_values ) ) {
+                $clauses[] = '1 = 0';
+            } else {
+                $placeholders = implode( ', ', array_fill( 0, count( $raw_values ), '%s' ) );
+                $clauses[]    = "`statut` IN ({$placeholders})";
+                $values       = array_merge( $values, $raw_values );
+            }
         }
 
         // Saison
@@ -1936,9 +1945,13 @@ class UFSC_Frontend_Shortcodes {
             $raw_values = function_exists( 'ufsc_get_licence_status_raw_values_for_norm' )
                 ? ufsc_get_licence_status_raw_values_for_norm( $args['status'] )
                 : array( $args['status'] );
-            $placeholders = implode( ', ', array_fill( 0, count( $raw_values ), '%s' ) );
-            $clauses[]    = "`statut` IN ({$placeholders})";
-            $values       = array_merge( $values, $raw_values );
+            if ( empty( $raw_values ) ) {
+                $clauses[] = '1 = 0';
+            } else {
+                $placeholders = implode( ', ', array_fill( 0, count( $raw_values ), '%s' ) );
+                $clauses[]    = "`statut` IN ({$placeholders})";
+                $values       = array_merge( $values, $raw_values );
+            }
         }
 
         // Saison
@@ -2099,10 +2112,20 @@ class UFSC_Frontend_Shortcodes {
             $club_id
         ) );
 
-        $used = (int) $wpdb->get_var( $wpdb->prepare(
-            "SELECT COUNT(*) FROM `{$licences_table}` WHERE club_id = %d",
-            $club_id
-        ) );
+        $licence_conditions = array( 'club_id = %d' );
+        $licence_args       = array( $club_id );
+        $licence_columns    = function_exists( 'ufsc_table_columns' )
+            ? ufsc_table_columns( $licences_table )
+            : $wpdb->get_col( "DESCRIBE `{$licences_table}`" );
+        if ( in_array( 'deleted_at', $licence_columns, true ) ) {
+            $licence_conditions[] = "(deleted_at IS NULL OR deleted_at = '0000-00-00 00:00:00')";
+        }
+        $used = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM `{$licences_table}` WHERE " . implode( ' AND ', $licence_conditions ),
+                $licence_args
+            )
+        );
 
         return array(
             'total'     => $quota_total,


### PR DESCRIPTION
### Motivation
- Sécuriser et homogénéiser les actions destructrices sur les licences (corbeille / restauration / suppression définitive / actions groupées) en utilisant la capacité métier correcte et en évitant des états incohérents. 
- Garantir que l’affichage front (club) n’expose pas des licences en corbeille et que les compteurs restent cohérents avec la liste admin et l’export. 
- Corriger quelques fragilités SQL (requêtes `IN()` vides) et rendre les mises à jour soft-delete robustes si `deleted_by` n’existe pas.

### Description
- Remplacement des vérifications hétérogènes par la vérification métier centralisée `UFSC_Capabilities::user_can(UFSC_Capabilities::CAP_LICENCE_EDIT)` pour les handlers destructeurs suivants : `handle_delete_licence`, `handle_trash_licence`, `handle_restore_licence`, `handle_force_delete_licence` et `handle_bulk_actions`.
- Ajout de validations supplémentaires dans les handlers : vérification d’un `id` valide, existence de la licence, présence de la colonne `deleted_at`, contrôle de scope/club avant action, et vérification de l’état réel `deleted_at` (impossible de restaurer/supprimer définitivement une licence qui n’est pas en corbeille).
- Mise à jour des opérations d’écrasement soft-delete pour être robustes si la colonne `deleted_by` est absente (composition dynamique des données/formats passés à `$wpdb->update`).
- Bulk actions : nettoyage des IDs (`array_values` + `array_filter`), utilisation de la PK configurée `pk_licence` au lieu d’un champ `id` hardcodé, vérification de scope par ligne et respect de l’état `deleted_at` avant restore/delete en masse.
- Front club : `get_licence()` et les compteurs (`get_club_quota_info()`) excluent explicitement les licences en corbeille si la colonne `deleted_at` existe, garantissant que le front n’affiche ni n’inclut les licences supprimées.
- Robustesse status-filter : quand la normalisation du statut ne renvoie aucune valeur brute, on ajoute un fallback `1 = 0` pour éviter des requêtes `IN ()` invalides.
- Fichiers modifiés : `includes/admin/class-sql-admin.php`, `includes/frontend/class-frontend-shortcodes.php`.

### Testing
- Syntax checks PHP : `php -l includes/admin/class-sql-admin.php` — OK.
- Syntax checks PHP : `php -l includes/frontend/class-frontend-shortcodes.php` — OK.
- Aucune modification des routes/hooks/slugs : les hooks existants et les pages admin restent inchangés (approche conservative).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e180c29038832bb6e5dcf79ca8ecd1)