### PR TITLE
Refonte UI Compte Club + affectation bureau/licence rétrocompatible

### DIFF
--- a/assets/css/ufsc-front.css
+++ b/assets/css/ufsc-front.css
@@ -146,8 +146,37 @@
 }
 @media (min-width: var(--desktop)) {
     .ufsc-club-profile-layout {
-        grid-template-columns: 2fr 1fr;
+        grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
     }
+}
+.ufsc-profile-cards {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--ufsc-spacing-md);
+}
+@media (min-width: var(--desktop)) {
+    .ufsc-profile-cards {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+.ufsc-profile-cards .ufsc-card {
+    height: 100%;
+}
+.ufsc-board-columns {
+    display: grid;
+    gap: var(--ufsc-spacing-sm);
+    grid-template-columns: 1fr;
+}
+@media (min-width: var(--tablet)) {
+    .ufsc-board-columns {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+.ufsc-board-role-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: var(--ufsc-spacing-sm);
+    background: #f8fafc;
 }
 .ufsc-club-profile-documents .ufsc-documents-grid {
     grid-template-columns: 1fr;
@@ -155,7 +184,7 @@
 
 /* Club profile typography and spacing */
 .ufsc-club-profile .ufsc-card h4,
-.ufsc-club-profile fieldset legend {
+.ufsc-club-profile .ufsc-form-section h4 {
     font-size: 1.1rem;
     font-weight: 600;
     line-height: 1.4;
@@ -163,12 +192,8 @@
     color: var(--ufsc-secondary);
 }
 
-.ufsc-club-profile fieldset {
+.ufsc-club-profile .ufsc-form-section {
     margin-bottom: var(--ufsc-spacing-lg);
-    padding: var(--ufsc-spacing-md);
-    background: #ffffff;
-    border: 1px solid #e1e5e9;
-    border-radius: 8px;
 }
 
 .ufsc-document-summary {
@@ -210,6 +235,18 @@
     border: 1px solid #ddd;
     border-radius: 4px;
     font-size: 14px;
+}
+
+.ufsc-bureau-assignment-form {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    margin-top: 8px;
+}
+.ufsc-bureau-role-select {
+    min-width: 150px;
+    font-size: 12px;
+    padding: 4px 6px;
 }
 
 /* Buttons */

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -26,6 +26,8 @@ class UFSC_Unified_Handlers {
         add_action( 'admin_post_ufsc_cancel_licence', array( __CLASS__, 'handle_cancel_licence' ) );
         add_action( 'admin_post_ufsc_update_licence_status', array( __CLASS__, 'handle_update_licence_status' ) );
         add_action( 'admin_post_nopriv_ufsc_update_licence_status', array( __CLASS__, 'handle_update_licence_status' ) );
+        add_action( 'admin_post_ufsc_assign_bureau_role', array( __CLASS__, 'handle_assign_bureau_role' ) );
+        add_action( 'admin_post_nopriv_ufsc_assign_bureau_role', array( __CLASS__, 'handle_assign_bureau_role' ) );
         add_action( 'admin_post_ufsc_sync_licence_statuses', array( __CLASS__, 'handle_sync_licence_statuses' ) );
 
         // UFSC PATCH: Licence document handlers
@@ -422,6 +424,108 @@ class UFSC_Unified_Handlers {
         );
 
         self::maybe_redirect( $redirect_url );
+    }
+
+    /**
+     * Assign or remove bureau role for an existing licence from front-end.
+     * This remains allowed even if the licence is locked/validated.
+     */
+    public static function handle_assign_bureau_role() {
+        if ( ! current_user_can( 'read' ) ) {
+            wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
+        check_admin_referer( 'ufsc_assign_bureau_role' );
+
+        if ( ! is_user_logged_in() ) {
+            self::redirect_with_error( 'Vous devez être connecté' );
+            return;
+        }
+
+        $licence_id       = isset( $_POST['licence_id'] ) ? absint( $_POST['licence_id'] ) : 0;
+        $requested_role   = isset( $_POST['bureau_role'] ) ? sanitize_key( wp_unslash( $_POST['bureau_role'] ) ) : '';
+        $requested_club   = isset( $_POST['club_id'] ) ? absint( $_POST['club_id'] ) : 0;
+        $allowed_roles    = array( '', 'president', 'secretaire', 'tresorier' );
+
+        if ( ! in_array( $requested_role, $allowed_roles, true ) || $licence_id <= 0 ) {
+            self::redirect_with_error( 'Paramètres invalides' );
+            return;
+        }
+
+        $user_id      = get_current_user_id();
+        $managed_club = ufsc_get_user_club_id( $user_id );
+        $can_manage_all = self::can_manage_all_clubs();
+
+        if ( $requested_club <= 0 ) {
+            $requested_club = $managed_club;
+        }
+        if ( $requested_club <= 0 && $can_manage_all ) {
+            $requested_club = self::resolve_licence_club_id( $licence_id );
+        }
+
+        if ( $requested_club <= 0 ) {
+            self::redirect_with_error( 'Aucun club associé à votre compte' );
+            return;
+        }
+        if ( ! $can_manage_all && $managed_club !== $requested_club ) {
+            self::redirect_with_error( 'Permissions insuffisantes' );
+            return;
+        }
+
+        $licence = self::get_licence_row( $licence_id, $requested_club );
+        if ( ! $licence ) {
+            self::redirect_with_error( 'Licence non trouvée', $licence_id );
+            return;
+        }
+
+        global $wpdb;
+        $settings = UFSC_SQL::get_settings();
+        $table    = $settings['table_licences'];
+
+        $columns = function_exists( 'ufsc_table_columns' ) ? (array) ufsc_table_columns( $table ) : array();
+        if ( ! empty( $columns ) && ! in_array( 'role', $columns, true ) ) {
+            self::redirect_with_error( 'Colonne rôle indisponible' );
+            return;
+        }
+
+        $new_role = $requested_role;
+        if ( '' !== $new_role ) {
+            $wpdb->update(
+                $table,
+                array( 'role' => '' ),
+                array(
+                    'club_id' => $requested_club,
+                    'role'    => $new_role,
+                ),
+                array( '%s' ),
+                array( '%d', '%s' )
+            );
+        }
+
+        $updated = $wpdb->update(
+            $table,
+            array( 'role' => $new_role ),
+            array(
+                'id'      => $licence_id,
+                'club_id' => $requested_club,
+            ),
+            array( '%s' ),
+            array( '%d', '%d' )
+        );
+
+        if ( false === $updated ) {
+            self::redirect_with_error( 'Mise à jour du bureau impossible', $licence_id );
+            return;
+        }
+
+        do_action( 'ufsc_bureau_assignment_updated', $requested_club, $licence_id, $new_role );
+        do_action( 'ufsc_licence_updated', (int) $requested_club );
+
+        $success_message = '' === $new_role
+            ? __( 'Rôle bureau retiré.', 'ufsc-clubs' )
+            : sprintf( __( 'Rôle bureau mis à jour : %s.', 'ufsc-clubs' ), self::get_bureau_role_label( $new_role ) );
+
+        self::redirect_with_success( $success_message );
     }
 
     /**
@@ -1463,6 +1567,16 @@ class UFSC_Unified_Handlers {
         $table    = $settings['table_licences'];
 
         return (int) $wpdb->get_var( $wpdb->prepare( "SELECT club_id FROM {$table} WHERE id = %d", $licence_id ) );
+    }
+
+    private static function get_bureau_role_label( $role ) {
+        $labels = array(
+            'president'  => __( 'Président', 'ufsc-clubs' ),
+            'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
+            'tresorier'  => __( 'Trésorier', 'ufsc-clubs' ),
+        );
+
+        return isset( $labels[ $role ] ) ? $labels[ $role ] : __( 'Aucun', 'ufsc-clubs' );
     }
 
     private static function maybe_redirect( $url ) {

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -526,7 +526,25 @@ class UFSC_Frontend_Shortcodes {
                                 <tr>
                                     <td><?php echo esc_html( $nom ); ?></td>
                                     <td><?php echo esc_html( $prenom ); ?></td>
-                                    <td><?php echo wp_kses_post( self::render_bureau_badges_for_front_licence( (int) ( $licence->id ?? 0 ), $bureau_data['assignments'] ) ); ?></td>
+                                    <td>
+                                        <?php
+                                        $licence_id = (int) ( $licence->id ?? 0 );
+                                        echo wp_kses_post( self::render_bureau_badges_for_front_licence( $licence_id, $bureau_data['assignments'] ) );
+                                        ?>
+                                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-bureau-assignment-form">
+                                            <?php wp_nonce_field( 'ufsc_assign_bureau_role' ); ?>
+                                            <input type="hidden" name="action" value="ufsc_assign_bureau_role">
+                                            <input type="hidden" name="licence_id" value="<?php echo esc_attr( $licence_id ); ?>">
+                                            <input type="hidden" name="club_id" value="<?php echo esc_attr( (int) $atts['club_id'] ); ?>">
+                                            <label class="screen-reader-text" for="ufsc-bureau-role-<?php echo esc_attr( $licence_id ); ?>">
+                                                <?php esc_html_e( 'Affectation bureau', 'ufsc-clubs' ); ?>
+                                            </label>
+                                            <?php echo self::render_bureau_role_selector( $licence_id, $bureau_data['assignments'] ); ?>
+                                            <button type="submit" class="ufsc-btn ufsc-btn-small ufsc-btn-secondary">
+                                                <?php esc_html_e( 'Affecter', 'ufsc-clubs' ); ?>
+                                            </button>
+                                        </form>
+                                    </td>
                                     <td><?php echo esc_html( $gender ); ?></td>
                                     <td><?php echo self::get_status_badge_front($status); ?></td>
                                     <td><?php echo esc_html( $season ); ?></td>
@@ -976,9 +994,8 @@ class UFSC_Frontend_Shortcodes {
                         <?php endif; ?>
                     </div>
                 <?php endif; ?>
-                <!-- // UFSC: Identité du club -->
                 <div class="ufsc-club-profile-layout">
-                    <div class="ufsc-club-profile-main">
+                    <div class="ufsc-club-profile-main ufsc-profile-cards">
                 <div class="ufsc-card ufsc-section">
                     <h4><?php esc_html_e( 'Identité du club', 'ufsc-clubs' ); ?></h4>
 
@@ -1015,9 +1032,8 @@ class UFSC_Frontend_Shortcodes {
                     </div>
                 </div>
 
-                <!-- Legal Section -->
-                <fieldset class="ufsc-form-section">
-                    <legend><?php esc_html_e( 'Informations légales', 'ufsc-clubs' ); ?></legend>
+                <div class="ufsc-card ufsc-form-section">
+                    <h4><?php esc_html_e( 'Informations légales', 'ufsc-clubs' ); ?></h4>
 
                     <div class="ufsc-grid">
                         <?php self::render_field( 'siren', $club, __( 'SIREN', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
@@ -1028,12 +1044,12 @@ class UFSC_Frontend_Shortcodes {
                         <?php self::render_field( 'num_declaration', $club, __( 'N° déclaration', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
                         <?php self::render_field( 'date_declaration', $club, __( 'Date déclaration', 'ufsc-clubs' ), 'date', false, $is_admin ); ?>
                     </div>
-                </fieldset>
+                </div>
 
-                <!-- Staff Section -->
-                <fieldset class="ufsc-form-section">
-                    <legend><?php esc_html_e( 'Dirigeants', 'ufsc-clubs' ); ?></legend>
-
+                <div class="ufsc-card ufsc-form-section">
+                    <h4><?php esc_html_e( 'Dirigeants', 'ufsc-clubs' ); ?></h4>
+                    <div class="ufsc-board-columns">
+                        <div class="ufsc-board-role-card">
                     <h5><?php esc_html_e( 'Président', 'ufsc-clubs' ); ?></h5>
                     <div class="ufsc-grid">
                         <?php self::render_field( 'president_prenom', $club, __( 'Prénom', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
@@ -1041,7 +1057,9 @@ class UFSC_Frontend_Shortcodes {
                         <?php self::render_field( 'president_tel', $club, __( 'Téléphone', 'ufsc-clubs' ), 'tel', false, $is_admin ); ?>
                         <?php self::render_field( 'president_email', $club, __( 'Email', 'ufsc-clubs' ), 'email', false, $is_admin ); ?>
                     </div>
+                        </div>
 
+                        <div class="ufsc-board-role-card">
                     <h5><?php esc_html_e( 'Secrétaire', 'ufsc-clubs' ); ?></h5>
                     <div class="ufsc-grid">
                         <?php self::render_field( 'secretaire_prenom', $club, __( 'Prénom', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
@@ -1049,13 +1067,17 @@ class UFSC_Frontend_Shortcodes {
                         <?php self::render_field( 'secretaire_tel', $club, __( 'Téléphone', 'ufsc-clubs' ), 'tel', false, $is_admin ); ?>
                         <?php self::render_field( 'secretaire_email', $club, __( 'Email', 'ufsc-clubs' ), 'email', false, $is_admin ); ?>
                     </div>
+                        </div>
 
+                        <div class="ufsc-board-role-card">
                     <h5><?php esc_html_e( 'Trésorier', 'ufsc-clubs' ); ?></h5>
                     <div class="ufsc-grid">
                         <?php self::render_field( 'tresorier_prenom', $club, __( 'Prénom', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
                         <?php self::render_field( 'tresorier_nom', $club, __( 'Nom', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
                         <?php self::render_field( 'tresorier_tel', $club, __( 'Téléphone', 'ufsc-clubs' ), 'tel', false, $is_admin ); ?>
                         <?php self::render_field( 'tresorier_email', $club, __( 'Email', 'ufsc-clubs' ), 'email', false, $is_admin ); ?>
+                    </div>
+                        </div>
                     </div>
 
                     <h5><?php esc_html_e( 'Entraîneur', 'ufsc-clubs' ); ?></h5>
@@ -1065,22 +1087,20 @@ class UFSC_Frontend_Shortcodes {
                         <?php self::render_field( 'entraineur_tel', $club, __( 'Téléphone', 'ufsc-clubs' ), 'tel', false, $is_admin ); ?>
                         <?php self::render_field( 'entraineur_email', $club, __( 'Email', 'ufsc-clubs' ), 'email', false, $is_admin ); ?>
                     </div>
-                </fieldset>
+                </div>
 
-                <!-- Social Section -->
-                <fieldset class="ufsc-form-section">
-                    <legend><?php esc_html_e( 'Réseaux sociaux', 'ufsc-clubs' ); ?></legend>
+                <div class="ufsc-card ufsc-form-section">
+                    <h4><?php esc_html_e( 'Réseaux sociaux', 'ufsc-clubs' ); ?></h4>
 
                     <div class="ufsc-grid">
                         <?php self::render_field( 'url_site', $club, __( 'Site web', 'ufsc-clubs' ), 'url', false, $is_admin ); ?>
                         <?php self::render_field( 'url_facebook', $club, __( 'Facebook', 'ufsc-clubs' ), 'url', false, $is_admin ); ?>
                         <?php self::render_field( 'url_instagram', $club, __( 'Instagram', 'ufsc-clubs' ), 'url', false, $is_admin ); ?>
                     </div>
-                </fieldset>
+                </div>
 
-                <!-- Numbers/Dates Section -->
-                <fieldset class="ufsc-form-section">
-                    <legend><?php esc_html_e( 'Chiffres et dates', 'ufsc-clubs' ); ?></legend>
+                <div class="ufsc-card ufsc-form-section">
+                    <h4><?php esc_html_e( 'Chiffres et dates', 'ufsc-clubs' ); ?></h4>
 
                     <div class="ufsc-grid">
                         <?php self::render_field( 'num_affiliation', $club, __( 'N° d\'affiliation', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
@@ -1088,22 +1108,21 @@ class UFSC_Frontend_Shortcodes {
                         <?php self::render_field( 'date_affiliation', $club, __( 'Date d\'affiliation', 'ufsc-clubs' ), 'date', false, $is_admin ); ?>
                         <?php self::render_field( 'responsable_id', $club, __( 'ID responsable', 'ufsc-clubs' ), 'number', true, false ); ?>
                     </div>
-                </fieldset>
+                </div>
 
-                <!-- Distribution Section -->
-                <fieldset class="ufsc-form-section">
-                    <legend><?php esc_html_e( 'Distribution', 'ufsc-clubs' ); ?></legend>
+                <div class="ufsc-card ufsc-form-section">
+                    <h4><?php esc_html_e( 'Distribution', 'ufsc-clubs' ); ?></h4>
 
                     <div class="ufsc-grid">
                         <?php self::render_field( 'precision_distribution', $club, __( 'Précision distribution', 'ufsc-clubs' ), 'textarea', false, $is_admin ); ?>
                     </div>
-                </fieldset>
+                </div>
                     </div>
 
                 <!-- // UFSC: Documents Section - 6 mandatory documents -->
                 <div class="ufsc-club-profile-documents">
-                    <fieldset class="ufsc-form-section">
-                        <legend><?php esc_html_e( 'Mes documents', 'ufsc-clubs' ); ?></legend>
+                    <div class="ufsc-card ufsc-form-section">
+                        <h4><?php esc_html_e( 'Mes documents', 'ufsc-clubs' ); ?></h4>
 
                         <?php
                         // // UFSC: 6 mandatory documents as per requirements
@@ -1210,7 +1229,7 @@ class UFSC_Frontend_Shortcodes {
                                 </div>
                             <?php endforeach; ?>
                         </div>
-                    </fieldset>
+                    </div>
                 </div>
                 </div>
 
@@ -2152,6 +2171,43 @@ class UFSC_Frontend_Shortcodes {
         }
 
         return $badges ? implode( ' ', $badges ) : '—';
+    }
+
+    /**
+     * Render bureau role selector for one licence with current assignment pre-selected.
+     *
+     * @param int   $licence_id Licence ID.
+     * @param array $assignments Current assignments by role.
+     * @return string
+     */
+    private static function render_bureau_role_selector( $licence_id, $assignments ) {
+        $current_role = '';
+        foreach ( array( 'president', 'secretaire', 'tresorier' ) as $role ) {
+            $assigned_ids = isset( $assignments[ $role ] ) ? array_map( 'intval', (array) $assignments[ $role ] ) : array();
+            if ( in_array( (int) $licence_id, $assigned_ids, true ) ) {
+                $current_role = $role;
+                break;
+            }
+        }
+
+        $labels = array(
+            ''           => __( 'Aucun rôle', 'ufsc-clubs' ),
+            'president'  => __( 'Président', 'ufsc-clubs' ),
+            'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
+            'tresorier'  => __( 'Trésorier', 'ufsc-clubs' ),
+        );
+
+        ob_start();
+        ?>
+        <select id="ufsc-bureau-role-<?php echo esc_attr( (int) $licence_id ); ?>" name="bureau_role" class="ufsc-bureau-role-select">
+            <?php foreach ( $labels as $role_key => $role_label ) : ?>
+                <option value="<?php echo esc_attr( $role_key ); ?>" <?php selected( $current_role, $role_key ); ?>>
+                    <?php echo esc_html( $role_label ); ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+        <?php
+        return (string) ob_get_clean();
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Moderniser l’UI/UX de la page « Compte Club » pour une présentation en cards/colonnes (meilleure lisibilité et responsive). 
- Permettre au club, côté front, d’affecter après coup un rôle de bureau (président/secrétaire/trésorier) à une licence existante, même si la licence est validée/verrouillée. 
- Conserver strictement la rétrocompatibilité et les flux existants (no destructive migration, mêmes routes/shortcodes/hooks). 

### Description
- Interface: refonte du rendu profil club en blocs « card » et grille responsive (1 colonne mobile / 2 colonnes desktop) et regroupement des sections (identité, coordonnées, infos légales, dirigeants, documents, réseaux, chiffres). (fichier modifié: `includes/frontend/class-frontend-shortcodes.php`, CSS: `assets/css/ufsc-front.css`).
- Affectation bureau front: ajout d’un mini-formulaire par ligne de licence avec select role (`Président`, `Secrétaire`, `Trésorier`, `Aucun rôle`) et nonce `ufsc_assign_bureau_role`, rendu et sélecteur fournis côté front. (modif: `includes/frontend/class-frontend-shortcodes.php`).
- Handler serveur: nouveau handler sécurisé `handle_assign_bureau_role` exposé via `admin_post_ufsc_assign_bureau_role` qui valide capability/nonce/login/périmètre club, assure l’unicité du rôle au niveau du club en retirant d’abord le rôle existant, met à jour la colonne `role` et déclenche `do_action('ufsc_licence_updated')` pour recalculer alertes/conformité; pas de migration destructrice, utilise la colonne `role` existante. (modif: `includes/core/class-unified-handlers.php`).
- Styles: ajouts CSS pour layout cards, colonnes dirigeants et styles du petit formulaire d’affectation (modif: `assets/css/ufsc-front.css`).
- Sécurité et robustesse: utilisation de `check_admin_referer`, `sanitize_key`, `absint`, `wp_unslash`, vérifications d’appartenance club et fallback si la colonne `role` absente pour garder rétrocompatibilité.

### Testing
- Vérification de syntaxe PHP: `php -l includes/core/class-unified-handlers.php` — réussite. 
- Vérification de syntaxe PHP: `php -l includes/frontend/class-frontend-shortcodes.php` — réussite. 
- Exécution du test existant `php tests/test-frontend.php` a échoué par manque de PHPUnit dans l’environnement CI local (erreur: `Class "PHPUnit\Framework\TestCase" not found`), ce qui n’indique pas de régression applicative à ce stade.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77d850a34832bb27c64597879ef4c)