### PR TITLE
Premium redesign: Club dashboard and profile UI, KPIs, attestation and layout refactor

### DIFF
--- a/assets/css/ufsc-front.css
+++ b/assets/css/ufsc-front.css
@@ -562,3 +562,690 @@ button#upload_btn {
     padding: 5px 15px !important;
     margin: 28px 0 !important;
 }
+
+/* ===== Premium redesign: club dashboard + compte club ===== */
+.ufsc-club-dashboard,
+.ufsc-club-profile {
+    max-width: 1360px;
+    margin: 0 auto;
+    padding: clamp(16px, 2vw, 32px);
+    color: #0f172a;
+}
+
+.ufsc-dashboard-shell,
+.ufsc-club-profile-shell {
+    display: grid;
+    gap: 24px;
+}
+
+.ufsc-dashboard-header--premium,
+.ufsc-profile-header {
+    background: linear-gradient(145deg, #0f3a64 0%, #1f5f94 45%, #2d7ec0 100%);
+    color: #fff;
+    padding: clamp(20px, 3vw, 34px);
+    border-radius: 18px;
+    box-shadow: 0 20px 35px rgba(15, 58, 100, 0.22);
+}
+
+.ufsc-dashboard-header--premium .ufsc-dashboard-subtitle,
+.ufsc-profile-header .ufsc-dashboard-subtitle {
+    color: rgba(255, 255, 255, 0.92);
+    margin-top: 8px;
+}
+
+.ufsc-dashboard-status-line {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-top: 12px;
+    align-items: center;
+}
+
+.ufsc-dashboard-kpi-band {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.ufsc-kpi-tile {
+    border-radius: 16px;
+    border: 1px solid #dbe4ef;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+    padding: 18px;
+}
+
+.ufsc-kpi-tile-label {
+    display: block;
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #475569;
+    margin-bottom: 10px;
+}
+
+.ufsc-kpi-tile-value {
+    font-size: clamp(1.35rem, 2vw, 2rem);
+    line-height: 1;
+}
+
+.ufsc-dashboard-nav {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    background: #fff;
+    padding: 12px;
+    border-radius: 14px;
+    border: 1px solid #dbe4ef;
+}
+
+.ufsc-nav-btn {
+    border: 1px solid #c7d7ea;
+    border-radius: 999px;
+    padding: 9px 14px;
+    background: #f8fbff;
+    font-weight: 600;
+}
+
+.ufsc-nav-btn.active {
+    background: #2271b1;
+    color: #fff;
+    border-color: #2271b1;
+}
+
+.ufsc-dashboard-content > .ufsc-dashboard-section {
+    background: #fff;
+    border: 1px solid #dbe4ef;
+    border-radius: 18px;
+    padding: clamp(14px, 2vw, 22px);
+}
+
+.ufsc-club-hero {
+    display: grid;
+    grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+    gap: 24px;
+    border-radius: 18px;
+    border: 1px solid #d9e3ee;
+    box-shadow: 0 14px 28px rgba(15, 23, 42, 0.08);
+}
+
+.ufsc-club-hero-media img.photo-club-front {
+    width: 100%;
+    max-width: none;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    border-radius: 12px;
+}
+
+.ufsc-hero-media-actions {
+    display: grid;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.ufsc-club-hero-content h4 {
+    font-size: clamp(1.35rem, 2.2vw, 1.95rem);
+    margin: 0 0 6px;
+}
+
+.ufsc-club-profile-layout {
+    gap: 20px;
+}
+
+.ufsc-profile-cards .ufsc-card {
+    border-radius: 14px;
+    border: 1px solid #dbe4ef;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.07);
+}
+
+.ufsc-board-columns {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.ufsc-board-role-card {
+    border-radius: 12px;
+    border: 1px solid #d3dfec;
+    background: #f8fbff;
+}
+
+.ufsc-form-actions {
+    position: sticky;
+    bottom: 14px;
+    display: flex;
+    justify-content: flex-end;
+    background: #ffffffde;
+    backdrop-filter: blur(8px);
+    border: 1px solid #dbe4ef;
+    border-radius: 12px;
+    padding: 12px;
+    margin-top: 18px;
+}
+
+.ufsc-club-profile-documents .ufsc-documents-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.ufsc-document-card {
+    border: 1px solid #d7e2ee;
+    border-radius: 14px;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+}
+
+.ufsc-document-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.ufsc-document-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+@media (max-width: 1180px) {
+    .ufsc-dashboard-kpi-band,
+    .ufsc-board-columns {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 900px) {
+    .ufsc-club-hero,
+    .ufsc-club-profile-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 680px) {
+    .ufsc-dashboard-kpi-band,
+    .ufsc-club-profile-documents .ufsc-documents-grid,
+    .ufsc-board-columns {
+        grid-template-columns: 1fr;
+    }
+
+    .ufsc-form-actions {
+        position: static;
+    }
+}
+
+/* ===== Premium redesign pass 2 (ambitious cockpit/extranet look) ===== */
+.ufsc-club-dashboard,
+.ufsc-club-profile {
+    max-width: min(1680px, 96vw);
+    padding-inline: clamp(14px, 3vw, 40px);
+}
+
+.ufsc-dashboard-shell,
+.ufsc-club-profile-shell {
+    gap: clamp(20px, 2.2vw, 34px);
+}
+
+.ufsc-dashboard-header--premium,
+.ufsc-profile-header {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 24px;
+    box-shadow: 0 26px 46px rgba(9, 30, 52, 0.33);
+}
+
+.ufsc-dashboard-header--premium::before,
+.ufsc-profile-header::before {
+    content: "";
+    position: absolute;
+    inset: auto -60px -90px auto;
+    width: 280px;
+    height: 280px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0));
+    pointer-events: none;
+}
+
+.ufsc-dashboard-header--premium h2,
+.ufsc-profile-header h3 {
+    font-size: clamp(1.6rem, 3.1vw, 2.5rem);
+    line-height: 1.15;
+    margin: 0;
+}
+
+.ufsc-dashboard-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.ufsc-dashboard-actions .ufsc-btn {
+    min-height: 44px;
+    border: 1px solid rgba(255, 255, 255, 0.26);
+    box-shadow: 0 8px 16px rgba(7, 23, 39, 0.22);
+}
+
+.ufsc-dashboard-kpi-band {
+    grid-template-columns: repeat(4, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.ufsc-kpi-tile {
+    border-radius: 20px;
+    padding: 22px;
+    background: linear-gradient(180deg, #fff 0%, #f8fbff 100%);
+}
+
+.ufsc-kpi-tile-value {
+    font-size: clamp(1.7rem, 2.6vw, 2.4rem);
+    font-weight: 800;
+}
+
+.ufsc-cockpit-priority .ufsc-priority-card {
+    border-radius: 18px;
+    border-left: 6px solid #2271b1;
+    background: linear-gradient(180deg, #fff, #f7fbff);
+}
+
+.ufsc-priority-title {
+    margin: 0 0 8px;
+    font-size: 1.05rem;
+    font-weight: 700;
+}
+
+.ufsc-priority-list {
+    margin: 0;
+    padding-left: 18px;
+    display: grid;
+    gap: 6px;
+}
+
+.ufsc-dashboard-nav {
+    padding: 14px;
+    border-radius: 16px;
+    box-shadow: 0 12px 25px rgba(15, 23, 42, 0.07);
+}
+
+.ufsc-nav-btn {
+    font-size: 0.94rem;
+    min-height: 42px;
+}
+
+.ufsc-dashboard-content > .ufsc-dashboard-section {
+    border-radius: 22px;
+    box-shadow: 0 20px 36px rgba(15, 23, 42, 0.08);
+}
+
+.ufsc-club-hero {
+    border-radius: 22px;
+    padding: clamp(18px, 2vw, 26px);
+    background: linear-gradient(128deg, #ffffff 0%, #f6fbff 56%, #eef6ff 100%);
+    border: 1px solid #d0dff0;
+    box-shadow: 0 18px 34px rgba(15, 23, 42, 0.11);
+}
+
+.ufsc-club-hero-content .div-attestation {
+    margin-top: 14px;
+    padding: 14px;
+    border-radius: 12px;
+    background: #ffffff;
+    border: 1px solid #dbe6f2;
+}
+
+.ufsc-profile-insight-band {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(180px, 1fr));
+    gap: 14px;
+}
+
+.ufsc-profile-insight {
+    border-radius: 14px;
+    border: 1px solid #d6e2ef;
+    background: #fff;
+    padding: 14px 16px;
+    display: grid;
+    gap: 8px;
+}
+
+.ufsc-profile-insight > span {
+    font-size: 0.76rem;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: #5f7084;
+}
+
+.ufsc-profile-insight > strong {
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.ufsc-club-profile .ufsc-card h4 {
+    font-size: 1.2rem;
+    margin-bottom: 16px;
+}
+
+.ufsc-profile-cards .ufsc-card,
+.ufsc-club-profile-documents .ufsc-card {
+    border-radius: 18px;
+    background: #fff;
+}
+
+.ufsc-board-role-card h5 {
+    margin-bottom: 12px;
+    font-size: 1rem;
+}
+
+.ufsc-document-card {
+    background: linear-gradient(180deg, #fff, #fbfdff);
+}
+
+.ufsc-document-card .ufsc-upload-label {
+    display: inline-block;
+    margin-top: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: #edf5ff;
+    border: 1px solid #c8dcf5;
+}
+
+.ufsc-form-actions {
+    border-radius: 16px;
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.09);
+}
+
+@media (max-width: 1200px) {
+    .ufsc-profile-insight-band,
+    .ufsc-dashboard-kpi-band {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 720px) {
+    .ufsc-profile-insight-band,
+    .ufsc-dashboard-kpi-band {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* ===== V3 refinement for production premium pass ===== */
+.ufsc-premium-v3 .ufsc-dashboard-header--premium {
+    display: block !important;
+}
+
+.ufsc-premium-v3 .ufsc-dashboard-hero-layout {
+    display: grid !important;
+    grid-template-columns: minmax(340px, 380px) minmax(0, 1fr);
+    gap: 22px;
+    align-items: start;
+    width: 100%;
+}
+
+.ufsc-premium-v3 .ufsc-hero-left {
+    display: grid;
+    gap: 14px;
+}
+
+.ufsc-premium-v3 .ufsc-hero-right {
+    display: grid !important;
+    align-content: start;
+    min-width: 0;
+}
+
+.ufsc-premium-v3 .ufsc-dashboard-hero-side {
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(8, 25, 42, 0.26);
+    padding: 12px;
+    display: grid;
+    gap: 10px;
+    justify-items: center;
+}
+
+.ufsc-premium-v3 .ufsc-dashboard-hero-side img {
+    width: 100%;
+    max-width: 280px;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    border-radius: 12px;
+    box-shadow: 0 10px 24px rgba(5, 18, 30, 0.4);
+}
+
+.ufsc-premium-v3 .ufsc-dashboard-mainpane {
+    display: grid;
+    gap: 18px;
+}
+
+.ufsc-premium-v3 .ufsc-hero-kpi-grid {
+    display: grid !important;
+    gap: 12px;
+    grid-template-columns: repeat(3, minmax(170px, 1fr));
+    margin-top: 0;
+    width: 100%;
+}
+
+.ufsc-premium-v3 .ufsc-hero-kpi-grid .ufsc-kpi-tile {
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.14) !important;
+    border: 1px solid rgba(255, 255, 255, 0.24);
+    box-shadow: none;
+    backdrop-filter: blur(2px);
+    min-height: 112px;
+}
+
+.ufsc-premium-v3 .ufsc-hero-kpi-card {
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    align-content: start;
+    gap: 8px;
+    padding: 14px 16px;
+    overflow: visible;
+}
+
+.ufsc-premium-v3 .ufsc-hero-kpi-card.-neutral {
+    border-left: 4px solid rgba(255, 255, 255, 0.55);
+}
+
+.ufsc-premium-v3 .ufsc-hero-kpi-card.-success {
+    border-left: 4px solid #86efac;
+    background: linear-gradient(180deg, rgba(16,185,129,.35), rgba(255,255,255,.12)) !important;
+}
+
+.ufsc-premium-v3 .ufsc-hero-kpi-card.-warning {
+    border-left: 4px solid #fbbf24;
+    background: linear-gradient(180deg, rgba(234,179,8,.34), rgba(255,255,255,.12)) !important;
+}
+
+.ufsc-premium-v3 .ufsc-priority-tile {
+    min-height: 128px;
+}
+
+.ufsc-premium-v3 .ufsc-priority-detail {
+    display: block;
+    margin-top: 8px;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: .84rem;
+}
+
+.ufsc-premium-v3 .ufsc-hero-kpi-grid .ufsc-kpi-tile-label {
+    color: rgba(255,255,255,.82);
+}
+
+.ufsc-premium-v3 .ufsc-hero-kpi-grid .ufsc-kpi-tile-value {
+    color: #fff;
+    font-size: clamp(1.55rem, 2vw, 2rem);
+    line-height: 1.1;
+}
+
+.ufsc-premium-v3 .ufsc-dashboard-mainpane .ufsc-dashboard-section {
+    background: #fff;
+}
+
+.ufsc-premium-v3 .ufsc-club-profile-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(320px, 0.8fr);
+}
+
+.ufsc-premium-v3 .ufsc-club-profile-main {
+    gap: 18px;
+    grid-column: 1 / span 2;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.ufsc-premium-v3 .ufsc-club-profile-documents {
+    grid-column: 3;
+}
+
+.ufsc-premium-v3 .ufsc-club-profile-documents .ufsc-card {
+    background: linear-gradient(180deg, #ffffff, #f6faff);
+}
+
+.ufsc-premium-v3 .ufsc-board-role-card {
+    background: linear-gradient(180deg, #f9fcff, #edf5ff);
+    border-color: #c8dced;
+}
+
+.ufsc-premium-v3 .ufsc-board-role-card--coach {
+    margin-top: 14px;
+}
+
+.ufsc-premium-v3 .ufsc-form-actions {
+    padding: 14px;
+    border: 1px solid #cfe0f0;
+    background: linear-gradient(180deg, rgba(255,255,255,0.95), rgba(247,251,255,0.95));
+}
+
+.ufsc-premium-v3 .ufsc-field input,
+.ufsc-premium-v3 .ufsc-field select,
+.ufsc-premium-v3 .ufsc-field textarea {
+    border-color: #c5d5e6;
+    border-radius: 10px;
+    min-height: 44px;
+    background: #fdfefe;
+}
+
+.ufsc-premium-v3 .ufsc-field label {
+    font-size: .86rem;
+    color: #2b425a;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+}
+
+@media (max-width: 1180px) {
+    .ufsc-premium-v3 .ufsc-dashboard-hero-layout,
+    .ufsc-premium-v3 .ufsc-club-profile-layout {
+        grid-template-columns: 1fr;
+    }
+    .ufsc-premium-v3 .ufsc-hero-kpi-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .ufsc-premium-v3 .ufsc-club-profile-main,
+    .ufsc-premium-v3 .ufsc-club-profile-documents {
+        grid-column: auto;
+    }
+}
+
+@media (max-width: 680px) {
+    .ufsc-premium-v3 .ufsc-hero-kpi-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* ===== Stabilisation UI (corrections ciblées) ===== */
+.ufsc-premium-v3 .ufsc-dashboard-header--premium::before,
+.ufsc-premium-v3 .ufsc-profile-header::before {
+    width: 190px;
+    height: 190px;
+    opacity: .32;
+}
+
+.ufsc-premium-v3 .ufsc-profile-header .ufsc-permission-notice {
+    max-width: 360px;
+    font-size: .9rem;
+    line-height: 1.35;
+    background: rgba(255,255,255,.14);
+    border: 1px solid rgba(255,255,255,.25);
+    border-radius: 10px;
+    padding: 8px 10px;
+}
+
+.ufsc-premium-v3 .ufsc-profile-insight {
+    padding: 16px 18px;
+    gap: 10px;
+}
+
+.ufsc-premium-v3 .ufsc-club-profile-layout {
+    grid-template-columns: 1fr;
+    max-width: 1320px;
+    margin: 0 auto;
+}
+
+.ufsc-premium-v3 .ufsc-section-board {
+    grid-column: 1 / -1;
+}
+
+.ufsc-premium-v3 .ufsc-club-profile-main {
+    grid-template-columns: repeat(2, minmax(320px, 1fr));
+    gap: 16px;
+}
+
+.ufsc-premium-v3 .ufsc-section-board .ufsc-board-columns {
+    grid-template-columns: repeat(3, minmax(240px, 1fr));
+    gap: 12px;
+}
+
+.ufsc-premium-v3 .ufsc-section-board .ufsc-board-role-card h5 {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ufsc-premium-v3 .ufsc-section-board .ufsc-field input,
+.ufsc-premium-v3 .ufsc-section-board .ufsc-field select,
+.ufsc-premium-v3 .ufsc-section-board .ufsc-field textarea {
+    min-height: 42px;
+}
+
+.ufsc-premium-v3 .ufsc-club-profile-documents .ufsc-documents-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.ufsc-premium-v3 .ufsc-document-name {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.3;
+}
+
+.ufsc-premium-v3 .ufsc-document-card {
+    min-height: 0;
+}
+
+.ufsc-premium-v3 .ufsc-document-card .ufsc-upload-label {
+    background: #1f5f94;
+    border-color: #1f5f94;
+    color: #fff;
+    font-weight: 600;
+}
+
+.ufsc-premium-v3 .ufsc-document-card .ufsc-upload-label:hover {
+    background: #174a72;
+    border-color: #174a72;
+}
+
+@media (max-width: 1380px) {
+    .ufsc-premium-v3 .ufsc-club-profile-main {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .ufsc-premium-v3 .ufsc-section-board .ufsc-board-columns {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 1024px) {
+    .ufsc-premium-v3 .ufsc-club-profile-layout {
+        grid-template-columns: 1fr;
+    }
+    .ufsc-premium-v3 .ufsc-club-profile-main,
+    .ufsc-premium-v3 .ufsc-club-profile-documents .ufsc-documents-grid {
+        grid-template-columns: 1fr;
+    }
+    .ufsc-premium-v3 .ufsc-section-board .ufsc-board-columns {
+        grid-template-columns: 1fr;
+    }
+}

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -122,82 +122,161 @@ class UFSC_Frontend_Shortcodes {
             )
         );
 
-        $sections = explode( ',', $atts['show_sections'] );
+        $sections        = explode( ',', $atts['show_sections'] );
+        $club            = self::get_club_data( $club_id );
+        $club_status     = isset( $club->statut ) ? $club->statut : '';
+        $bureau_data     = self::get_bureau_coverage_data( (int) $club_id );
+        $missing_roles   = ! empty( $bureau_data['missing_labels'] ) ? count( $bureau_data['missing_labels'] ) : 0;
+        $mandatory_docs  = array( 'doc_statuts', 'doc_recepisse', 'doc_jo', 'doc_pv_ag', 'doc_cer', 'doc_attestation_cer' );
+        $missing_docs    = 0;
+        $attestation_dashboard = function_exists( 'ufsc_get_affiliation_attestation_data' )
+            ? ufsc_get_affiliation_attestation_data( $club_id, $club )
+            : array( 'url' => '', 'status' => 'pending', 'can_view' => false );
+        foreach ( $mandatory_docs as $doc_key ) {
+            if ( empty( $club->$doc_key ) || ! wp_get_attachment_url( $club->$doc_key ) ) {
+                $missing_docs++;
+            }
+        }
 
         ob_start();
         ?>
-        <div class="ufsc-club-dashboard" id="ufsc-dashboard">
-            <div class="ufsc-dashboard-header">
-                <div class="ufsc-dashboard-brand">
-                    <img class="ufsc-dashboard-logo" src="<?php echo esc_url( UFSC_CL_URL . 'assets/svg/ufsc-badge.svg' ); ?>" alt="<?php esc_attr_e( 'UFSC', 'ufsc-clubs' ); ?>">
-                    <div class="ufsc-dashboard-title">
-                        <h2><?php esc_html_e( 'Tableau de bord - Mon Club', 'ufsc-clubs' ); ?></h2>
-                        <p class="ufsc-dashboard-subtitle">
-                            <?php
-                            $club_name = self::get_club_name( $club_id );
-                            if ( $club_name ) {
-                                echo sprintf( esc_html__( 'Club: %s', 'ufsc-clubs' ), esc_html( $club_name ) );
-                            }
-                            ?>
-                        </p>
+        <div class="ufsc-club-dashboard ufsc-premium-v3" id="ufsc-dashboard">
+            <div class="ufsc-dashboard-shell">
+                <div class="ufsc-dashboard-header ufsc-dashboard-header--premium">
+                    <div class="ufsc-dashboard-hero-layout">
+                    <div class="ufsc-hero-left">
+                        <div class="ufsc-dashboard-brand">
+                            <img class="ufsc-dashboard-logo" src="<?php echo esc_url( UFSC_CL_URL . 'assets/svg/ufsc-badge.svg' ); ?>" alt="<?php esc_attr_e( 'UFSC', 'ufsc-clubs' ); ?>">
+                            <div class="ufsc-dashboard-title">
+                                <h2><?php esc_html_e( 'Tableau de bord Club', 'ufsc-clubs' ); ?></h2>
+                                <p class="ufsc-dashboard-subtitle">
+                                    <?php
+                                    $club_name = self::get_club_name( $club_id );
+                                    if ( $club_name ) {
+                                        echo sprintf( esc_html__( 'Pilotage de %s', 'ufsc-clubs' ), esc_html( $club_name ) );
+                                    }
+                                    ?>
+                                </p>
+                                <div class="ufsc-dashboard-status-line">
+                                    <span class="ufsc-badge ufsc-badge-info"><?php esc_html_e( 'État du club', 'ufsc-clubs' ); ?></span>
+                                    <?php echo self::get_status_badge_front( $club_status ); ?>
+                                    <?php if ( ! empty( $club->num_affiliation ) ) : ?>
+                                        <span class="ufsc-badge ufsc-badge-region"><?php echo esc_html( sprintf( __( 'Affiliation %s', 'ufsc-clubs' ), $club->num_affiliation ) ); ?></span>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="ufsc-dashboard-actions">
+                            <?php if ( in_array( 'add_licence', $sections, true ) ): ?>
+                                <a href="#ufsc-section-add_licence" class="ufsc-btn ufsc-btn-primary" onclick="document.querySelector('[data-section=&quot;add_licence&quot;]').click(); return false;">
+                                    <?php esc_html_e( 'Ajouter une licence', 'ufsc-clubs' ); ?>
+                                </a>
+                            <?php endif; ?>
+                            <?php if ( in_array( 'profile', $sections, true ) ): ?>
+                                <a href="#ufsc-section-profile" class="ufsc-btn ufsc-btn-secondary" onclick="document.querySelector('[data-section=&quot;profile&quot;]').click(); return false;">
+                                    <?php esc_html_e( 'Mettre à jour le club', 'ufsc-clubs' ); ?>
+                                </a>
+                            <?php endif; ?>
+                        </div>
+                        <?php if ( ! empty( $club->profile_photo_url ) || ! empty( $attestation_dashboard['can_view'] ) ) : ?>
+                            <div class="ufsc-dashboard-hero-side">
+                                <?php if ( ! empty( $club->profile_photo_url ) ) : ?>
+                                    <img src="<?php echo esc_url( $club->profile_photo_url ); ?>" alt="<?php esc_attr_e( 'Photo du club', 'ufsc-clubs' ); ?>" />
+                                <?php endif; ?>
+                                <div class="ufsc-dashboard-hero-side-meta">
+                                    <?php if ( ! empty( $attestation_dashboard['can_view'] ) ) : ?>
+                                        <?php if ( ! empty( $attestation_dashboard['url'] ) ) : ?>
+                                            <a href="<?php echo esc_url( $attestation_dashboard['url'] ); ?>" target="_blank" rel="noopener" class="ufsc-btn ufsc-btn-secondary">
+                                                <?php esc_html_e( 'Attestation UFSC', 'ufsc-clubs' ); ?>
+                                            </a>
+                                        <?php else : ?>
+                                            <span class="ufsc-badge ufsc-badge-warning"><?php esc_html_e( 'Attestation en cours', 'ufsc-clubs' ); ?></span>
+                                        <?php endif; ?>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+
+                    <div class="ufsc-hero-right">
+                    <div class="ufsc-hero-kpi-grid" aria-label="<?php esc_attr_e( 'Indicateurs de pilotage club', 'ufsc-clubs' ); ?>">
+                        <div class="ufsc-card ufsc-kpi-tile ufsc-hero-kpi-card -neutral">
+                            <span class="ufsc-kpi-tile-label">📋 <?php esc_html_e( 'Licences', 'ufsc-clubs' ); ?></span>
+                            <strong class="ufsc-kpi-tile-value"><?php echo esc_html( (int) $stats['total_licences'] ); ?></strong>
+                        </div>
+                        <div class="ufsc-card ufsc-kpi-tile ufsc-hero-kpi-card -success">
+                            <span class="ufsc-kpi-tile-label">✅ <?php esc_html_e( 'Validées', 'ufsc-clubs' ); ?></span>
+                            <strong class="ufsc-kpi-tile-value"><?php echo esc_html( (int) $stats['validated_licences'] ); ?></strong>
+                        </div>
+                        <div class="ufsc-card ufsc-kpi-tile ufsc-hero-kpi-card -warning">
+                            <span class="ufsc-kpi-tile-label">👥 <?php esc_html_e( 'Bureau à compléter', 'ufsc-clubs' ); ?></span>
+                            <strong class="ufsc-kpi-tile-value"><?php echo esc_html( (int) $missing_roles ); ?></strong>
+                        </div>
+                        <div class="ufsc-card ufsc-kpi-tile ufsc-hero-kpi-card -warning">
+                            <span class="ufsc-kpi-tile-label">📄 <?php esc_html_e( 'Documents manquants', 'ufsc-clubs' ); ?></span>
+                            <strong class="ufsc-kpi-tile-value"><?php echo esc_html( (int) $missing_docs ); ?></strong>
+                        </div>
+                        <div class="ufsc-card ufsc-kpi-tile ufsc-hero-kpi-card ufsc-priority-tile -warning">
+                            <span class="ufsc-kpi-tile-label">⚠️ <?php esc_html_e( 'Priorité', 'ufsc-clubs' ); ?></span>
+                            <strong class="ufsc-kpi-tile-value"><?php echo esc_html( (int) $missing_docs ); ?></strong>
+                            <span class="ufsc-priority-detail"><?php esc_html_e( 'Document(s) à compléter', 'ufsc-clubs' ); ?></span>
+                        </div>
+                        <div class="ufsc-card ufsc-kpi-tile ufsc-hero-kpi-card ufsc-priority-tile -warning">
+                            <span class="ufsc-kpi-tile-label">🧩 <?php esc_html_e( 'Bureau', 'ufsc-clubs' ); ?></span>
+                            <strong class="ufsc-kpi-tile-value"><?php echo esc_html( (int) $missing_roles ); ?></strong>
+                            <span class="ufsc-priority-detail"><?php esc_html_e( 'Rôle(s) manquant(s)', 'ufsc-clubs' ); ?></span>
+                        </div>
+                        <div class="ufsc-card ufsc-kpi-tile ufsc-hero-kpi-card ufsc-priority-tile <?php echo ! empty( $attestation_dashboard['url'] ) ? '-success' : '-neutral'; ?>">
+                            <span class="ufsc-kpi-tile-label">🏅 <?php esc_html_e( 'Attestation UFSC', 'ufsc-clubs' ); ?></span>
+                            <strong class="ufsc-kpi-tile-value"><?php echo ! empty( $attestation_dashboard['url'] ) ? '✓' : '…'; ?></strong>
+                            <span class="ufsc-priority-detail"><?php echo ! empty( $attestation_dashboard['url'] ) ? esc_html__( 'Disponible', 'ufsc-clubs' ) : esc_html__( 'En préparation', 'ufsc-clubs' ); ?></span>
+                        </div>
+                    </div>
+                    </div>
                     </div>
                 </div>
-                <?php if ( in_array( 'add_licence', $sections ) ): ?>
-                    <div class="ufsc-dashboard-actions">
-                        <a href="#ufsc-section-add_licence" class="ufsc-btn ufsc-btn-primary" onclick="document.querySelector('[data-section=&quot;add_licence&quot;]').click(); return false;">
-                            <?php esc_html_e( 'Ajouter une licence', 'ufsc-clubs' ); ?>
-                        </a>
-                    </div>
-                <?php endif; ?>
-            </div>
 
-            <div class="ufsc-dashboard-nav">
-                <?php if ( in_array( 'licences', $sections ) ): ?>
-                    <button class="ufsc-nav-btn active" data-section="licences">
-                        <?php esc_html_e( 'Mes Licences', 'ufsc-clubs' ); ?>
-                    </button>
-                <?php endif; ?>
-                <?php if ( in_array( 'stats', $sections ) ): ?>
-                    <button class="ufsc-nav-btn" data-section="stats">
-                        <?php esc_html_e( 'Statistiques', 'ufsc-clubs' ); ?>
-                    </button>
-                <?php endif; ?>
-                <?php if ( in_array( 'profile', $sections ) ): ?>
-                    <button class="ufsc-nav-btn" data-section="profile">
-                        <?php esc_html_e( 'Mon Club', 'ufsc-clubs' ); ?>
-                    </button>
-                <?php endif; ?>
-                <?php if ( in_array( 'add_licence', $sections ) ): ?>
-                    <button class="ufsc-nav-btn" data-section="add_licence">
-                        <?php esc_html_e( 'Ajouter une Licence', 'ufsc-clubs' ); ?>
-                    </button>
-                <?php endif; ?>
-            </div>
-
-            <div class="ufsc-dashboard-content">
-                <?php if ( in_array( 'licences', $sections ) ): ?>
-                    <div id="ufsc-section-licences" class="ufsc-dashboard-section active">
-                        <?php echo self::render_club_licences( array( 'club_id' => $club_id ) ); ?>
+                <div class="ufsc-dashboard-mainpane">
+                    <div class="ufsc-dashboard-nav">
+                        <?php if ( in_array( 'licences', $sections ) ): ?>
+                            <button class="ufsc-nav-btn active" data-section="licences"><?php esc_html_e( 'Mes Licences', 'ufsc-clubs' ); ?></button>
+                        <?php endif; ?>
+                        <?php if ( in_array( 'stats', $sections ) ): ?>
+                            <button class="ufsc-nav-btn" data-section="stats"><?php esc_html_e( 'Statistiques', 'ufsc-clubs' ); ?></button>
+                        <?php endif; ?>
+                        <?php if ( in_array( 'profile', $sections ) ): ?>
+                            <button class="ufsc-nav-btn" data-section="profile"><?php esc_html_e( 'Mon Club', 'ufsc-clubs' ); ?></button>
+                        <?php endif; ?>
+                        <?php if ( in_array( 'add_licence', $sections ) ): ?>
+                            <button class="ufsc-nav-btn" data-section="add_licence"><?php esc_html_e( 'Ajouter une Licence', 'ufsc-clubs' ); ?></button>
+                        <?php endif; ?>
                     </div>
-                <?php endif; ?>
+                    <div class="ufsc-dashboard-content">
+                        <?php if ( in_array( 'licences', $sections ) ): ?>
+                            <div id="ufsc-section-licences" class="ufsc-dashboard-section active">
+                                <?php echo self::render_club_licences( array( 'club_id' => $club_id ) ); ?>
+                            </div>
+                        <?php endif; ?>
 
-                <?php if ( in_array( 'stats', $sections ) ): ?>
-                    <div id="ufsc-section-stats" class="ufsc-dashboard-section">
-                        <?php echo self::render_club_stats( array( 'club_id' => $club_id ) ); ?>
-                    </div>
-                <?php endif; ?>
+                        <?php if ( in_array( 'stats', $sections ) ): ?>
+                            <div id="ufsc-section-stats" class="ufsc-dashboard-section">
+                                <?php echo self::render_club_stats( array( 'club_id' => $club_id ) ); ?>
+                            </div>
+                        <?php endif; ?>
 
-                <?php if ( in_array( 'profile', $sections ) ): ?>
-                    <div id="ufsc-section-profile" class="ufsc-dashboard-section">
-                        <?php echo self::render_club_profile( array( 'club_id' => $club_id ) ); ?>
-                    </div>
-                <?php endif; ?>
+                        <?php if ( in_array( 'profile', $sections ) ): ?>
+                            <div id="ufsc-section-profile" class="ufsc-dashboard-section">
+                                <?php echo self::render_club_profile( array( 'club_id' => $club_id ) ); ?>
+                            </div>
+                        <?php endif; ?>
 
-                <?php if ( in_array( 'add_licence', $sections ) ): ?>
-                    <div id="ufsc-section-add_licence" class="ufsc-dashboard-section">
-                        <?php echo self::render_add_licence( array( 'club_id' => $club_id ) ); ?>
+                        <?php if ( in_array( 'add_licence', $sections ) ): ?>
+                            <div id="ufsc-section-add_licence" class="ufsc-dashboard-section">
+                                <?php echo self::render_add_licence( array( 'club_id' => $club_id ) ); ?>
+                            </div>
+                        <?php endif; ?>
                     </div>
-                <?php endif; ?>
+                </div>
             </div>
         </div>
 
@@ -208,7 +287,7 @@ class UFSC_Frontend_Shortcodes {
 
                 // Update nav
                 $('.ufsc-nav-btn').removeClass('active');
-                $(this).addClass('active');
+                $('.ufsc-nav-btn[data-section="' + section + '"]').addClass('active');
 
                 // Show section
                 $('.ufsc-dashboard-section').removeClass('active');
@@ -927,76 +1006,120 @@ class UFSC_Frontend_Shortcodes {
         $regions = UFSC_CL_Utils::regions();
         ?>
 
-        <div class="ufsc-club-profile">
-            <!-- // UFSC: Enhanced club profile with sections and cards -->
-            <div class="ufsc-section-header">
-                <h3><?php esc_html_e( 'Profil du Club', 'ufsc-clubs' ); ?></h3>
-                <?php if ( ! $is_admin ): ?>
-                    <p class="ufsc-permission-notice">
-                        <?php esc_html_e( 'Seuls l\'email et le téléphone peuvent être modifiés', 'ufsc-clubs' ); ?>
-                    </p>
-                <?php endif; ?>
-            </div>
-            <?php if ( ! empty( $club->profile_photo_url ) ) : ?>
-
-                <div class="ufsc-club-photo">
-                    <img src="<?php echo esc_url( $club->profile_photo_url ); ?>" alt="<?php esc_attr_e( 'Photo du club', 'ufsc-clubs' ); ?>"  class="photo-club-front"/>
-                    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-remove-photo-form">
-                        <?php wp_nonce_field( 'ufsc_remove_profile_photo', 'ufsc_remove_profile_photo_nonce' ); ?>
-                        <input type="hidden" name="action" value="ufsc_remove_profile_photo" />
-                        <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
-                        <button type="submit" class="button ufsc-remove-photo"><?php esc_html_e( 'Supprimer la photo', 'ufsc-clubs' ); ?></button>
-                    </form>
-                    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-change-photo-form">
-                        <?php wp_nonce_field( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' ); ?>
-                        <input type="hidden" name="action" value="ufsc_upload_profile_photo" />
-                        <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
-                        <input type="file" name="profile_photo" accept="image/jpeg,image/png,image/webp" required />
-                        <button type="submit" id="upload_btn" class="buytton ufsc-upload-photo"><?php esc_html_e( 'Changer la photo', 'ufsc-clubs' ); ?></button>
-                    </form>
+        <div class="ufsc-club-profile ufsc-premium-v3">
+            <div class="ufsc-club-profile-shell">
+                <div class="ufsc-section-header ufsc-profile-header">
+                    <div>
+                        <h3><?php esc_html_e( 'Compte Club', 'ufsc-clubs' ); ?></h3>
+                        <p class="ufsc-dashboard-subtitle"><?php esc_html_e( 'Consultez et mettez à jour les informations officielles de votre club.', 'ufsc-clubs' ); ?></p>
+                    </div>
+                    <?php if ( ! $is_admin ): ?>
+                        <p class="ufsc-permission-notice">
+                            <?php esc_html_e( 'Seuls l\'email et le téléphone peuvent être modifiés', 'ufsc-clubs' ); ?>
+                        </p>
+                    <?php endif; ?>
                 </div>
-            <?php else : ?>
-                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-upload-photo-form">
-                    <?php wp_nonce_field( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' ); ?>
-                    <input type="hidden" name="action" value="ufsc_upload_profile_photo" />
-                    <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
-                    <input type="file" name="profile_photo" accept="image/jpeg,image/png,image/webp"clas="upload-file-profile" />
-                    <button type="submit" class="button ufsc-upload-photo"><?php esc_html_e( 'Ajouter une photo', 'ufsc-clubs' ); ?></button>
-                </form>
-            <?php endif; ?>
 
+            <?php
+                // UFSC PATCH: Attestation UFSC section (stable + legacy fallback).
+                $attestation = function_exists( 'ufsc_get_affiliation_attestation_data' )
+                    ? ufsc_get_affiliation_attestation_data( $club->id, $club )
+                    : array( 'url' => '', 'status' => 'pending', 'can_view' => false );
+            ?>
+                <div class="ufsc-card ufsc-club-hero">
+                    <div class="ufsc-club-hero-media">
+                        <?php if ( ! empty( $club->profile_photo_url ) ) : ?>
+                            <img src="<?php echo esc_url( $club->profile_photo_url ); ?>" alt="<?php esc_attr_e( 'Photo du club', 'ufsc-clubs' ); ?>" class="photo-club-front"/>
+                            <div class="ufsc-hero-media-actions">
+                                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-remove-photo-form">
+                                    <?php wp_nonce_field( 'ufsc_remove_profile_photo', 'ufsc_remove_profile_photo_nonce' ); ?>
+                                    <input type="hidden" name="action" value="ufsc_remove_profile_photo" />
+                                    <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
+                                    <button type="submit" class="button ufsc-remove-photo"><?php esc_html_e( 'Supprimer la photo', 'ufsc-clubs' ); ?></button>
+                                </form>
+                                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-change-photo-form">
+                                    <?php wp_nonce_field( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' ); ?>
+                                    <input type="hidden" name="action" value="ufsc_upload_profile_photo" />
+                                    <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
+                                    <input type="file" name="profile_photo" accept="image/jpeg,image/png,image/webp" required />
+                                    <button type="submit" id="upload_btn" class="buytton ufsc-upload-photo"><?php esc_html_e( 'Changer la photo', 'ufsc-clubs' ); ?></button>
+                                </form>
+                            </div>
+                        <?php else : ?>
+                            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-upload-photo-form">
+                                <?php wp_nonce_field( 'ufsc_upload_profile_photo', 'ufsc_upload_profile_photo_nonce' ); ?>
+                                <input type="hidden" name="action" value="ufsc_upload_profile_photo" />
+                                <input type="hidden" name="club_id" value="<?php echo esc_attr( $club->id ); ?>" />
+                                <input type="file" name="profile_photo" accept="image/jpeg,image/png,image/webp"clas="upload-file-profile" />
+                                <button type="submit" class="button ufsc-upload-photo"><?php esc_html_e( 'Ajouter une photo', 'ufsc-clubs' ); ?></button>
+                            </form>
+                        <?php endif; ?>
+                    </div>
+                    <div class="ufsc-club-hero-content">
+                        <h4><?php echo esc_html( $club->nom ?? '' ); ?></h4>
+                        <div class="ufsc-dashboard-status-line">
+                            <?php echo self::get_status_badge_front( $club->statut ?? '' ); ?>
+                            <?php if ( ! empty( $club->num_affiliation ) ) : ?>
+                                <span class="ufsc-badge ufsc-badge-region"><?php echo esc_html( sprintf( __( 'Affiliation %s', 'ufsc-clubs' ), $club->num_affiliation ) ); ?></span>
+                            <?php endif; ?>
+                        </div>
+                        <?php if ( $attestation['can_view'] ) : ?>
+                            <div class="div-attestation">
+                                <h3 class="title-attestation club front"><?php esc_html_e( 'Attestation UFSC', 'ufsc-clubs' ); ?></h3>
+                                <?php if ( $attestation['url'] ) : ?>
+                                    <div class="ufsc-current-file">
+                                        <p class="ufsc-document-status"><?php esc_html_e( 'Disponible', 'ufsc-clubs' ); ?></p>
+                                        <div class="ufsc-document-actions">
+                                            <a href="<?php echo esc_url( $attestation['url'] ); ?>" target="_blank" rel="noopener" class="button">
+                                                <?php esc_html_e( 'Voir', 'ufsc-clubs' ); ?>
+                                            </a>
+                                            <a href="<?php echo esc_url( $attestation['url'] ); ?>" download class="button" id="btn-telechrager-attestation">
+                                                <?php esc_html_e( 'Télécharger', 'ufsc-clubs' ); ?>
+                                            </a>
+                                        </div>
+                                    </div>
+                                <?php else : ?>
+                                    <p class="ufsc-document-status"><?php esc_html_e( 'En cours de génération', 'ufsc-clubs' ); ?></p>
+                                <?php endif; ?>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            <?php
+                $profile_bureau = self::get_bureau_coverage_data( (int) $club->id );
+                $profile_missing_roles = ! empty( $profile_bureau['missing_labels'] ) ? count( $profile_bureau['missing_labels'] ) : 0;
+                $profile_docs_fields = array( 'doc_statuts', 'doc_recepisse', 'doc_jo', 'doc_pv_ag', 'doc_cer', 'doc_attestation_cer' );
+                $profile_missing_docs = 0;
+                foreach ( $profile_docs_fields as $profile_doc_key ) {
+                    $profile_doc_value = isset( $club->$profile_doc_key ) ? $club->$profile_doc_key : '';
+                    if ( empty( $profile_doc_value ) || ! wp_get_attachment_url( $profile_doc_value ) ) {
+                        $profile_missing_docs++;
+                    }
+                }
+            ?>
+            <div class="ufsc-profile-insight-band">
+                <div class="ufsc-card ufsc-profile-insight">
+                    <span><?php esc_html_e( 'Statut global', 'ufsc-clubs' ); ?></span>
+                    <?php echo self::get_status_badge_front( $club->statut ?? '' ); ?>
+                </div>
+                <div class="ufsc-card ufsc-profile-insight">
+                    <span><?php esc_html_e( 'Bureau', 'ufsc-clubs' ); ?></span>
+                    <strong><?php echo esc_html( sprintf( __( '%d rôle(s) manquant(s)', 'ufsc-clubs' ), (int) $profile_missing_roles ) ); ?></strong>
+                </div>
+                <div class="ufsc-card ufsc-profile-insight">
+                    <span><?php esc_html_e( 'Documents', 'ufsc-clubs' ); ?></span>
+                    <strong><?php echo esc_html( sprintf( __( '%d document(s) manquant(s)', 'ufsc-clubs' ), (int) $profile_missing_docs ) ); ?></strong>
+                </div>
+                <div class="ufsc-card ufsc-profile-insight">
+                    <span><?php esc_html_e( 'Attestation UFSC', 'ufsc-clubs' ); ?></span>
+                    <strong><?php echo ! empty( $attestation['url'] ) ? esc_html__( 'Disponible', 'ufsc-clubs' ) : esc_html__( 'En attente', 'ufsc-clubs' ); ?></strong>
+                </div>
+            </div>
             <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data" class="ufsc-club-form ufsc-club-profile">
                 <div class="ufsc-notices" aria-live="polite"></div>
                 <input type="hidden" name="action" value="ufsc_save_club">
                 <input type="hidden" name="club_id" value="<?= (int) $club->id ?>" />
                 <?php wp_nonce_field( 'ufsc_save_club', 'ufsc_club_nonce' ); ?>
-
-                <?php
-                    // UFSC PATCH: Attestation UFSC section (stable + legacy fallback).
-                    $attestation = function_exists( 'ufsc_get_affiliation_attestation_data' )
-                        ? ufsc_get_affiliation_attestation_data( $club->id, $club )
-                        : array( 'url' => '', 'status' => 'pending', 'can_view' => false );
-                    if ( $attestation['can_view'] ) :
-                ?>
-                    <div class="div-attestation">
-                        <h3 class="title-attestation club front"><?php esc_html_e( 'Attestation UFSC', 'ufsc-clubs' ); ?></h3>
-                        <?php if ( $attestation['url'] ) : ?>
-                            <div class="ufsc-current-file">
-                                <p class="ufsc-document-status"><?php esc_html_e( 'Disponible', 'ufsc-clubs' ); ?></p>
-                                <div class="ufsc-document-actions">
-                                    <a href="<?php echo esc_url( $attestation['url'] ); ?>" target="_blank" rel="noopener" class="button">
-                                        <?php esc_html_e( 'Voir', 'ufsc-clubs' ); ?>
-                                    </a>
-                                    <a href="<?php echo esc_url( $attestation['url'] ); ?>" download class="button" id="btn-telechrager-attestation">
-                                        <?php esc_html_e( 'Télécharger', 'ufsc-clubs' ); ?>
-                                    </a>
-                                </div>
-                            </div>
-                        <?php else : ?>
-                            <p class="ufsc-document-status"><?php esc_html_e( 'En cours de génération', 'ufsc-clubs' ); ?></p>
-                        <?php endif; ?>
-                    </div>
-                <?php endif; ?>
                 <div class="ufsc-club-profile-layout">
                     <div class="ufsc-club-profile-main ufsc-profile-cards">
                 <div class="ufsc-card ufsc-section">
@@ -1049,7 +1172,7 @@ class UFSC_Frontend_Shortcodes {
                     </div>
                 </div>
 
-                <div class="ufsc-card ufsc-form-section">
+                <div class="ufsc-card ufsc-form-section ufsc-section-board">
                     <h4><?php esc_html_e( 'Dirigeants', 'ufsc-clubs' ); ?></h4>
                     <div class="ufsc-board-columns">
                         <div class="ufsc-board-role-card">
@@ -1083,12 +1206,14 @@ class UFSC_Frontend_Shortcodes {
                         </div>
                     </div>
 
-                    <h5><?php esc_html_e( 'Entraîneur', 'ufsc-clubs' ); ?></h5>
-                    <div class="ufsc-grid">
-                        <?php self::render_field( 'entraineur_prenom', $club, __( 'Prénom', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
-                        <?php self::render_field( 'entraineur_nom', $club, __( 'Nom', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
-                        <?php self::render_field( 'entraineur_tel', $club, __( 'Téléphone', 'ufsc-clubs' ), 'tel', false, $is_admin ); ?>
-                        <?php self::render_field( 'entraineur_email', $club, __( 'Email', 'ufsc-clubs' ), 'email', false, $is_admin ); ?>
+                    <div class="ufsc-board-role-card ufsc-board-role-card--coach">
+                        <h5><?php esc_html_e( 'Entraîneur', 'ufsc-clubs' ); ?></h5>
+                        <div class="ufsc-grid">
+                            <?php self::render_field( 'entraineur_prenom', $club, __( 'Prénom', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
+                            <?php self::render_field( 'entraineur_nom', $club, __( 'Nom', 'ufsc-clubs' ), 'text', false, $is_admin ); ?>
+                            <?php self::render_field( 'entraineur_tel', $club, __( 'Téléphone', 'ufsc-clubs' ), 'tel', false, $is_admin ); ?>
+                            <?php self::render_field( 'entraineur_email', $club, __( 'Email', 'ufsc-clubs' ), 'email', false, $is_admin ); ?>
+                        </div>
                     </div>
                 </div>
 
@@ -1121,6 +1246,15 @@ class UFSC_Frontend_Shortcodes {
                     </div>
                 </div>
                     </div>
+
+                <!-- // UFSC: Submit section -->
+                <div class="ufsc-form-actions">
+                    <?php if ( $can_edit ): ?>
+                        <button type="submit" name="ufsc_save_club" class="ufsc-btn ufsc-btn-primary">
+                            <?php esc_html_e( 'Mettre à jour le club', 'ufsc-clubs' ); ?>
+                        </button>
+                    <?php endif; ?>
+                </div>
 
                 <!-- // UFSC: Documents Section - 6 mandatory documents -->
                 <div class="ufsc-club-profile-documents">
@@ -1235,14 +1369,6 @@ class UFSC_Frontend_Shortcodes {
                     </div>
                 </div>
                 </div>
-
-                <!-- // UFSC: Submit section -->
-                <div class="ufsc-form-actions">
-                    <?php if ( $can_edit ): ?>
-                        <button type="submit" name="ufsc_save_club" class="ufsc-btn ufsc-btn-primary">
-                            <?php esc_html_e( 'Mettre à jour le club', 'ufsc-clubs' ); ?>
-                        </button>
-                    <?php endif; ?>
                 </div>
 
             </form>


### PR DESCRIPTION
### Motivation
- Introduce a premium redesign for the club dashboard and club profile to improve visual hierarchy, KPIs and mobile responsiveness.
- Surface attestation availability, missing mandatory documents and bureau coverage as actionable indicators in the dashboard and profile.
- Consolidate layout into a modern hero + KPI + main pane structure and stabilize interactions.
- Fix a small navigation activation bug to ensure the correct tab receives the active state.

### Description
- Added a large stylesheet section to `assets/css/ufsc-front.css` implementing the `ufsc-premium-v3` theme, responsive grids, KPI tiles, hero/profile cards, and numerous visual refinements and breakpoints.
- Reworked frontend rendering in `includes/frontend/class-frontend-shortcodes.php` to compute and expose club data such as `$club`, `$club_status`, bureau coverage, `missing_roles`, and `missing_docs`, and to fetch attestation data via `ufsc_get_affiliation_attestation_data` when available.
- Replaced the old dashboard/profile HTML with a new grid-based structure (hero + KPI grid + main pane) that shows KPIs (licenses, validated, missing roles, missing documents, attestation state) and moves the attestation and club-photo UX into the hero area while preserving existing upload/remove flows.
- Fixed the nav button activation JS to add the `active` class by selector (`$('.ufsc-nav-btn[data-section="' + section + '"]').addClass('active');`) and preserved existing chart initialization and form handling logic.

### Testing
- Performed a PHP syntax check (`php -l`) on modified files which passed without errors.
- Executed available plugin unit tests via `phpunit` in the development environment which passed where tests exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a01c2bd4832b9308e4baf026fd29)