### PR TITLE
Harden licence birth date validation on write paths

### DIFF
--- a/includes/api/class-rest-api.php
+++ b/includes/api/class-rest-api.php
@@ -415,7 +415,7 @@ class UFSC_REST_API {
 		}
 
 		$date_naissance = isset( $sanitized_data['date_naissance'] ) ? (string) $sanitized_data['date_naissance'] : '';
-		if ( '' === $date_naissance || '0000-00-00' === $date_naissance || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date_naissance ) ) {
+		if ( ! self::is_valid_birth_date( $date_naissance ) ) {
 			return new WP_Error( 'invalid_birth_date', __( 'Date de naissance invalide (YYYY-MM-DD requis).', 'ufsc-clubs' ), array( 'status' => 400 ) );
 		}
 
@@ -504,7 +504,7 @@ class UFSC_REST_API {
 				$sanitized[ $key ] = $value;
 			} elseif ( 'date_naissance' === $key ) {
 				$value = sanitize_text_field( $value );
-				if ( '' === $value || '0000-00-00' === $value || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $value ) ) {
+				if ( ! self::is_valid_birth_date( $value ) ) {
 					return new WP_Error( 'invalid_birth_date', __( 'Date de naissance invalide (YYYY-MM-DD requis).', 'ufsc-clubs' ), array( 'status' => 400 ) );
 				}
 				$sanitized[ $key ] = $value;
@@ -565,6 +565,21 @@ class UFSC_REST_API {
 			'message'        => __( 'Licence mise à jour avec succès.', 'ufsc-clubs' ),
 			'updated_fields' => array_keys( $sanitized ),
 		), 200 );
+	}
+
+	/**
+	 * Validate a birth date in strict YYYY-MM-DD format.
+	 *
+	 * @param string $date Birth date.
+	 * @return bool
+	 */
+	private static function is_valid_birth_date( $date ) {
+		if ( '' === $date || '0000-00-00' === $date || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+			return false;
+		}
+
+		$date_obj = DateTime::createFromFormat( 'Y-m-d', $date );
+		return $date_obj instanceof DateTime && $date_obj->format( 'Y-m-d' ) === $date;
 	}
 
 	/**

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -1170,7 +1170,7 @@ class UFSC_Unified_Handlers {
         }
 
         $date_naissance = isset( $post_data['date_naissance'] ) ? sanitize_text_field( wp_unslash( (string) $post_data['date_naissance'] ) ) : '';
-        if ( '' === $date_naissance || '0000-00-00' === $date_naissance || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date_naissance ) ) {
+        if ( ! self::is_valid_birth_date( $date_naissance ) ) {
             $errors[] = __( 'Date de naissance invalide (YYYY-MM-DD requis)', 'ufsc-clubs' );
         } else {
             $data['date_naissance'] = $date_naissance;
@@ -1182,7 +1182,6 @@ class UFSC_Unified_Handlers {
             'adresse' => 'sanitize_textarea_field',
             'ville' => 'sanitize_text_field',
             'code_postal' => 'sanitize_text_field',
-            'date_naissance' => 'sanitize_text_field',
             'sexe' => 'sanitize_text_field',
             'role' => 'sanitize_text_field',
             'competition' => 'absint',
@@ -1256,6 +1255,18 @@ class UFSC_Unified_Handlers {
         $data = self::normalize_licence_date_fields( $data );
 
         return $data;
+    }
+
+    /**
+     * Validate licence birth date (strict YYYY-MM-DD + valid calendar day).
+     */
+    private static function is_valid_birth_date( $date ) {
+        if ( '' === $date || '0000-00-00' === $date || ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+            return false;
+        }
+
+        $date_obj = DateTime::createFromFormat( 'Y-m-d', $date );
+        return $date_obj instanceof DateTime && $date_obj->format( 'Y-m-d' ) === $date;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Empêcher le retour de l'erreur SQL «Incorrect DATE value: ''» en durcissant la validation côté écriture sans refondre la logique de lecture/statistiques existante.
- Préserver la stabilité du dashboard et des rapports en ne modifiant pas la requête `get_age_distribution()` déjà stabilisée.
- Appliquer une validation prudente sur les chemins d'enregistrement/API pour rejeter les pseudo-dates (ex. `2024-02-31`) tout en évitant toute régression des imports ou formulaires.

### Description
- Remplacé les vérifications regex simples par une validation stricte utilisant `DateTime::createFromFormat('Y-m-d', ...)` exposée via la méthode privée `is_valid_birth_date()` dans `includes/core/class-unified-handlers.php` et `includes/api/class-rest-api.php`.
- Remplacé les contrôles de `date_naissance` dans `process_licence_data()` et dans les endpoints REST de création/mise à jour de licence par des appels à `is_valid_birth_date()` pour garantir un jour/calendrier réel en format `YYYY-MM-DD`.
- Retiré `date_naissance` de la table `optional_fields` dans `process_licence_data()` pour éviter qu'une re-sanitisation écrase la valeur déjà validée.
- Aucune modification du SQL de `get_age_distribution()` ni des flux d'import/export/lecture, uniquement durcissement ciblé des chemins d'écriture.

### Testing
- Syntax check passé pour les fichiers modifiés avec `php -l includes/core/class-unified-handlers.php` et `php -l includes/api/class-rest-api.php` (success).
- Inspection des changements avec `git diff -- includes/core/class-unified-handlers.php includes/api/class-rest-api.php` et état du dépôt avec `git status --short` pour valider les fichiers modifiés (success).
- Aucun test unitaire automatisé supplémentaire disponible dans ce patch; opérations manuelles à exécuter post-merge listées dans la checklist du ticket (dashboard, création/modification via admin/front/API, import CSV).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7d31bbcb8832ba25750e25985b7fd)