### PR TITLE
Fix bulk actions, clarify visibility, stabilize return and add non-blocking bureau badges (version 042026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # UFSC Clubs & Licences Plugin - Changelog
 
+## Version 042026 - Correctifs ciblés (Avril 2026)
+
+- Correctif des actions groupées sur listes licences/clubs (multi-sélection, scope, nonce, redirection stable).
+- Clarification des libellés du filtre de visibilité sans changement des valeurs techniques.
+- Stabilisation du bouton retour sur écrans licence avec fallback déterministe.
+- Identification visuelle des licences de bureau (Président / Secrétaire / Trésorier) et alerte non bloquante en cas de rôles manquants.
+- Harmonisation de la version canonique du plugin (`UFSC_CL_VERSION` + en-tête plugin).
+
 ## Version 1.5.7 - Mise à jour mineure (Septembre 2025)
 
 - Mise à jour du numéro de version du plugin.

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -252,6 +252,40 @@ class UFSC_SQL_Admin
     }
 
     /**
+     * Build a safe return URL for admin forms.
+     *
+     * @param string $fallback_page Menu page slug fallback.
+     * @return string
+     */
+    private static function get_admin_return_url( $fallback_page ) {
+        $fallback = admin_url( 'admin.php?page=' . sanitize_key( $fallback_page ) );
+        $candidate = '';
+
+        if ( isset( $_REQUEST['return_to'] ) ) {
+            $candidate = wp_unslash( $_REQUEST['return_to'] );
+        } elseif ( wp_get_referer() ) {
+            $candidate = wp_get_referer();
+        }
+
+        if ( ! $candidate || ! wp_validate_redirect( $candidate, false ) ) {
+            return $fallback;
+        }
+
+        $parts = wp_parse_url( $candidate );
+        if ( empty( $parts['query'] ) ) {
+            return $fallback;
+        }
+
+        parse_str( $parts['query'], $query );
+        $page = isset( $query['page'] ) ? sanitize_key( (string) $query['page'] ) : '';
+        if ( ! in_array( $page, array( 'ufsc-sql-licences', 'ufsc-sql-clubs' ), true ) ) {
+            return $fallback;
+        }
+
+        return remove_query_arg( array( 'updated', 'deleted', 'deleted_id', 'error' ), $candidate );
+    }
+
+    /**
      * Filter data array to columns that exist in the table.
      *
      * @param string $table Table name.
@@ -339,6 +373,113 @@ class UFSC_SQL_Admin
         }
 
         return '';
+    }
+
+    /**
+     * Get bureau role assignments for a club from existing licences.
+     *
+     * @param int $club_id Club ID.
+     * @return array<string,array<int>>
+     */
+    private static function get_bureau_role_assignments( $club_id ) {
+        global $wpdb;
+        $club_id = (int) $club_id;
+        if ( $club_id <= 0 ) {
+            return array();
+        }
+
+        $settings       = UFSC_SQL::get_settings();
+        $licences_table = $settings['table_licences'];
+        $pk             = $settings['pk_licence'];
+        $columns        = self::get_table_columns( $licences_table );
+
+        if ( ! in_array( 'role', $columns, true ) ) {
+            return array();
+        }
+
+        $required_roles = array( 'president', 'secretaire', 'tresorier' );
+        $where          = "club_id = %d AND role IN ('president','secretaire','tresorier')";
+        if ( in_array( 'deleted_at', $columns, true ) ) {
+            $where .= " AND (deleted_at IS NULL OR deleted_at = '0000-00-00 00:00:00')";
+        }
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT {$pk} AS licence_id, role FROM `{$licences_table}` WHERE {$where}",
+                $club_id
+            )
+        );
+
+        $assignments = array();
+        foreach ( $required_roles as $required_role ) {
+            $assignments[ $required_role ] = array();
+        }
+        foreach ( (array) $rows as $row ) {
+            $role = sanitize_key( (string) ( $row->role ?? '' ) );
+            if ( ! isset( $assignments[ $role ] ) ) {
+                continue;
+            }
+            $assignments[ $role ][] = (int) ( $row->licence_id ?? 0 );
+        }
+
+        return $assignments;
+    }
+
+    /**
+     * Render non-blocking bureau coverage alert for one club.
+     *
+     * @param int $club_id Club ID.
+     * @return void
+     */
+    private static function render_bureau_alert_for_club( $club_id ) {
+        $assignments = self::get_bureau_role_assignments( $club_id );
+        if ( empty( $assignments ) ) {
+            return;
+        }
+        $role_labels = array(
+            'president' => __( 'Président', 'ufsc-clubs' ),
+            'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
+            'tresorier' => __( 'Trésorier', 'ufsc-clubs' ),
+        );
+        $missing = array();
+        foreach ( $role_labels as $role => $label ) {
+            if ( empty( $assignments[ $role ] ) ) {
+                $missing[] = sprintf( __( '%s non licencié', 'ufsc-clubs' ), $label );
+            }
+        }
+
+        if ( empty( $missing ) ) {
+            return;
+        }
+
+        echo '<div class="notice notice-warning"><p><strong>' . esc_html__( 'Vous n’avez pas encore licencié l’ensemble du bureau du club.', 'ufsc-clubs' ) . '</strong><br />';
+        echo esc_html( implode( ' • ', $missing ) );
+        echo '</p></div>';
+    }
+
+    /**
+     * Return bureau badges for one licence row.
+     *
+     * @param int   $licence_id Licence ID.
+     * @param array $assignments Assignments by role.
+     * @return string
+     */
+    private static function get_bureau_badges_for_licence( $licence_id, $assignments ) {
+        $role_labels = array(
+            'president' => __( 'Président', 'ufsc-clubs' ),
+            'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
+            'tresorier' => __( 'Trésorier', 'ufsc-clubs' ),
+        );
+
+        $badges = array();
+        foreach ( $role_labels as $role => $label ) {
+            $ids = isset( $assignments[ $role ] ) ? (array) $assignments[ $role ] : array();
+            if ( in_array( (int) $licence_id, array_map( 'intval', $ids ), true ) ) {
+                $badges[] = '<span class="ufsc-badge badge-info" style="margin-right:4px;">' . esc_html( $label ) . '</span>';
+            }
+        }
+
+        return $badges ? implode( ' ', $badges ) : '—';
     }
 
     /**
@@ -1734,7 +1875,7 @@ class UFSC_SQL_Admin
         $filter_region = $filters['filter_region'];
         $filter_club   = $filters['filter_club'];
         $filter_status = $filters['filter_status'];
-        $filter_visibility = $filters['filter_visibility'];
+        $filter_visibility = in_array( $filters['filter_visibility'], array( 'active', 'trash', 'all' ), true ) ? $filters['filter_visibility'] : 'active';
         $scope_slug    = UFSC_Scope::get_user_scope_region();
         $scope_label   = $scope_slug ? UFSC_Scope::get_region_label( $scope_slug ) : '';
         if ( $scope_slug ) {
@@ -1831,6 +1972,9 @@ class UFSC_SQL_Admin
         if (isset($_GET['error'])) {
             echo UFSC_CL_Utils::show_error(sanitize_text_field($_GET['error']));
         }
+        if ( $filter_club > 0 ) {
+            self::render_bureau_alert_for_club( $filter_club );
+        }
 
         // Add nonce for AJAX operations
         echo '<input type="hidden" id="ufsc-ajax-nonce" value="' . wp_create_nonce('ufsc_ajax_nonce') . '" />';
@@ -1918,9 +2062,9 @@ class UFSC_SQL_Admin
         echo '<div>';
         echo '<label for="filter_visibility"><strong>' . esc_html__('Visibilité', 'ufsc-clubs') . '</strong></label>';
         echo '<select name="filter_visibility" id="filter_visibility">';
-        echo '<option value="active"' . selected( $filter_visibility, 'active', false ) . '>' . esc_html__( 'Hors corbeille', 'ufsc-clubs' ) . '</option>';
-        echo '<option value="trash"' . selected( $filter_visibility, 'trash', false ) . '>' . esc_html__( 'Corbeille', 'ufsc-clubs' ) . '</option>';
-        echo '<option value="all"' . selected( $filter_visibility, 'all', false ) . '>' . esc_html__( 'Toutes', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="active"' . selected( $filter_visibility, 'active', false ) . '>' . esc_html__( 'Actives / visibles', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="trash"' . selected( $filter_visibility, 'trash', false ) . '>' . esc_html__( 'Dans la corbeille', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="all"' . selected( $filter_visibility, 'all', false ) . '>' . esc_html__( 'Toutes les licences', 'ufsc-clubs' ) . '</option>';
         echo '</select>';
         echo '</div>';
 
@@ -1937,6 +2081,9 @@ class UFSC_SQL_Admin
         echo '</div>';
 
         echo '<form method="post" id="bulk-actions-form">';
+        echo '<input type="hidden" name="page" value="ufsc-sql-licences" />';
+        echo '<input type="hidden" name="filter_visibility" value="' . esc_attr( $filter_visibility ) . '" />';
+        echo '<input type="hidden" name="return_to" value="' . esc_url( self::build_licences_redirect_url() ) . '" />';
         // Bulk actions
         echo '<div class="ufsc-bulk-actions" style="margin: 15px 0;">';
 
@@ -1969,6 +2116,7 @@ class UFSC_SQL_Admin
         echo '<td class="check-column"><input type="checkbox" id="select-all-licences" /></td>';
         echo '<th class="column-id">' . esc_html__('ID', 'ufsc-clubs') . '</th>';
         echo '<th>' . esc_html__('Licencié', 'ufsc-clubs') . '</th>';
+        echo '<th>' . esc_html__('Bureau', 'ufsc-clubs') . '</th>';
         echo '<th class="column-date">' . esc_html__('Naissance', 'ufsc-clubs') . '</th>';
         echo '<th>' . esc_html__('Club', 'ufsc-clubs') . '</th>';
         echo '<th class="column-region">' . esc_html__('Région', 'ufsc-clubs') . '</th>';
@@ -1978,6 +2126,7 @@ class UFSC_SQL_Admin
         echo '</tr></thead>';
         echo '<tbody>';
 
+        $bureau_assignments_cache = array();
         if ($rows) {
             foreach ($rows as $r) {
                 $normalized_status = function_exists( 'ufsc_normalize_license_status' )
@@ -1988,18 +2137,24 @@ class UFSC_SQL_Admin
                     $normalized_status = 'en_attente';
                 }
 
-                $view_url     = admin_url('admin.php?page=ufsc-sql-licences&action=view&id=' . $r->$pk);
-                $edit_url     = admin_url('admin.php?page=ufsc-sql-licences&action=edit&id=' . $r->$pk);
+                $return_to    = rawurlencode( self::build_licences_redirect_url() );
+                $view_url     = admin_url('admin.php?page=ufsc-sql-licences&action=view&id=' . $r->$pk . '&return_to=' . $return_to);
+                $edit_url     = admin_url('admin.php?page=ufsc-sql-licences&action=edit&id=' . $r->$pk . '&return_to=' . $return_to);
                 $trash_url    = wp_nonce_url(admin_url('admin-post.php?action=ufsc_sql_trash_licence&id=' . $r->$pk), 'ufsc_sql_trash_licence');
                 $restore_url  = wp_nonce_url(admin_url('admin-post.php?action=ufsc_sql_restore_licence&id=' . $r->$pk), 'ufsc_sql_restore_licence');
                 $force_delete_url = wp_nonce_url(admin_url('admin-post.php?action=ufsc_sql_force_delete_licence&id=' . $r->$pk), 'ufsc_sql_force_delete_licence');
                 $name         = trim($r->prenom . ' ' . $r->nom);
                 $club_display = $r->club_nom ? esc_html($r->club_nom) : esc_html__('Club #', 'ufsc-clubs') . $r->club_id;
+                $club_id_for_row = isset( $r->club_id ) ? (int) $r->club_id : 0;
+                if ( $club_id_for_row > 0 && ! isset( $bureau_assignments_cache[ $club_id_for_row ] ) ) {
+                    $bureau_assignments_cache[ $club_id_for_row ] = self::get_bureau_role_assignments( $club_id_for_row );
+                }
 
                 echo '<tr>';
                 echo '<th class="check-column"><input type="checkbox" name="licence_ids[]" value="' . (int) $r->$pk . '" /></th>';
                 echo '<td>' . (int) $r->$pk . '</td>';
                 echo '<td><strong>' . esc_html($name) . '</strong></td>';
+                echo '<td>' . wp_kses_post( self::get_bureau_badges_for_licence( (int) $r->$pk, $bureau_assignments_cache[ $club_id_for_row ] ?? array() ) ) . '</td>';
                 echo '<td>' . esc_html($r->date_naissance) . '</td>';
                 echo '<td>' . $club_display . '</td>';echo '<td>' . esc_html( '' !== trim( (string) ( $r->region_resolved ?? '' ) ) ? (string) $r->region_resolved : ( '' !== trim( (string) ( $r->region ?? '' ) ) ? (string) $r->region : '—' ) ) . '</td>';
                 echo '<td>';
@@ -2038,7 +2193,7 @@ class UFSC_SQL_Admin
                 echo '</tr>';
             }
         } else {
-            echo '<tr><td colspan="9">' . esc_html__('Aucune licence trouvée', 'ufsc-clubs') . '</td></tr>';
+            echo '<tr><td colspan="10">' . esc_html__('Aucune licence trouvée', 'ufsc-clubs') . '</td></tr>';
         }
         echo '</tbody></table>';
         echo '</form>';
@@ -2116,6 +2271,7 @@ class UFSC_SQL_Admin
         $pk     = $s['pk_licence'];
         $fields = UFSC_SQL::get_licence_fields();
         $row    = $id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$t` WHERE `$pk`=%d", $id)) : null;
+        $return_url = self::get_admin_return_url( 'ufsc-sql-licences' );
         if ( $row ) {
             if ( isset( $row->club_id ) ) {
                 UFSC_Scope::assert_club_in_scope( (int) $row->club_id );
@@ -2168,6 +2324,7 @@ class UFSC_SQL_Admin
             echo '<input type="hidden" name="action" value="ufsc_sql_save_licence" />';
             echo '<input type="hidden" name="id" value="' . (int) $id . '" />';
             echo '<input type="hidden" name="page" value="ufsc-sql-licences"/>';
+            echo '<input type="hidden" name="return_to" value="' . esc_url( $return_url ) . '" />';
         }
 
         echo '<div class="ufsc-grid">';
@@ -2187,13 +2344,13 @@ class UFSC_SQL_Admin
         if (! $readonly) {
             echo '<div class="ufsc-form-actions" style="background: #f8f9fa; padding: 15px; margin: 20px 0; border-radius: 4px;">';
             echo '<div class="ufsc-button-group">';
-            echo '<a class="button" href="javascript:history.back()">' . esc_html__('Retour', 'ufsc-clubs') . '</a>';
+            echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Retour', 'ufsc-clubs') . '</a>';
             echo '<button type="submit" name="save_action" value="save" class="button button-primary">' . esc_html__('Enregistrer', 'ufsc-clubs') . '</button>';
             if ($id) {
                 // Only show payment button for existing licenses
                 echo '<button type="submit" name="save_action" value="save_and_payment" class="button button-secondary" style="background: #00a32a; border-color: #00a32a; color: white;">' . esc_html__('Enregistrer et envoyer pour paiement', 'ufsc-clubs') . '</button>';
             }
-            echo '<a class="button" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-licences')) . '">' . esc_html__('Annuler', 'ufsc-clubs') . '</a>';
+            echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Annuler', 'ufsc-clubs') . '</a>';
             echo '</div>';
             if (! $id) {
                 echo '<p class="description" style="margin-top: 10px;">' . esc_html__('Note: Le bouton "Envoyer pour paiement" sera disponible après le premier enregistrement.', 'ufsc-clubs') . '</p>';
@@ -2201,9 +2358,9 @@ class UFSC_SQL_Admin
             echo '</div>';
             echo '</form>';
         } else {
-            echo '<p><a class="button" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-licences')) . '">' . esc_html__('Retour à la liste', 'ufsc-clubs') . '</a>';
+            echo '<p><a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Retour à la liste', 'ufsc-clubs') . '</a>';
             if (current_user_can('manage_options')) {
-                echo ' <a class="button button-primary" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-licences&action=edit&id=' . $id)) . '">' . esc_html__('Modifier', 'ufsc-clubs') . '</a>';
+                echo ' <a class="button button-primary" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-licences&action=edit&id=' . $id . '&return_to=' . rawurlencode( $return_url ))) . '">' . esc_html__('Modifier', 'ufsc-clubs') . '</a>';
             }
             echo '</p>';
         }
@@ -3497,8 +3654,8 @@ class UFSC_SQL_Admin
         echo '<div>';
         echo '<label for="filter_visibility"><strong>' . esc_html__('Visibilité', 'ufsc-clubs') . '</strong></label>';
         echo '<select name="filter_visibility" id="filter_visibility">';
-        echo '<option value="active">' . esc_html__('Hors corbeille', 'ufsc-clubs') . '</option>';
-        echo '<option value="trash">' . esc_html__('Corbeille', 'ufsc-clubs') . '</option>';
+        echo '<option value="active">' . esc_html__('Actives / visibles', 'ufsc-clubs') . '</option>';
+        echo '<option value="trash">' . esc_html__('Dans la corbeille', 'ufsc-clubs') . '</option>';
         echo '<option value="all">' . esc_html__('Toutes', 'ufsc-clubs') . '</option>';
         echo '</select>';
         echo '</div>';
@@ -4346,8 +4503,8 @@ class UFSC_SQL_Admin
 
     public static function handle_bulk_actions()
     {
-
-        if (! isset($_GET['page']) || $_GET['page'] !== 'ufsc-sql-licences') {
+        $page = isset( $_REQUEST['page'] ) ? sanitize_key( wp_unslash( $_REQUEST['page'] ) ) : '';
+        if ( 'ufsc-sql-licences' !== $page ) {
             return;
         }
 
@@ -4380,7 +4537,10 @@ class UFSC_SQL_Admin
                 return;
             }
         }
-        $item_ids = array_map('intval', $_POST['licence_ids']);
+        $item_ids = array_values( array_unique( array_filter( array_map( 'intval', (array) $_POST['licence_ids'] ) ) ) );
+        if ( empty( $item_ids ) ) {
+            return;
+        }
         switch ($action) {
             case 'validate':
                 self::bulk_validate_items($item_ids, $table);
@@ -4400,7 +4560,12 @@ class UFSC_SQL_Admin
         }
 
         if (! self::is_cli()) {
-            wp_redirect(add_query_arg('processed', count($item_ids), $_POST['_wp_http_referer']));
+            $redirect_to = self::build_licences_redirect_url(
+                array(
+                    'processed' => count( $item_ids ),
+                )
+            );
+            wp_safe_redirect( $redirect_to );
             exit;
         }
     }

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -252,6 +252,35 @@ class UFSC_SQL_Admin
     }
 
     /**
+     * Build a safe licences return URL from an explicit candidate.
+     *
+     * @param string $candidate Candidate URL from request.
+     * @return string Empty string when invalid.
+     */
+    private static function get_safe_licences_return_url( $candidate ) {
+        $candidate = (string) $candidate;
+        if ( '' === $candidate ) {
+            return '';
+        }
+        if ( ! wp_validate_redirect( $candidate, false ) ) {
+            return '';
+        }
+
+        $parts = wp_parse_url( $candidate );
+        if ( empty( $parts['query'] ) ) {
+            return '';
+        }
+
+        parse_str( $parts['query'], $query );
+        $page = isset( $query['page'] ) ? sanitize_key( (string) $query['page'] ) : '';
+        if ( 'ufsc-sql-licences' !== $page ) {
+            return '';
+        }
+
+        return remove_query_arg( array( 'updated', 'deleted', 'deleted_id', 'error' ), $candidate );
+    }
+
+    /**
      * Build a safe return URL for admin forms.
      *
      * @param string $fallback_page Menu page slug fallback.
@@ -4560,10 +4589,16 @@ class UFSC_SQL_Admin
         }
 
         if (! self::is_cli()) {
-            $redirect_to = self::build_licences_redirect_url(
+            $requested_return_to = isset( $_POST['return_to'] ) ? wp_unslash( $_POST['return_to'] ) : '';
+            $redirect_base       = self::get_safe_licences_return_url( $requested_return_to );
+            if ( '' === $redirect_base ) {
+                $redirect_base = self::build_licences_redirect_url();
+            }
+            $redirect_to = add_query_arg(
                 array(
                     'processed' => count( $item_ids ),
-                )
+                ),
+                $redirect_base
             );
             wp_safe_redirect( $redirect_to );
             exit;

--- a/includes/admin/list-tables/class-ufsc-clubs-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-clubs-list-table.php
@@ -356,6 +356,7 @@ class UFSC_Clubs_List_Table {
         }
 
         echo '<form method="post" id="bulk-actions-form">';
+        echo '<input type="hidden" name="page" value="ufsc-sql-clubs" />';
         // Bulk actions
         echo '<div class="ufsc-bulk-actions" style="margin: 15px 0;">';
 
@@ -651,7 +652,8 @@ class UFSC_Clubs_List_Table {
     }
 
     public static function handle_bulk_actions() {
-        if (!isset($_GET['page']) || $_GET['page'] !== 'ufsc-sql-clubs') {
+        $page = isset( $_REQUEST['page'] ) ? sanitize_key( wp_unslash( $_REQUEST['page'] ) ) : '';
+        if ( 'ufsc-sql-clubs' !== $page ) {
             return;
         }
         if ( ! current_user_can( 'manage_options' ) ) {
@@ -675,7 +677,10 @@ class UFSC_Clubs_List_Table {
         $settings  = UFSC_SQL::get_settings();
         $table     = $settings['table_clubs'];
         $action    = sanitize_text_field($_POST['bulk_action']);
-        $item_ids  = array_map('intval', $_POST['club_ids']);
+        $item_ids  = array_values( array_unique( array_filter( array_map( 'intval', (array) $_POST['club_ids'] ) ) ) );
+        if ( empty( $item_ids ) ) {
+            return;
+        }
         switch ($action) {
             case 'actif':
                 self::bulk_actif_items($item_ids, $table);
@@ -694,7 +699,8 @@ class UFSC_Clubs_List_Table {
         if ( defined( 'WP_CLI' ) && WP_CLI ) {
             return;
         }
-        wp_redirect(add_query_arg('processed', count($item_ids), $_POST['_wp_http_referer']));
+        $redirect_to = isset( $_POST['_wp_http_referer'] ) ? wp_validate_redirect( wp_unslash( $_POST['_wp_http_referer'] ), admin_url( 'admin.php?page=ufsc-sql-clubs' ) ) : admin_url( 'admin.php?page=ufsc-sql-clubs' );
+        wp_safe_redirect( add_query_arg( 'processed', count( $item_ids ), $redirect_to ) );
         exit;
     }
 

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -347,6 +347,7 @@ class UFSC_Frontend_Shortcodes {
         $licences = self::get_club_licences( $atts['club_id'], $atts );
         $total_count = self::get_club_licences_count( $atts['club_id'], $atts );
         $total_pages = ceil( $total_count / $atts['per_page'] );
+        $bureau_data = self::get_bureau_coverage_data( (int) $atts['club_id'] );
 
         $club_name  = self::get_club_name( $atts['club_id'] );
         $wc_settings = ufsc_get_woocommerce_settings();
@@ -387,6 +388,12 @@ class UFSC_Frontend_Shortcodes {
                     </button>
                 </div>
             </div>
+            <?php if ( ! empty( $bureau_data['missing_labels'] ) ) : ?>
+                <div class="ufsc-message ufsc-info">
+                    <strong><?php esc_html_e( 'Vous n’avez pas encore licencié l’ensemble du bureau du club.', 'ufsc-clubs' ); ?></strong><br>
+                    <?php echo esc_html( implode( ' • ', $bureau_data['missing_labels'] ) ); ?>
+                </div>
+            <?php endif; ?>
 
             <!-- Filters -->
             <div class="ufsc-licences-filters">
@@ -461,6 +468,7 @@ class UFSC_Frontend_Shortcodes {
                             <tr>
                                 <th><?php esc_html_e( 'Nom', 'ufsc-clubs' ); ?></th>
                                 <th><?php esc_html_e( 'Prénom', 'ufsc-clubs' ); ?></th>
+                                <th><?php esc_html_e( 'Bureau', 'ufsc-clubs' ); ?></th>
                                 <th><?php esc_html_e( 'Sexe', 'ufsc-clubs' ); ?></th>
                                 <th><?php esc_html_e( 'Status', 'ufsc-clubs' ); ?></th>
                                 <th><?php esc_html_e( 'Saison', 'ufsc-clubs' ); ?></th>
@@ -514,6 +522,7 @@ class UFSC_Frontend_Shortcodes {
                                 <tr>
                                     <td><?php echo esc_html( $nom ); ?></td>
                                     <td><?php echo esc_html( $prenom ); ?></td>
+                                    <td><?php echo wp_kses_post( self::render_bureau_badges_for_front_licence( (int) ( $licence->id ?? 0 ), $bureau_data['assignments'] ) ); ?></td>
                                     <td><?php echo esc_html( $gender ); ?></td>
                                     <td><?php echo self::get_status_badge_front($status); ?></td>
                                     <td><?php echo esc_html( $season ); ?></td>
@@ -1970,6 +1979,96 @@ class UFSC_Frontend_Shortcodes {
         $sql       = "SELECT COUNT(*) FROM `{$licences_table}` {$where_sql}";
 
         return (int) $wpdb->get_var( $wpdb->prepare( $sql, $values ) );
+    }
+
+    /**
+     * Get bureau assignments and missing roles from licences.
+     *
+     * @param int $club_id Club identifier.
+     * @return array{assignments: array<string,array<int>>, missing_labels: array<int,string>}
+     */
+    private static function get_bureau_coverage_data( $club_id ) {
+        global $wpdb;
+
+        $club_id = (int) $club_id;
+        $data = array(
+            'assignments' => array(
+                'president' => array(),
+                'secretaire' => array(),
+                'tresorier' => array(),
+            ),
+            'missing_labels' => array(),
+        );
+
+        if ( $club_id <= 0 || ! function_exists( 'ufsc_get_licences_table' ) ) {
+            return $data;
+        }
+
+        $licences_table = ufsc_get_licences_table();
+        $columns = function_exists( 'ufsc_table_columns' )
+            ? ufsc_table_columns( $licences_table )
+            : $wpdb->get_col( "DESCRIBE `{$licences_table}`" );
+
+        if ( ! in_array( 'role', (array) $columns, true ) ) {
+            return $data;
+        }
+
+        $where = "club_id = %d AND role IN ('president','secretaire','tresorier')";
+        if ( in_array( 'deleted_at', (array) $columns, true ) ) {
+            $where .= " AND (deleted_at IS NULL OR deleted_at = '0000-00-00 00:00:00')";
+        }
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT id, role FROM `{$licences_table}` WHERE {$where}",
+                $club_id
+            )
+        );
+
+        foreach ( (array) $rows as $row ) {
+            $role = sanitize_key( (string) ( $row->role ?? '' ) );
+            if ( isset( $data['assignments'][ $role ] ) ) {
+                $data['assignments'][ $role ][] = (int) ( $row->id ?? 0 );
+            }
+        }
+
+        $role_labels = array(
+            'president' => __( 'Président', 'ufsc-clubs' ),
+            'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
+            'tresorier' => __( 'Trésorier', 'ufsc-clubs' ),
+        );
+        foreach ( $role_labels as $role => $label ) {
+            if ( empty( $data['assignments'][ $role ] ) ) {
+                $data['missing_labels'][] = sprintf( __( '%s non licencié', 'ufsc-clubs' ), $label );
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Render bureau badges for one licence line.
+     *
+     * @param int   $licence_id Licence identifier.
+     * @param array $assignments Role assignments.
+     * @return string
+     */
+    private static function render_bureau_badges_for_front_licence( $licence_id, $assignments ) {
+        $role_labels = array(
+            'president' => __( 'Président', 'ufsc-clubs' ),
+            'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
+            'tresorier' => __( 'Trésorier', 'ufsc-clubs' ),
+        );
+
+        $badges = array();
+        foreach ( $role_labels as $role => $label ) {
+            $ids = isset( $assignments[ $role ] ) ? array_map( 'intval', (array) $assignments[ $role ] ) : array();
+            if ( in_array( (int) $licence_id, $ids, true ) ) {
+                $badges[] = '<span class="ufsc-badge badge-info" style="margin-right:4px;">' . esc_html( $label ) . '</span>';
+            }
+        }
+
+        return $badges ? implode( ' ', $badges ) : '—';
     }
 
     /**

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -2,13 +2,13 @@
 /**
  * Plugin Name: UFSC – Clubs & Licences (SQL)
  * Description: Gestion Clubs/Licences connectée aux tables SQL existantes (mapping complet), formulaires complets (admin & front), documents PDF/JPG/PNG, exports CSV, badges colorés, mini-dashboard, shortcodes.
- * Version: 1.5.7
+ * Version: 042026
  * Author: Davy – Studio REACTIV (pour l'UFSC)
  * Text Domain: ufsc-clubs
  */
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-define( 'UFSC_CL_VERSION', '1.5.7' );
+define( 'UFSC_CL_VERSION', '042026' );
 define( 'UFSC_CL_DIR', plugin_dir_path( __FILE__ ) );
 define( 'UFSC_CL_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
### Motivation
- Correct erratic behaviour of bulk actions on licences and clubs so multi-selection works reliably from the checkboxes.
- Clarify the ambiguous "Visibilité" filter labels for better UX while preserving internal values.
- Replace fragile `history.back()` return logic with a validated fallback to avoid incoherent navigation.
- Provide a conservative, non-blocking way to identify the three bureau roles (Président / Secrétaire / Trésorier) both in admin lists and the club frontend.

### Description
- Bulk actions: handlers now check `$_REQUEST['page']`, list forms include a hidden `page` field and `return_to`, submitted IDs are sanitized (`intval`), filtered and uniqued before processing, and redirects use `wp_safe_redirect()` to a context-preserving URL. (files: `includes/admin/class-sql-admin.php`, `includes/admin/list-tables/class-ufsc-clubs-list-table.php`).
- Return stability: added `UFSC_SQL_Admin::get_admin_return_url()` and propagate a validated `return_to` in list links and forms, replacing `history.back()` on licence edit/view forms. (file: `includes/admin/class-sql-admin.php`).
- Visibility labels: rewritten display labels only (no change of internal values `active|trash|all`) to "Actives / visibles", "Dans la corbeille", "Toutes les licences" where the filter is rendered. (file: `includes/admin/class-sql-admin.php`).
- Bureau identification (non-blocking): added read-only detection of roles from existing licence rows and small UI additions: admin licences list gains a "Bureau" column with badges; admin list shows a gentle warning when a filtered club lacks one or more bureau roles; frontend club licence list shows badges and a non-blocking message when roles are missing; helper functions added to compute assignments. No data-model changes introduced. (files: `includes/admin/class-sql-admin.php`, `includes/frontend/class-frontend-shortcodes.php`).
- Version bump and docs: canonical plugin version constant and plugin header updated to `042026`, and `CHANGELOG.md` updated. (file: `ufsc-clubs-licences-sql.php`, `CHANGELOG.md`).

### Testing
- `php -l` lint on modified files (`includes/admin/class-sql-admin.php`, `includes/admin/list-tables/class-ufsc-clubs-list-table.php`, `includes/frontend/class-frontend-shortcodes.php`, `ufsc-clubs-licences-sql.php`) — Result: no syntax errors — PASS. 
- Duplicate / method presence check (`rg` for new helpers) to ensure single definitions (`get_admin_return_url`, `get_bureau_role_assignments`, `render_bureau_alert_for_club`, `get_bureau_coverage_data`, `render_bureau_badges_for_front_licence`) — Result: single occurrences found — PASS. 
- Static verification of bulk mechanics for licences: presence of hidden `page`, nonce, `licence_ids[]` handling and safe redirect in handler — Result: code present and properly sanitized/redirected — PASS (static). 
- Static verification of bulk mechanics for clubs: hidden `page`, sanitized/unique `club_ids[]`, scope/cap checks and safe redirect — Result: code present and correctly updated — PASS (static). 
- Visibility filter labels: confirmed display labels changed and internal values preserved — PASS. 
- Return button stabilization: `return_to` propagation and `get_admin_return_url()` validation added and `history.back()` removed from licence form — PASS (static). 
- Bureau identification and alert: admin + frontend helpers and UI badges implemented and message is informational (non-blocking) — PASS (static). 
- Full end-to-end interactive tests (UI clicks, DB, preprod flow) — Not executable in this environment (no WP instance/DB/UI) — FAIL (environment limitation). 

Note: all changes are conservative, keep existing nonces, actions, slugs and table usage; final E2E verification on a staging/preprod instance is recommended before production deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18e40fe30832bb9630a6e8a353e98)