### PR TITLE
Rendre l'ajout au panier idempotent pour licences brouillon et uniformiser les CTA

### DIFF
--- a/assets/frontend/css/frontend.css
+++ b/assets/frontend/css/frontend.css
@@ -1790,3 +1790,52 @@ textarea:focus {
     border-radius: 6px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
+
+/* UFSC patch: scoped, unified CTA styles for licence/cart actions only. */
+.ufsc-row-actions,
+.ufsc-licence-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.ufsc-row-actions .ufsc-btn,
+.ufsc-row-actions .ufsc-action,
+.ufsc-licence-actions .ufsc-btn,
+.ufsc-licence-actions .ufsc-action {
+    border-radius: 999px;
+    font-weight: 600;
+    line-height: 1.2;
+    min-height: 38px;
+    padding: 9px 16px;
+    text-decoration: none;
+    border: 1px solid rgba(15, 23, 42, 0.14);
+    background: #ffffff;
+    color: #0f172a;
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+    transition: all .18s ease;
+}
+
+.ufsc-row-actions .ufsc-btn:hover,
+.ufsc-row-actions .ufsc-action:hover,
+.ufsc-licence-actions .ufsc-btn:hover,
+.ufsc-licence-actions .ufsc-action:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
+}
+
+.ufsc-row-actions .ufsc-btn-primary,
+.ufsc-licence-actions .ufsc-btn-primary {
+    background: linear-gradient(135deg, #0d6efd, #2563eb);
+    border-color: transparent;
+    color: #fff;
+}
+
+.ufsc-row-actions .ufsc-btn-danger,
+.ufsc-licence-actions .ufsc-btn-danger,
+.ufsc-licence-actions .ufsc-action-danger {
+    background: #fff5f5;
+    border-color: #fecaca;
+    color: #b91c1c;
+}

--- a/inc/woocommerce/cart-integration.php
+++ b/inc/woocommerce/cart-integration.php
@@ -524,25 +524,6 @@ function ufsc_handle_add_to_cart_secure() {
 
 	$cart_item_data['ufsc_club_id'] = $club_id;
 
-	// Add license IDs if provided (lot)
-	if ( ! empty( $license_ids ) ) {
-		if ( ! ufsc_validate_licence_ids_for_cart( $license_ids, $club_id ) ) {
-			$log_warning( 'ufsc_add_to_cart_ids_invalid', array(
-				'user_id'    => $current_user_id,
-				'club_id'    => $club_id,
-				'product_id' => $product_id,
-				'ids_count'  => count( $license_ids ),
-			) );
-
-			wc_add_notice( __( 'Une ou plusieurs licences ne peuvent pas être ajoutées au panier.', 'ufsc-clubs' ), 'error' );
-			wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
-			exit;
-		}
-
-		$cart_item_data['ufsc_license_ids'] = $license_ids;
-		$quantity                           = count( $cart_item_data['ufsc_license_ids'] ); // Override quantity to match license count
-	}
-
 	// Ensure cart is ready
 	if ( function_exists( 'wc_load_cart' ) ) {
 		wc_load_cart();
@@ -560,23 +541,75 @@ function ufsc_handle_add_to_cart_secure() {
 		exit;
 	}
 
-	$cart_item_key = WC()->cart->add_to_cart( $product_id, max( 1, $quantity ), 0, array(), $cart_item_data );
+	$cart_item_key = false;
 
-	if ( $cart_item_key ) {
-		wc_add_notice(
-			sprintf( __( '%s ajouté au panier', 'ufsc-clubs' ), $product->get_name() ),
-			'success'
+	// Licence flow: add one cart line per licence (idempotent per licence ID).
+	if ( ! empty( $license_ids ) ) {
+		if ( ! ufsc_validate_licence_ids_for_cart( $license_ids, $club_id ) ) {
+			$log_warning( 'ufsc_add_to_cart_ids_invalid', array(
+				'user_id'    => $current_user_id,
+				'club_id'    => $club_id,
+				'product_id' => $product_id,
+				'ids_count'  => count( $license_ids ),
+			) );
+
+			wc_add_notice( __( 'Une ou plusieurs licences ne peuvent pas être ajoutées au panier.', 'ufsc-clubs' ), 'error' );
+			wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
+			exit;
+		}
+
+		$add_result = ufsc_add_licence_ids_to_cart_idempotent(
+			$product_id,
+			$club_id,
+			$license_ids,
+			array()
 		);
-	} else {
-		$log_warning( 'ufsc_add_to_cart_add_failed', array(
-			'user_id'    => $current_user_id,
-			'product_id' => $product_id,
-			'club_id'    => $club_id,
-			'qty'        => max( 1, $quantity ),
-			'ids_count'  => count( $license_ids ),
-		) );
 
-		wc_add_notice( __( 'Erreur lors de l\'ajout au panier', 'ufsc-clubs' ), 'error' );
+		if ( is_wp_error( $add_result ) ) {
+			$log_warning(
+				'ufsc_add_to_cart_ids_add_failed',
+				array(
+					'user_id'    => $current_user_id,
+					'club_id'    => $club_id,
+					'product_id' => $product_id,
+					'ids'        => $license_ids,
+					'error'      => $add_result->get_error_code(),
+				)
+			);
+			wc_add_notice( $add_result->get_error_message(), 'error' );
+			wp_safe_redirect( wp_get_referer() ? wp_get_referer() : home_url() );
+			exit;
+		}
+
+		$cart_item_key = ! empty( $add_result['added'] ) || ! empty( $add_result['existing'] );
+
+		if ( ! empty( $add_result['added'] ) ) {
+			wc_add_notice(
+				sprintf( __( '%s ajouté au panier', 'ufsc-clubs' ), $product->get_name() ),
+				'success'
+			);
+		} else {
+			wc_add_notice( __( 'Cette ou ces licences sont déjà présentes dans le panier.', 'ufsc-clubs' ), 'notice' );
+		}
+	} else {
+		$cart_item_key = WC()->cart->add_to_cart( $product_id, max( 1, $quantity ), 0, array(), $cart_item_data );
+
+		if ( $cart_item_key ) {
+			wc_add_notice(
+				sprintf( __( '%s ajouté au panier', 'ufsc-clubs' ), $product->get_name() ),
+				'success'
+			);
+		} else {
+			$log_warning( 'ufsc_add_to_cart_add_failed', array(
+				'user_id'    => $current_user_id,
+				'product_id' => $product_id,
+				'club_id'    => $club_id,
+				'qty'        => max( 1, $quantity ),
+				'ids_count'  => count( $license_ids ),
+			) );
+
+			wc_add_notice( __( 'Erreur lors de l\'ajout au panier', 'ufsc-clubs' ), 'error' );
+		}
 	}
 
 	// Redirect back to the referring page
@@ -586,6 +619,83 @@ function ufsc_handle_add_to_cart_secure() {
 			: ( function_exists( 'wc_get_cart_url' ) ? wc_get_cart_url() : home_url() )
 	);
 	exit;
+}
+
+/**
+ * Add licence IDs to cart in an idempotent way.
+ *
+ * - One cart line per licence ID (prevents incorrect quantity merging).
+ * - Reuses existing cart lines when same licence is already present.
+ *
+ * @param int   $product_id Product ID.
+ * @param int   $club_id    Club ID.
+ * @param array $licence_ids Licence IDs.
+ * @param array $extra_cart_item_data Additional cart item data.
+ * @return array|WP_Error
+ */
+function ufsc_add_licence_ids_to_cart_idempotent( $product_id, $club_id, $licence_ids, $extra_cart_item_data = array() ) {
+	$product_id = absint( $product_id );
+	$club_id    = absint( $club_id );
+	$licence_ids = array_values( array_unique( array_filter( array_map( 'absint', (array) $licence_ids ) ) ) );
+
+	if ( $product_id <= 0 || $club_id <= 0 || empty( $licence_ids ) ) {
+		return new WP_Error( 'ufsc_invalid_add_to_cart_payload', __( 'Paramètres d\'ajout au panier invalides.', 'ufsc-clubs' ) );
+	}
+
+	if ( ! function_exists( 'WC' ) || ! WC() || ! WC()->cart ) {
+		return new WP_Error( 'ufsc_cart_unavailable', __( 'Panier indisponible, veuillez réessayer.', 'ufsc-clubs' ) );
+	}
+
+	$added    = array();
+	$existing = array();
+	$failed   = array();
+
+	foreach ( $licence_ids as $licence_id ) {
+		$already_in_cart = false;
+
+		foreach ( WC()->cart->get_cart() as $item ) {
+			if ( absint( $item['product_id'] ?? 0 ) !== $product_id ) {
+				continue;
+			}
+
+			$item_ids = ufsc_extract_licence_ids_from_cart_item( $item );
+			if ( in_array( $licence_id, $item_ids, true ) ) {
+				$already_in_cart = true;
+				break;
+			}
+		}
+
+		if ( $already_in_cart ) {
+			$existing[] = $licence_id;
+			continue;
+		}
+
+		$item_data = array_merge(
+			(array) $extra_cart_item_data,
+			array(
+				'ufsc_club_id'     => $club_id,
+				'ufsc_licence_id'  => $licence_id,
+				'ufsc_license_ids' => array( $licence_id ),
+			)
+		);
+
+		$cart_item_key = WC()->cart->add_to_cart( $product_id, 1, 0, array(), $item_data );
+		if ( ! $cart_item_key ) {
+			$failed[] = $licence_id;
+			continue;
+		}
+
+		$added[] = $licence_id;
+	}
+
+	if ( ! empty( $failed ) ) {
+		return new WP_Error( 'ufsc_add_to_cart_failed', __( 'Erreur lors de l\'ajout au panier', 'ufsc-clubs' ) );
+	}
+
+	return array(
+		'added'    => $added,
+		'existing' => $existing,
+	);
 }
 
 /**

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -995,10 +995,21 @@ class UFSC_Unified_Handlers {
                 self::store_form_and_redirect( $_POST, array( __( 'Panier indisponible, veuillez réessayer.', 'ufsc-clubs' ) ), $new_id );
             }
 
-            $added = WC()->cart->add_to_cart( $product_id, 1, 0, array(), $cart_item_data );
-
-            if ( ! $added ) {
-                self::store_form_and_redirect( $_POST, array( __( 'Impossible d\'ajouter le produit au panier', 'ufsc-clubs' ) ), $new_id );
+            if ( function_exists( 'ufsc_add_licence_ids_to_cart_idempotent' ) ) {
+                $add_result = ufsc_add_licence_ids_to_cart_idempotent(
+                    $product_id,
+                    $club_id,
+                    array( $new_id ),
+                    $cart_item_data
+                );
+                if ( is_wp_error( $add_result ) ) {
+                    self::store_form_and_redirect( $_POST, array( $add_result->get_error_message() ), $new_id );
+                }
+            } else {
+                $added = WC()->cart->add_to_cart( $product_id, 1, 0, array(), $cart_item_data );
+                if ( ! $added ) {
+                    self::store_form_and_redirect( $_POST, array( __( 'Impossible d\'ajouter le produit au panier', 'ufsc-clubs' ) ), $new_id );
+                }
             }
 
             self::update_licence_status_db( $new_id, 'en_attente' );
@@ -1034,10 +1045,21 @@ class UFSC_Unified_Handlers {
                 'season'              => isset( $wc_settings['season'] ) ? sanitize_text_field( $wc_settings['season'] ) : '',
                 'category'            => isset( $data['categorie'] ) ? sanitize_text_field( $data['categorie'] ) : '',
             );
-            $added = WC()->cart->add_to_cart( $product_id, 1, 0, array(), $cart_item_data );
-
-            if ( ! $added ) {
-                self::store_form_and_redirect( $_POST, array( __( 'Impossible d\'ajouter le produit au panier', 'ufsc-clubs' ) ), $new_id );
+            if ( function_exists( 'ufsc_add_licence_ids_to_cart_idempotent' ) ) {
+                $add_result = ufsc_add_licence_ids_to_cart_idempotent(
+                    $product_id,
+                    $club_id,
+                    array( $new_id ),
+                    $cart_item_data
+                );
+                if ( is_wp_error( $add_result ) ) {
+                    self::store_form_and_redirect( $_POST, array( $add_result->get_error_message() ), $new_id );
+                }
+            } else {
+                $added = WC()->cart->add_to_cart( $product_id, 1, 0, array(), $cart_item_data );
+                if ( ! $added ) {
+                    self::store_form_and_redirect( $_POST, array( __( 'Impossible d\'ajouter le produit au panier', 'ufsc-clubs' ) ), $new_id );
+                }
             }
 
             self::update_licence_status_db( $new_id, 'en_attente' );

--- a/templates/frontend/licences-list.php
+++ b/templates/frontend/licences-list.php
@@ -63,6 +63,22 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
             $renew_open_label = $renew_start_ts > 0 ? wp_date( 'd/m/Y', $renew_start_ts ) : __( '30/07', 'ufsc-clubs' );
 
             $can_renew = $renew_open && ! $renew_done && ! $is_locked && ! empty( $current_season ) && $season_label === $current_season;
+            $is_in_cart = false;
+            if ( function_exists( 'WC' ) && WC() && WC()->cart ) {
+                foreach ( WC()->cart->get_cart() as $cart_item ) {
+                    $item_ids = array();
+                    if ( function_exists( 'ufsc_extract_licence_ids_from_cart_item' ) ) {
+                        $item_ids = ufsc_extract_licence_ids_from_cart_item( $cart_item );
+                    } elseif ( isset( $cart_item['ufsc_licence_id'] ) ) {
+                        $item_ids[] = absint( $cart_item['ufsc_licence_id'] );
+                    }
+
+                    if ( in_array( absint( $licence->id ?? 0 ), array_map( 'absint', (array) $item_ids ), true ) ) {
+                        $is_in_cart = true;
+                        break;
+                    }
+                }
+            }
             ?>
             <div class="ufsc-card ufsc-licence-card">
                 <div class="ufsc-licence-card-header">
@@ -99,6 +115,19 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                     <?php endif; ?>
 
                     <?php if ( ! $is_locked ) : ?>
+                        <?php if ( ! empty( $wc_settings['product_license_id'] ) ) : ?>
+                            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline">
+                                <?php wp_nonce_field( 'ufsc_add_to_cart_action', '_ufsc_nonce' ); ?>
+                                <input type="hidden" name="action" value="ufsc_add_to_cart">
+                                <input type="hidden" name="product_id" value="<?php echo esc_attr( (int) $wc_settings['product_license_id'] ); ?>">
+                                <input type="hidden" name="ufsc_club_id" value="<?php echo esc_attr( (int) ( $licence->club_id ?? 0 ) ); ?>">
+                                <input type="hidden" name="ufsc_license_ids" value="<?php echo esc_attr( (int) ( $licence->id ?? 0 ) ); ?>">
+                                <button type="submit" class="ufsc-action">
+                                    <?php echo $is_in_cart ? esc_html__( 'Payer maintenant / Voir panier', 'ufsc-clubs' ) : esc_html__( 'Ajouter au panier', 'ufsc-clubs' ); ?>
+                                </button>
+                            </form>
+                        <?php endif; ?>
+
                         <a class="ufsc-action" href="<?php echo esc_url( add_query_arg( array( 'ufsc_action' => 'edit', 'licence_id' => $licence->id ) ) ); ?>">
                             <?php esc_html_e( 'Modifier', 'ufsc-clubs' ); ?>
                         </a>


### PR DESCRIPTION
### Motivation
- Corriger les incohérences entre écrans (dashboard / page licences / formulaire) où l'ajout de plusieurs licences brouillon pouvait fusionner des lignes ou créer des doublons. 
- Faire de la fiche licence brouillon la source de vérité en réutilisant systématiquement les brouillons existants plutôt que d'en recréer. 
- Prévenir les rattachements incorrects order_item <-> licence lors de multi-ajouts ou clics répétés en introduisant une logique idempotente minimale et ciblée. 
- Améliorer l'apparence et la cohérence des CTA liés au panier/paiement sans toucher aux routes/hook métiers existants. 

### Description
- Ajout de la fonction `ufsc_add_licence_ids_to_cart_idempotent()` dans `inc/woocommerce/cart-integration.php` qui ajoute une ligne panier par licence, réutilise une ligne existante si la licence est déjà en panier et retourne les IDs ajoutés/existants ou une erreur en cas d'échec. 
- Modification de `ufsc_handle_add_to_cart_secure()` pour router le flux `ufsc_license_ids` via la nouvelle fonction idempotente (au lieu d'une seule ligne quantity=N) et conserver le comportement existant pour les autres usages. 
- Mise à jour de `includes/core/class-unified-handlers.php` pour réutiliser la même fonction idempotente lors des ajouts au panier depuis le formulaire unifié, avec un fallback vers l'ancien `WC()->cart->add_to_cart()` pour compatibilité. 
- Ajout du CTA "Ajouter au panier / Payer maintenant" sur la page dédiée `templates/frontend/licences-list.php` avec détection si la licence est déjà dans le panier, et ajout de styles scoped dans `assets/frontend/css/frontend.css` pour uniformiser visuellement les boutons d'action (scope `.ufsc-row-actions` / `.ufsc-licence-actions`). 

### Testing
- Vérification de syntaxe PHP effectuée avec `php -l` sur les fichiers modifiés (`inc/woocommerce/cart-integration.php`, `includes/core/class-unified-handlers.php`, `templates/frontend/licences-list.php`) et aucune erreur détectée. 
- Tests manuels prévus et checklist fournie pour : ajout unique depuis dashboard et page licences, multi-ajout de plusieurs brouillons, clics répétés (idempotence), paiement et vérification des rattachements order/order-item/licence, et contrôle de non-régression sur autres produits (liste dans PR). 
- Aucun test d'intégration automatisé supplémentaire n'a été exécuté dans cet environnement; la modification est ciblée et conserve les vérifications existantes (nonce, ownership, `ufsc_validate_licence_ids_for_cart`) pour limiter les risques de régression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91a0eacd8832b9dc8e0030ec82cd2)