### PR TITLE
Include 'Adhérent' in bureau role selector and normalize licence action buttons UI

### DIFF
--- a/assets/css/ufsc-front.css
+++ b/assets/css/ufsc-front.css
@@ -514,6 +514,58 @@
     background-color: #e74c3c; 
 }
 
+/* Scoped licence card actions: unified horizontal buttons without vertical stretching. */
+.ufsc-licence-card .ufsc-licence-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
+.ufsc-licence-card .ufsc-licence-action-form {
+    display: flex;
+    margin: 0;
+}
+
+.ufsc-licence-card .ufsc-licence-actions .ufsc-action,
+.ufsc-licence-card .ufsc-licence-actions button.ufsc-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 36px;
+    padding: 8px 14px;
+    margin: 0;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    background: #fff;
+    color: #1f2937;
+    font-size: 13px;
+    line-height: 1.2;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    box-sizing: border-box;
+}
+
+.ufsc-licence-card .ufsc-licence-actions .ufsc-action-primary {
+    background: #2271b1;
+    border-color: #2271b1;
+    color: #fff;
+}
+
+.ufsc-licence-card .ufsc-licence-actions .ufsc-action-danger {
+    background: #fff5f5;
+    border-color: #f5c2c7;
+    color: #b42318;
+}
+
+@media (max-width: 640px) {
+    .ufsc-licence-card .ufsc-licence-actions .ufsc-action,
+    .ufsc-licence-card .ufsc-licence-actions button.ufsc-action {
+        width: 100%;
+    }
+}
+
 img.photo-club-front {
     max-width: 400px;
 }

--- a/includes/core/class-unified-handlers.php
+++ b/includes/core/class-unified-handlers.php
@@ -445,7 +445,7 @@ class UFSC_Unified_Handlers {
         $licence_id       = isset( $_POST['licence_id'] ) ? absint( $_POST['licence_id'] ) : 0;
         $requested_role   = isset( $_POST['bureau_role'] ) ? sanitize_key( wp_unslash( $_POST['bureau_role'] ) ) : '';
         $requested_club   = isset( $_POST['club_id'] ) ? absint( $_POST['club_id'] ) : 0;
-        $allowed_roles    = array( '', 'president', 'secretaire', 'tresorier' );
+        $allowed_roles    = array( '', 'president', 'secretaire', 'tresorier', 'adherent' );
 
         if ( ! in_array( $requested_role, $allowed_roles, true ) || $licence_id <= 0 ) {
             self::redirect_with_error( 'Paramètres invalides' );
@@ -1621,6 +1621,7 @@ class UFSC_Unified_Handlers {
             'president'  => __( 'Président', 'ufsc-clubs' ),
             'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
             'tresorier'  => __( 'Trésorier', 'ufsc-clubs' ),
+            'adherent'   => __( 'Adhérent', 'ufsc-clubs' ),
         );
 
         return isset( $labels[ $role ] ) ? $labels[ $role ] : __( 'Aucun', 'ufsc-clubs' );

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -2218,6 +2218,7 @@ class UFSC_Frontend_Shortcodes {
                 'president' => array(),
                 'secretaire' => array(),
                 'tresorier' => array(),
+                'adherent' => array(),
             ),
             'missing_labels' => array(),
             'status_code'    => 'non_conforme',
@@ -2237,7 +2238,7 @@ class UFSC_Frontend_Shortcodes {
             return $data;
         }
 
-        $where = "club_id = %d AND role IN ('president','secretaire','tresorier')";
+        $where = "club_id = %d AND role IN ('president','secretaire','tresorier','adherent')";
         if ( in_array( 'deleted_at', (array) $columns, true ) ) {
             $where .= " AND (deleted_at IS NULL OR deleted_at = '0000-00-00 00:00:00')";
         }
@@ -2290,6 +2291,7 @@ class UFSC_Frontend_Shortcodes {
             'president' => __( 'Président', 'ufsc-clubs' ),
             'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
             'tresorier' => __( 'Trésorier', 'ufsc-clubs' ),
+            'adherent'  => __( 'Adhérent', 'ufsc-clubs' ),
         );
 
         $badges = array();
@@ -2312,7 +2314,7 @@ class UFSC_Frontend_Shortcodes {
      */
     private static function render_bureau_role_selector( $licence_id, $assignments ) {
         $current_role = '';
-        foreach ( array( 'president', 'secretaire', 'tresorier' ) as $role ) {
+        foreach ( array( 'president', 'secretaire', 'tresorier', 'adherent' ) as $role ) {
             $assigned_ids = isset( $assignments[ $role ] ) ? array_map( 'intval', (array) $assignments[ $role ] ) : array();
             if ( in_array( (int) $licence_id, $assigned_ids, true ) ) {
                 $current_role = $role;
@@ -2325,6 +2327,7 @@ class UFSC_Frontend_Shortcodes {
             'president'  => __( 'Président', 'ufsc-clubs' ),
             'secretaire' => __( 'Secrétaire', 'ufsc-clubs' ),
             'tresorier'  => __( 'Trésorier', 'ufsc-clubs' ),
+            'adherent'   => __( 'Adhérent', 'ufsc-clubs' ),
         );
 
         ob_start();

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -1813,6 +1813,7 @@ class UFSC_Frontend_Shortcodes {
         $action     = isset( $_GET['ufsc_action'] ) ? sanitize_key( $_GET['ufsc_action'] ) : '';
         $licence_id = isset( $_GET['licence_id'] ) ? intval( $_GET['licence_id'] ) : 0;
 
+        wp_enqueue_style( 'ufsc-front', UFSC_CL_URL . 'assets/css/ufsc-front.css', array(), UFSC_CL_VERSION );
         wp_enqueue_script( 'ufsc-licences', UFSC_CL_URL . 'assets/js/ufsc-licences.js', array( 'jquery' ), UFSC_CL_VERSION, true );
 
         ob_start();

--- a/templates/frontend/licences-list.php
+++ b/templates/frontend/licences-list.php
@@ -99,14 +99,14 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                     </a>
 
                     <?php if ( $can_renew && ! empty( $wc_settings['product_license_id'] ) ) : ?>
-                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline">
+                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-licence-action-form">
                             <?php wp_nonce_field( 'ufsc_add_to_cart_action', '_ufsc_nonce' ); ?>
                             <input type="hidden" name="action" value="ufsc_add_to_cart">
                             <input type="hidden" name="product_id" value="<?php echo esc_attr( (int) $wc_settings['product_license_id'] ); ?>">
                             <input type="hidden" name="ufsc_action" value="renew_licence">
                             <input type="hidden" name="ufsc_renew_from_licence_id" value="<?php echo esc_attr( (int) ( $licence->id ?? 0 ) ); ?>">
                             <input type="hidden" name="ufsc_target_season" value="<?php echo esc_attr( $next_season ); ?>">
-                            <button type="submit" class="ufsc-action"><?php esc_html_e( 'Renouveler', 'ufsc-clubs' ); ?></button>
+                            <button type="submit" class="ufsc-action ufsc-action-primary"><?php esc_html_e( 'Renouveler', 'ufsc-clubs' ); ?></button>
                         </form>
                     <?php elseif ( ! $renew_open ) : ?>
                         <span class="ufsc-text-muted" title="<?php esc_attr_e( 'Le renouvellement n\'est pas encore ouvert.', 'ufsc-clubs' ); ?>">
@@ -116,13 +116,13 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
                     <?php if ( ! $is_locked ) : ?>
                         <?php if ( ! empty( $wc_settings['product_license_id'] ) ) : ?>
-                            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline">
+                            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-licence-action-form">
                                 <?php wp_nonce_field( 'ufsc_add_to_cart_action', '_ufsc_nonce' ); ?>
                                 <input type="hidden" name="action" value="ufsc_add_to_cart">
                                 <input type="hidden" name="product_id" value="<?php echo esc_attr( (int) $wc_settings['product_license_id'] ); ?>">
                                 <input type="hidden" name="ufsc_club_id" value="<?php echo esc_attr( (int) ( $licence->club_id ?? 0 ) ); ?>">
                                 <input type="hidden" name="ufsc_license_ids" value="<?php echo esc_attr( (int) ( $licence->id ?? 0 ) ); ?>">
-                                <button type="submit" class="ufsc-action">
+                                <button type="submit" class="ufsc-action ufsc-action-primary">
                                     <?php echo $is_in_cart ? esc_html__( 'Payer maintenant / Voir panier', 'ufsc-clubs' ) : esc_html__( 'Ajouter au panier', 'ufsc-clubs' ); ?>
                                 </button>
                             </form>
@@ -132,12 +132,12 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
                             <?php esc_html_e( 'Modifier', 'ufsc-clubs' ); ?>
                         </a>
 
-                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline"
+                        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="ufsc-licence-action-form"
                               onsubmit="return confirm('<?php echo esc_js( __( 'Confirmer la suppression de cette licence ?', 'ufsc-clubs' ) ); ?>');">
                             <?php wp_nonce_field( 'ufsc_delete_licence' ); ?>
                             <input type="hidden" name="action" value="ufsc_delete_licence">
                             <input type="hidden" name="licence_id" value="<?php echo esc_attr( $licence->id ?? 0 ); ?>">
-                            <button type="submit" class="ufsc-action ufsc-action-danger" style="background:none;border:none;padding:0;cursor:pointer;">
+                            <button type="submit" class="ufsc-action ufsc-action-danger">
                                 <?php esc_html_e( 'Supprimer', 'ufsc-clubs' ); ?>
                             </button>
                         </form>


### PR DESCRIPTION
### Motivation
- Fix the missing “Adhérent” option in the bureau/role selector so the role can be chosen, saved and re-displayed. 
- Correct inconsistent/streched action buttons on licence cards (align, uniform height, responsive) with a scoped, minimal CSS fix. 
- Keep the patch minimal and safe to avoid regressions in cart, licence draft flows and unrelated UI.

### Description
- Added `adherent` handling end-to-end: front selector, badge detection and server validation by updating `render_bureau_role_selector()` and the bureau assignments data in `includes/frontend/class-frontend-shortcodes.php`, and allowing `adherent` in the whitelist and label mapping in `includes/core/class-unified-handlers.php`.
- Replaced inline `style="display:inline"` in licence action forms and normalized action buttons markup in `templates/frontend/licences-list.php` by adding `ufsc-licence-action-form` and semantic action classes (`ufsc-action-primary`, `ufsc-action-danger`) while keeping all POST hidden fields/nonces intact (no change to payloads or handlers).
- Added scoped CSS only for licence cards in `assets/css/ufsc-front.css` under `.ufsc-licence-card .ufsc-licence-actions` to enforce horizontal layout, consistent button height/padding, and full-width stacking on small screens; other global buttons remain unaffected.
- No changes to hooks, endpoints, slugs, GET parameters, payment or draft logic — only role allowance/labels and UI presentation for licence actions were touched.

### Testing
- Lint (PHP) checked the modified PHP files with `php -l` and they reported no syntax errors for `includes/frontend/class-frontend-shortcodes.php`, `includes/core/class-unified-handlers.php` and `templates/frontend/licences-list.php` (all succeeded).
- Visual/CSS changes limited and scoped to `.ufsc-licence-card .ufsc-licence-actions` to minimise regression risk; no automated visual tests run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9283fa1c8832ba9d2b0c716444881)