### PR TITLE
Persist bureau role, normalize phone/date, surface bureau status (admin+front), set version 042026

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -455,6 +455,53 @@ class UFSC_SQL_Admin
     }
 
     /**
+     * Compute club bureau coverage status.
+     *
+     * @param array $assignments Bureau assignments by role.
+     * @return array{code:string,label:string,class:string,missing:array}
+     */
+    private static function get_bureau_coverage_status( $assignments ) {
+        $role_labels = array(
+            'president'  => __( 'Président', 'ufsc-clubs' ),
+            'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
+            'tresorier'  => __( 'Trésorier', 'ufsc-clubs' ),
+        );
+
+        $missing = array();
+        foreach ( $role_labels as $role => $label ) {
+            $ids = isset( $assignments[ $role ] ) ? (array) $assignments[ $role ] : array();
+            if ( empty( $ids ) ) {
+                $missing[] = sprintf( __( '%s non licencié', 'ufsc-clubs' ), $label );
+            }
+        }
+
+        if ( empty( $assignments ) ) {
+            return array(
+                'code'    => 'unknown',
+                'label'   => __( 'Bureau non conforme', 'ufsc-clubs' ),
+                'class'   => 'badge-danger',
+                'missing' => $missing,
+            );
+        }
+
+        if ( empty( $missing ) ) {
+            return array(
+                'code'    => 'complete',
+                'label'   => __( 'Bureau à jour', 'ufsc-clubs' ),
+                'class'   => 'badge-success',
+                'missing' => array(),
+            );
+        }
+
+        return array(
+            'code'    => 'incomplete',
+            'label'   => __( 'Bureau incomplet', 'ufsc-clubs' ),
+            'class'   => 'badge-warning',
+            'missing' => $missing,
+        );
+    }
+
+    /**
      * Render non-blocking bureau coverage alert for one club.
      *
      * @param int $club_id Club ID.
@@ -465,24 +512,21 @@ class UFSC_SQL_Admin
         if ( empty( $assignments ) ) {
             return;
         }
-        $role_labels = array(
-            'president' => __( 'Président', 'ufsc-clubs' ),
-            'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
-            'tresorier' => __( 'Trésorier', 'ufsc-clubs' ),
-        );
-        $missing = array();
-        foreach ( $role_labels as $role => $label ) {
-            if ( empty( $assignments[ $role ] ) ) {
-                $missing[] = sprintf( __( '%s non licencié', 'ufsc-clubs' ), $label );
-            }
+        $status = self::get_bureau_coverage_status( $assignments );
+
+        $notice_class = 'notice-info';
+        if ( 'complete' === $status['code'] ) {
+            $notice_class = 'notice-success';
+        } elseif ( 'incomplete' === $status['code'] ) {
+            $notice_class = 'notice-warning';
+        } elseif ( 'unknown' === $status['code'] ) {
+            $notice_class = 'notice-error';
         }
 
-        if ( empty( $missing ) ) {
-            return;
+        echo '<div class="notice ' . esc_attr( $notice_class ) . '"><p><strong>' . esc_html__( 'Statut du bureau :', 'ufsc-clubs' ) . ' ' . esc_html( $status['label'] ) . '</strong>';
+        if ( ! empty( $status['missing'] ) ) {
+            echo '<br />' . esc_html( implode( ' • ', $status['missing'] ) );
         }
-
-        echo '<div class="notice notice-warning"><p><strong>' . esc_html__( 'Vous n’avez pas encore licencié l’ensemble du bureau du club.', 'ufsc-clubs' ) . '</strong><br />';
-        echo esc_html( implode( ' • ', $missing ) );
         echo '</p></div>';
     }
 
@@ -509,6 +553,53 @@ class UFSC_SQL_Admin
         }
 
         return $badges ? implode( ' ', $badges ) : '—';
+    }
+
+    /**
+     * Normalize date value for HTML date input and storage.
+     *
+     * @param mixed $value Raw date value.
+     * @return string
+     */
+    private static function normalize_date_value( $value ) {
+        $raw = trim( (string) $value );
+        if ( '' === $raw || '0000-00-00' === $raw || '0000-00-00 00:00:00' === $raw ) {
+            return '';
+        }
+
+        if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $raw ) ) {
+            return $raw;
+        }
+
+        if ( preg_match( '/^\d{4}-\d{2}-\d{2}\s+/', $raw ) ) {
+            return substr( $raw, 0, 10 );
+        }
+
+        $timestamp = strtotime( $raw );
+        if ( false === $timestamp ) {
+            return '';
+        }
+
+        return gmdate( 'Y-m-d', $timestamp );
+    }
+
+    /**
+     * Human label for bureau role.
+     *
+     * @param mixed $role Raw role value.
+     * @return string
+     */
+    private static function get_bureau_role_label( $role ) {
+        $role = sanitize_key( (string) $role );
+        $labels = array(
+            'president'  => __( 'Président', 'ufsc-clubs' ),
+            'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
+            'tresorier'  => __( 'Trésorier', 'ufsc-clubs' ),
+            'entraineur' => __( 'Entraîneur', 'ufsc-clubs' ),
+            'adherent'   => __( 'Adhérent', 'ufsc-clubs' ),
+        );
+
+        return $labels[ $role ] ?? ucfirst( $role );
     }
 
     /**
@@ -1069,10 +1160,29 @@ class UFSC_SQL_Admin
             echo UFSC_CL_Utils::show_error(sanitize_text_field($_GET['error']));
         }
 
+        if ( $row ) {
+            $role_value        = isset( $row->role ) ? sanitize_key( (string) $row->role ) : '';
+            $is_bureau_member  = in_array( $role_value, array( 'president', 'secretaire', 'tresorier' ), true );
+            $role_label        = $role_value ? self::get_bureau_role_label( $role_value ) : __( '—', 'ufsc-clubs' );
+            $membership_label  = $is_bureau_member ? __( 'Oui', 'ufsc-clubs' ) : __( 'Non', 'ufsc-clubs' );
+            $membership_badge  = $is_bureau_member
+                ? '<span class="ufsc-badge badge-success">' . esc_html__( 'Membre du bureau', 'ufsc-clubs' ) . '</span>'
+                : '<span class="ufsc-badge badge-muted">' . esc_html__( 'Hors bureau', 'ufsc-clubs' ) . '</span>';
+
+            echo '<div class="notice notice-info"><p><strong>' . esc_html__( 'Synthèse bureau', 'ufsc-clubs' ) . '</strong><br />';
+            echo esc_html__( 'Membre du bureau :', 'ufsc-clubs' ) . ' <strong>' . esc_html( $membership_label ) . '</strong> &nbsp; ' . wp_kses_post( $membership_badge );
+            echo '<br />' . esc_html__( 'Rôle bureau :', 'ufsc-clubs' ) . ' <strong>' . esc_html( $role_label ) . '</strong>';
+            echo '</p></div>';
+        }
+
         $docs_error = get_transient('ufsc_docs_errors_' . get_current_user_id());
         if ($docs_error) {
             delete_transient('ufsc_docs_errors_' . get_current_user_id());
             echo UFSC_CL_Utils::show_error(sanitize_text_field($docs_error));
+        }
+
+        if ( $id ) {
+            self::render_bureau_alert_for_club( $id );
         }
 
         if (! $readonly) {
@@ -2551,7 +2661,22 @@ class UFSC_SQL_Admin
             echo '<input type="email" name="' . esc_attr($k) . '" value="' . esc_attr($val) . '" placeholder="' . esc_attr__('exemple@email.com', 'ufsc-clubs') . '" required ' . $readonly_attr . ' />';
         } elseif ($k === 'telephone' || $k === 'tel') {
             echo '<input type="tel" name="' . esc_attr($k) . '" value="' . esc_attr($val) . '" placeholder="' . esc_attr__('01 23 45 67 89', 'ufsc-clubs') . '" ' . $readonly_attr . ' />';
+        } elseif ($k === 'role') {
+            $role_options = array(
+                ''           => __( 'Sélectionner', 'ufsc-clubs' ),
+                'president'  => __( 'Président', 'ufsc-clubs' ),
+                'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
+                'tresorier'  => __( 'Trésorier', 'ufsc-clubs' ),
+                'entraineur' => __( 'Entraîneur', 'ufsc-clubs' ),
+                'adherent'   => __( 'Adhérent', 'ufsc-clubs' ),
+            );
+            echo '<select name="' . esc_attr($k) . '" ' . $disabled_attr . '>';
+            foreach ( $role_options as $role_key => $role_label ) {
+                echo '<option value="' . esc_attr( $role_key ) . '" ' . selected( sanitize_key( (string) $val ), $role_key, false ) . '>' . esc_html( $role_label ) . '</option>';
+            }
+            echo '</select>';
         } elseif ($k === 'date_naissance' || strpos($k, 'date_') === 0) {
+            $val = self::normalize_date_value( $val );
             echo '<input type="date" name="' . esc_attr($k) . '" value="' . esc_attr($val) . '" ' . $readonly_attr . ' />';
         } elseif ($k === 'prenom') {
             echo '<input type="text" name="' . esc_attr($k) . '" value="' . esc_attr($val) . '" placeholder="' . esc_attr__('Prénom', 'ufsc-clubs') . '" required ' . $readonly_attr . ' />';
@@ -2628,6 +2753,22 @@ class UFSC_SQL_Admin
             } else {
                 $data[$k] = sanitize_text_field(wp_unslash($_POST[$k]));
             }
+        }
+
+        foreach ( $fields as $k => $conf ) {
+            if ( ! isset( $data[ $k ] ) ) {
+                continue;
+            }
+            $type = isset( $conf[1] ) ? $conf[1] : 'text';
+            if ( 'date' !== $type ) {
+                continue;
+            }
+            $normalized = self::normalize_date_value( $data[ $k ] );
+            if ( '' === $normalized && $id ) {
+                unset( $data[ $k ] );
+                continue;
+            }
+            $data[ $k ] = $normalized;
         }
 
         $is_paid_submission = false;

--- a/includes/core/class-sql.php
+++ b/includes/core/class-sql.php
@@ -105,6 +105,7 @@ class UFSC_SQL {
                 'profession'=>array('Profession','text'),
                 'fonction_publique'=>array('Fonction publique','bool'),
                 'competition'=>array('Compétition','bool'),
+                'role'=>array('Rôle dans le club','text'),
                 'licence_delegataire'=>array('Licence délégataire','bool'),
                 'numero_licence_delegataire'=>array('N° licence délégataire','text'),
                 'diffusion_image'=>array('Autoriser diffusion image','bool'),

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -388,6 +388,10 @@ class UFSC_Frontend_Shortcodes {
                     </button>
                 </div>
             </div>
+            <div class="ufsc-message ufsc-info">
+                <strong><?php esc_html_e( 'Statut du bureau :', 'ufsc-clubs' ); ?></strong>
+                <?php echo esc_html( $bureau_data['status_label'] ?? __( 'Bureau non conforme', 'ufsc-clubs' ) ); ?>
+            </div>
             <?php if ( ! empty( $bureau_data['missing_labels'] ) ) : ?>
                 <div class="ufsc-message ufsc-info">
                     <strong><?php esc_html_e( 'Vous n’avez pas encore licencié l’ensemble du bureau du club.', 'ufsc-clubs' ); ?></strong><br>
@@ -1306,6 +1310,13 @@ class UFSC_Frontend_Shortcodes {
             $form_data = (array) $edit_licence;
         }
 
+        if ( empty( $form_data['telephone'] ) ) {
+            $form_data['telephone'] = self::resolve_licence_phone( $form_data );
+        }
+        if ( isset( $form_data['role'] ) ) {
+            $form_data['role'] = sanitize_key( (string) $form_data['role'] );
+        }
+
         // UFSC: default checked (stable + no regression)
         $form_data = is_array( $form_data ) ? $form_data : array();
 
@@ -1693,7 +1704,9 @@ class UFSC_Frontend_Shortcodes {
             $where .= " AND (deleted_at IS NULL OR deleted_at = '0000-00-00 00:00:00')";
         }
 
-        return $wpdb->get_row( $wpdb->prepare( "SELECT {$select_fields} FROM `{$table}` WHERE {$where}", $licence_id, $club_id ) );
+        $row = $wpdb->get_row( $wpdb->prepare( "SELECT {$select_fields} FROM `{$table}` WHERE {$where}", $licence_id, $club_id ) );
+
+        return self::normalize_licence_row_for_display( $row );
     }
 
     // Helper methods
@@ -1895,6 +1908,11 @@ class UFSC_Frontend_Shortcodes {
         $values[]  = $offset;
 
         $rows = $wpdb->get_results( $wpdb->prepare( $sql, $values ) );
+        if ( ! empty( $rows ) ) {
+            foreach ( $rows as $idx => $row ) {
+                $rows[ $idx ] = self::normalize_licence_row_for_display( $row );
+            }
+        }
         if ( ! empty( $rows ) && function_exists( 'ufsc_get_licence_season_label' ) ) {
             foreach ( $rows as $row ) {
                 $row->season_label = ufsc_get_licence_season_label( $row );
@@ -1903,6 +1921,61 @@ class UFSC_Frontend_Shortcodes {
         }
 
         return $rows;
+    }
+
+    /**
+     * Resolve the best phone value from a licence row.
+     *
+     * @param object|array|null $licence Licence row.
+     * @return string
+     */
+    private static function resolve_licence_phone( $licence ) {
+        if ( ! is_object( $licence ) && ! is_array( $licence ) ) {
+            return '';
+        }
+
+        $candidates = array( 'tel_mobile', 'telephone', 'mobile', 'tel_fixe' );
+        foreach ( $candidates as $field ) {
+            $value = is_array( $licence ) ? ( $licence[ $field ] ?? '' ) : ( $licence->{$field} ?? '' );
+            $value = trim( (string) $value );
+            if ( '' !== $value ) {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Normalize legacy licence fields for consistent UI rendering.
+     *
+     * @param object|null $row Raw DB row.
+     * @return object|null
+     */
+    private static function normalize_licence_row_for_display( $row ) {
+        if ( ! is_object( $row ) ) {
+            return $row;
+        }
+
+        $phone = self::resolve_licence_phone( $row );
+        $row->telephone = $phone;
+        if ( empty( $row->tel_mobile ) ) {
+            $row->tel_mobile = $phone;
+        }
+
+        if ( isset( $row->role ) ) {
+            $row->role = sanitize_key( (string) $row->role );
+        }
+
+        if ( ! empty( $row->date_inscription ) && is_string( $row->date_inscription ) ) {
+            if ( preg_match( '/^\d{4}-\d{2}-\d{2}\s+/', $row->date_inscription ) ) {
+                $row->date_inscription = substr( $row->date_inscription, 0, 10 );
+            } elseif ( '0000-00-00' === $row->date_inscription || '0000-00-00 00:00:00' === $row->date_inscription ) {
+                $row->date_inscription = '';
+            }
+        }
+
+        return $row;
     }
 
     /**
@@ -1998,6 +2071,8 @@ class UFSC_Frontend_Shortcodes {
                 'tresorier' => array(),
             ),
             'missing_labels' => array(),
+            'status_code'    => 'non_conforme',
+            'status_label'   => __( 'Bureau non conforme', 'ufsc-clubs' ),
         );
 
         if ( $club_id <= 0 || ! function_exists( 'ufsc_get_licences_table' ) ) {
@@ -2041,6 +2116,14 @@ class UFSC_Frontend_Shortcodes {
             if ( empty( $data['assignments'][ $role ] ) ) {
                 $data['missing_labels'][] = sprintf( __( '%s non licencié', 'ufsc-clubs' ), $label );
             }
+        }
+
+        if ( empty( $data['missing_labels'] ) ) {
+            $data['status_code']  = 'a_jour';
+            $data['status_label'] = __( 'Bureau à jour', 'ufsc-clubs' );
+        } else {
+            $data['status_code']  = 'incomplet';
+            $data['status_label'] = __( 'Bureau incomplet', 'ufsc-clubs' );
         }
 
         return $data;

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === UFSC – Clubs & Licences (SQL) ===
 Contributors: Davy – Studio REACTIV (pour l'UFSC)
-Stable tag: 1.5.3ff
+Stable tag: 042026
 Requires at least: 6.0
 Tested up to: 6.6
 License: GPLv2 or later


### PR DESCRIPTION
### Motivation
- Fix admin/front inconsistencies where `role` was not persisted, telephone displayed differently, and `date_inscription` could be overwritten or shown as `0000-00-00`, while improving visibility of bureau coverage in admin and front.
- Keep changes conservative and non-breaking: preserve hooks, slugs, nonces, table names and existing business rules (locks/paid licences).

### Description
- Add `role` to the licence field map so unified handlers can persist `role` reliably (`includes/core/class-sql.php`).
- Admin: introduce `get_bureau_coverage_status()`, `normalize_date_value()` and `get_bureau_role_label()` and render a compact licence-level bureau synthesis and club-level bureau status notice; render a safe `role` `<select>` and normalize `date_*` fields before saving to avoid overwriting valid dates with empty values (`includes/admin/class-sql-admin.php`).
- Front: add `resolve_licence_phone()` and `normalize_licence_row_for_display()` to compute a single phone fallback (`tel_mobile` → `telephone` → `mobile` → `tel_fixe`), prefill the front edit form telephone and sanitize `role`, and expose a human `status_label` for bureau coverage in the club licences UI (`includes/frontend/class-frontend-shortcodes.php`).
- Update `readme.txt` `Stable tag` to `042026` to match plugin `Version: 042026` header (`readme.txt`).
- All changes are targeted, column-aware and preserve existing validation/nonce/capability checks; no new tables or public hooks introduced.

### Testing
- PHP lint: ran `php -l includes/core/class-sql.php && php -l includes/admin/class-sql-admin.php && php -l includes/frontend/class-frontend-shortcodes.php && php -l ufsc-clubs-licences-sql.php` and received no syntax errors, so `PASS`.
- Static presence checks: used `rg` to verify `role` is present in licence map, `resolve_licence_phone` fallback is added, and `normalize_date_value` is referenced; assertions succeeded, so `PASS`.
- Logic checks: confirmed admin shows the new bureau synthesis block and club-level bureau status notice and front shows `status_label` and telephone prefill via code inspection, so `PASS` for rendering wiring.
- Version visibility: checked `Version: 042026` (plugin header) and updated `Stable tag: 042026` in `readme.txt`, so `PASS`.
- Handlers/security review: validated that existing nonce/capability checks and sanitizers were preserved around modified handlers; static audit `PASS`.
- E2E functional tests (editing a paid/validated licence, saving role/date on a real WP+DB instance) were not executable in this environment and require a staging WP instance with production-like data, so those are deferred (marked `FAIL` here due to environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a61d350c832bba7bb4e627d860fc)