### PR TITLE
Sécurise les pages admin UFSC et ajoute libellés saisonniers pour Clubs/Licences

### DIFF
--- a/inc/common/season.php
+++ b/inc/common/season.php
@@ -43,6 +43,39 @@ if ( ! function_exists( 'ufsc_get_current_season_label' ) ) {
 	}
 }
 
+/**
+ * Admin-facing season label helper (sports season: 01/09 -> 31/08).
+ * Non-destructive: prefers a valid stored option when available.
+ */
+if ( ! function_exists( 'ufsc_get_admin_current_season_label' ) ) {
+	function ufsc_get_admin_current_season_label() {
+		$stored = get_option( 'ufsc_current_season', '' );
+		$stored = is_string( $stored ) ? sanitize_text_field( $stored ) : '';
+		if ( preg_match( '/^(\d{4})-(\d{4})$/', $stored, $matches ) && ( (int) $matches[2] ) === ( (int) $matches[1] + 1 ) ) {
+			return $stored;
+		}
+
+		$timezone   = function_exists( 'wp_timezone' ) ? wp_timezone() : new DateTimeZone( 'UTC' );
+		$now        = new DateTimeImmutable( 'now', $timezone );
+		$month      = (int) $now->format( 'n' );
+		$year       = (int) $now->format( 'Y' );
+		$start_year = ( $month >= 9 ) ? $year : ( $year - 1 );
+
+		return sprintf( '%d-%d', $start_year, $start_year + 1 );
+	}
+}
+
+if ( ! function_exists( 'ufsc_get_admin_next_season_label' ) ) {
+	function ufsc_get_admin_next_season_label() {
+		$current = ufsc_get_admin_current_season_label();
+		if ( preg_match( '/^(\d{4})-(\d{4})$/', $current, $matches ) ) {
+			return sprintf( '%d-%d', (int) $matches[1] + 1, (int) $matches[2] + 1 );
+		}
+
+		return '';
+	}
+}
+
 if ( ! function_exists( 'ufsc_get_next_season' ) ) {
 	function ufsc_get_next_season() {
 		$stored = get_option( 'ufsc_next_season', '' );

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -334,6 +334,39 @@ class UFSC_SQL_Admin
     }
 
     /**
+     * Read a scalar request value safely as string.
+     *
+     * @param array  $source Request array.
+     * @param string $key    Request key.
+     * @param string $default Default value.
+     * @return string
+     */
+    private static function request_string( $source, $key, $default = '' ) {
+        if ( ! is_array( $source ) || ! isset( $source[ $key ] ) ) {
+            return $default;
+        }
+
+        $value = wp_unslash( $source[ $key ] );
+        if ( is_array( $value ) || null === $value ) {
+            return $default;
+        }
+
+        return sanitize_text_field( (string) $value );
+    }
+
+    /**
+     * Get current season label for admin UX.
+     *
+     * @return string
+     */
+    private static function get_admin_current_season_label() {
+        if ( function_exists( 'ufsc_get_admin_current_season_label' ) ) {
+            return (string) ufsc_get_admin_current_season_label();
+        }
+        return __( 'saison en cours', 'ufsc-clubs' );
+    }
+
+    /**
      * Filter data array to columns that exist in the table.
      *
      * @param string $table Table name.
@@ -702,10 +735,10 @@ class UFSC_SQL_Admin
     public static function register_hidden_pages()
     {
         // Enregistrer les pages cachées pour les actions directes (mentionnées dans les specs)
-        add_submenu_page(null, __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-clubs', [__CLASS__, 'render_clubs']);
-        add_submenu_page(null, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
+        add_submenu_page('', __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-clubs', [__CLASS__, 'render_clubs']);
+        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
         // Alias pour compatibilité avec la spec (licenses vs licences)
-        add_submenu_page(null, __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-licenses', [__CLASS__, 'render_licences']);
+        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-licenses', [__CLASS__, 'render_licences']);
     }
 
     /* ---------------- Menus complets (obsolète - remplacé par menu unifié) ---------------- */
@@ -1182,18 +1215,14 @@ class UFSC_SQL_Admin
         }
         echo '<div class="wrap ufsc-admin ufsc-admin-page">';
 
-        if ($readonly) {
-            echo '<h2 class="ufsc-admin-title">' . ($id ? esc_html__('Consulter le club', 'ufsc-clubs') : esc_html__('Nouveau club', 'ufsc-clubs')) . '</h2>';
-        } else {
-            echo '<h2 class="ufsc-admin-title">' . ($id ? esc_html__('Éditer le club', 'ufsc-clubs') : esc_html__('Nouveau club', 'ufsc-clubs')) . '</h2>';
-        }
+        echo '<h2 class="ufsc-admin-title">' . esc_html__( 'Fiche club — Suivi administratif et affiliation', 'ufsc-clubs' ) . '</h2>';
 
         // Affichage des messages
         if (isset($_GET['updated']) && $_GET['updated'] == '1') {
             echo UFSC_CL_Utils::show_success(__('Club enregistré avec succès', 'ufsc-clubs'));
         }
         if (isset($_GET['error'])) {
-            echo UFSC_CL_Utils::show_error(sanitize_text_field($_GET['error']));
+            echo UFSC_CL_Utils::show_error( self::request_string( $_GET, 'error' ) );
         }
 
         if ( $row ) {
@@ -1238,7 +1267,8 @@ class UFSC_SQL_Admin
         echo '<div class="ufsc-admin-help">' . esc_html__( 'Date création :', 'ufsc-clubs' ) . ' ' . esc_html( (string) self::get_row_field_value( $row, 'date_creation' ) ?: '—' ) . '</div>';
         echo '<div class="ufsc-admin-help">' . esc_html__( 'Date affiliation :', 'ufsc-clubs' ) . ' ' . esc_html( (string) self::get_row_field_value( $row, 'date_affiliation' ) ?: '—' ) . '</div>';
         echo '</div>';
-        echo '<p class="ufsc-admin-subtitle">' . esc_html__( 'Cette fiche regroupe les informations administratives du club, ses dirigeants, ses documents transmis et l’état de son affiliation.', 'ufsc-clubs' ) . '</p>';
+        echo '<p class="ufsc-admin-subtitle">' . esc_html__( 'Cette fiche centralise l’identité du club, ses coordonnées, les dirigeants, les documents transmis et l’état de son affiliation pour la saison suivie.', 'ufsc-clubs' ) . '</p>';
+        echo '<p class="ufsc-admin-help">' . esc_html__( 'Saison affichée :', 'ufsc-clubs' ) . ' ' . esc_html( self::get_admin_current_season_label() ) . '</p>';
         echo '</section>';
 
         $rendered_keys = array();
@@ -2352,8 +2382,11 @@ class UFSC_SQL_Admin
             )
         );
 
-        echo '<div class="wrap ufsc-admin ufsc-admin-page"><h1 class="ufsc-admin-title">' . esc_html__('Licences (SQL)', 'ufsc-clubs') . '</h1>';
-        echo '<p class="ufsc-admin-subtitle">' . esc_html__( 'Gérez ici l’ensemble des licences rattachées aux clubs UFSC. Utilisez les filtres pour retrouver rapidement une licence, contrôler son statut, vérifier son paiement ou détecter les doublons d’identité.', 'ufsc-clubs' ) . '</p>';
+        $current_season_label = self::get_admin_current_season_label();
+        echo '<div class="wrap ufsc-admin ufsc-admin-page"><h1 class="ufsc-admin-title">' . esc_html__( 'Licences UFSC — Gestion administrative par saison', 'ufsc-clubs' ) . '</h1>';
+        echo '<p class="ufsc-admin-subtitle">' . esc_html__( 'Consultez, filtrez et mettez à jour les licences rattachées aux clubs pour la saison en cours. Les filtres permettent de contrôler rapidement les statuts, les paiements, les brouillons et les éventuels doublons d’identité.', 'ufsc-clubs' ) . '</p>';
+        echo '<p class="ufsc-admin-help">' . esc_html__( 'Saison affichée :', 'ufsc-clubs' ) . ' ' . esc_html( $current_season_label ? $current_season_label : __( 'saison en cours', 'ufsc-clubs' ) ) . '</p>';
+        echo '<div class="notice notice-info inline"><p>' . esc_html__( 'Renouvellement des licences : les licences sont suivies par saison. Lors du passage à la nouvelle saison, les licences pourront être renouvelées individuellement selon les règles définies par l’UFSC.', 'ufsc-clubs' ) . '</p></div>';
 
         // Affichage des notices
         if (isset($_GET['updated']) && $_GET['updated'] == '1') {
@@ -2364,7 +2397,7 @@ class UFSC_SQL_Admin
             echo UFSC_CL_Utils::show_success(__('La licence #' . $deleted_id . ' a été supprimée.', 'ufsc-clubs'));
         }
         if (isset($_GET['error'])) {
-            echo UFSC_CL_Utils::show_error(sanitize_text_field($_GET['error']));
+            echo UFSC_CL_Utils::show_error( self::request_string( $_GET, 'error' ) );
         }
         if ( isset( $_GET['bulk_message'] ) ) {
             $bulk_message = sanitize_key( wp_unslash( $_GET['bulk_message'] ) );
@@ -2836,9 +2869,9 @@ class UFSC_SQL_Admin
         }
 
         if ($readonly) {
-            echo '<h1 class="ufsc-admin-title">' . ($id ? esc_html__('Consulter la licence', 'ufsc-clubs') : esc_html__('Nouvelle licence', 'ufsc-clubs')) . '</h1>';
+            echo '<h1 class="ufsc-admin-title">' . esc_html__( 'Fiche licence — Identité, statut et rattachement club', 'ufsc-clubs' ) . '</h1>';
         } else {
-            echo '<h1 class="ufsc-admin-title">' . ($id ? esc_html__('Éditer la licence', 'ufsc-clubs') : esc_html__('Ajouter une nouvelle licence', 'ufsc-clubs')) . '</h1>';
+            echo '<h1 class="ufsc-admin-title">' . esc_html__( 'Fiche licence — Identité, statut et rattachement club', 'ufsc-clubs' ) . '</h1>';
             if (! $id) {
                 echo '<div class="ufsc-form-intro" style="background: #f8f9fa; padding: 15px; margin: 15px 0; border-left: 4px solid #2271b1; border-radius: 4px;">';
                 echo '<p><strong>' . esc_html__('Instructions pour l\'ajout d\'une licence', 'ufsc-clubs') . '</strong></p>';
@@ -2870,7 +2903,7 @@ class UFSC_SQL_Admin
             echo UFSC_CL_Utils::show_success($message);
         }
         if (isset($_GET['error'])) {
-            echo UFSC_CL_Utils::show_error(sanitize_text_field($_GET['error']));
+            echo UFSC_CL_Utils::show_error( self::request_string( $_GET, 'error' ) );
         }
 
         if (! $readonly) {
@@ -2898,7 +2931,8 @@ class UFSC_SQL_Admin
         echo '<div class="ufsc-admin-help">' . esc_html__( 'Statut :', 'ufsc-clubs' ) . ' ' . esc_html( function_exists( 'ufsc_get_licence_status_label_fr' ) ? ufsc_get_licence_status_label_fr( (string) self::get_row_field_value( $row, 'statut' ) ) : (string) self::get_row_field_value( $row, 'statut' ) ) . '</div>';
         echo '<div class="ufsc-admin-help">' . esc_html__( 'Date inscription :', 'ufsc-clubs' ) . ' ' . esc_html( (string) self::get_row_field_value( $row, 'date_inscription' ) ?: '—' ) . '</div>';
         echo '</div>';
-        echo '<p class="ufsc-admin-subtitle">' . esc_html__( 'Cette fiche permet de consulter les informations du licencié, son rattachement club, son statut administratif, ses options, son paiement et ses documents.', 'ufsc-clubs' ) . '</p>';
+        echo '<p class="ufsc-admin-subtitle">' . esc_html__( 'Cette fiche permet de contrôler les informations du licencié, son rattachement au club, son statut administratif, son paiement et les documents liés à la saison.', 'ufsc-clubs' ) . '</p>';
+        echo '<p class="ufsc-admin-help">' . esc_html__( 'Saison affichée :', 'ufsc-clubs' ) . ' ' . esc_html( self::get_admin_current_season_label() ) . '</p>';
         echo '</section>';
 
         $rendered_keys = array();

--- a/includes/admin/list-tables/class-ufsc-clubs-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-clubs-list-table.php
@@ -6,6 +6,22 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  * Enhanced admin list with filters, search, and pagination
  */
 class UFSC_Clubs_List_Table {
+    private static function get_current_request_url() {
+        $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+        if ( ! is_string( $request_uri ) || '' === $request_uri ) {
+            return admin_url( 'admin.php?page=ufsc-sql-clubs' );
+        }
+
+        return $request_uri;
+    }
+
+    private static function get_admin_season_label() {
+        if ( function_exists( 'ufsc_get_admin_current_season_label' ) ) {
+            return (string) ufsc_get_admin_current_season_label();
+        }
+
+        return __( 'saison en cours', 'ufsc-clubs' );
+    }
 
     /**
      * Render enhanced clubs list
@@ -51,7 +67,10 @@ class UFSC_Clubs_List_Table {
 
         // Render the page
         echo '<div class="wrap">';
-        echo '<h1>' . esc_html__( 'Clubs (SQL)', 'ufsc-clubs' ) . '</h1>';
+        echo '<h1 class="ufsc-admin-title">' . esc_html__( 'Clubs UFSC — Affiliations et suivi administratif', 'ufsc-clubs' ) . '</h1>';
+        echo '<p class="ufsc-admin-subtitle">' . esc_html__( 'Retrouvez ici l’ensemble des clubs enregistrés, leur région, leur statut d’affiliation, le nombre de licences associées et l’état des documents administratifs. Cette page permet de suivre les clubs actifs, en attente ou à renouveler.', 'ufsc-clubs' ) . '</p>';
+        echo '<p class="ufsc-admin-help">' . esc_html__( 'Saison affichée :', 'ufsc-clubs' ) . ' ' . esc_html( self::get_admin_season_label() ) . '</p>';
+        echo '<div class="notice notice-info inline"><p>' . esc_html__( 'Renouvellement des affiliations : à chaque nouvelle saison, les clubs devront confirmer ou renouveler leur affiliation afin de maintenir leurs licences actives.', 'ufsc-clubs' ) . '</p></div>';
 
         // Affichage des notices
         if ( isset($_GET['updated']) && $_GET['updated'] == '1' ) {
@@ -62,7 +81,10 @@ class UFSC_Clubs_List_Table {
             echo UFSC_CL_Utils::show_success(__('Le club #'.$deleted_id.' a été supprimé.', 'ufsc-clubs'));
         }
         if ( isset($_GET['error']) ) {
-            echo UFSC_CL_Utils::show_error(sanitize_text_field($_GET['error']));
+            $error_value = wp_unslash( $_GET['error'] );
+            if ( ! is_array( $error_value ) && null !== $error_value ) {
+                echo UFSC_CL_Utils::show_error( sanitize_text_field( (string) $error_value ) );
+            }
         }
 
         // Action buttons
@@ -229,11 +251,12 @@ class UFSC_Clubs_List_Table {
         echo '<a href="' . esc_url( admin_url( 'admin.php?page=ufsc-sql-clubs&action=new' ) ) . '" class="button button-primary">';
         echo esc_html__( 'Ajouter un club', 'ufsc-clubs' );
         echo '</a> ';
-        echo '<a href="' . esc_url( add_query_arg( 'export', 'csv' ) ) . '" class="button">';
+        $current_url = self::get_current_request_url();
+        echo '<a href="' . esc_url( add_query_arg( 'export', 'csv', $current_url ) ) . '" class="button">';
         echo esc_html__( 'Exporter CSV', 'ufsc-clubs' );
         echo '</a>';
 
-        echo '<a href="' . esc_url( add_query_arg( 'export', 'xlsx' ) ) . '" class="button">';
+        echo '<a href="' . esc_url( add_query_arg( 'export', 'xlsx', $current_url ) ) . '" class="button">';
         echo esc_html__( 'Exporter XLSX', 'ufsc-clubs' );
         echo '</a>';
 
@@ -333,7 +356,7 @@ class UFSC_Clubs_List_Table {
         echo ' | ';
         echo '<select onchange="window.location.href=this.value">';
         foreach ( array( 20, 50, 100 ) as $per_page ) {
-            $url = add_query_arg( 'per_page', $per_page );
+            $url = add_query_arg( 'per_page', $per_page, self::get_current_request_url() );
             echo '<option value="' . esc_url( $url ) . '"' . selected( $pagination['per_page'], $per_page, false ) . '>';
             echo sprintf( esc_html__( '%d par page', 'ufsc-clubs' ), $per_page );
             echo '</option>';
@@ -489,7 +512,7 @@ class UFSC_Clubs_List_Table {
         echo '<div class="tablenav bottom">';
         echo '<div class="tablenav-pages">';
 
-        $base_url = remove_query_arg( 'paged' );
+        $base_url = remove_query_arg( 'paged', self::get_current_request_url() );
 
         // Previous page
         if ( $current_page > 1 ) {
@@ -584,7 +607,7 @@ class UFSC_Clubs_List_Table {
      */
     private static function get_sortable_header( $column, $title, $sorting ) {
         $order = ( $sorting['orderby'] === $column && $sorting['order'] === 'asc' ) ? 'desc' : 'asc';
-        $url = add_query_arg( array( 'orderby' => $column, 'order' => $order ) );
+        $url = add_query_arg( array( 'orderby' => $column, 'order' => $order ), self::get_current_request_url() );
 
         $arrow = '';
         if ( $sorting['orderby'] === $column ) {

--- a/includes/admin/list-tables/class-ufsc-licences-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-licences-list-table.php
@@ -6,6 +6,14 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  * Enhanced admin list with filters, search, and pagination
  */
 class UFSC_Licences_List_Table {
+    private static function get_current_request_url() {
+        $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+        if ( ! is_string( $request_uri ) || '' === $request_uri ) {
+            return admin_url( 'admin.php?page=ufsc-sql-licences' );
+        }
+
+        return $request_uri;
+    }
 
     /**
      * Render enhanced licences list
@@ -294,7 +302,7 @@ class UFSC_Licences_List_Table {
         echo '<a href="' . esc_url( admin_url( 'admin.php?page=ufsc-sql-licences&action=new' ) ) . '" class="button button-primary">';
         echo esc_html__( 'Ajouter une licence', 'ufsc-clubs' );
         echo '</a> ';
-        echo '<a href="' . esc_url( add_query_arg( 'export', '1' ) ) . '" class="button">';
+        echo '<a href="' . esc_url( add_query_arg( 'export', '1', self::get_current_request_url() ) ) . '" class="button">';
         echo esc_html__( 'Exporter CSV', 'ufsc-clubs' );
         echo '</a>';
         echo '</p>';
@@ -393,7 +401,7 @@ class UFSC_Licences_List_Table {
         echo ' | ';
         echo '<select onchange="window.location.href=this.value">';
         foreach ( array( 20, 50, 100 ) as $per_page ) {
-            $url = add_query_arg( 'per_page', $per_page );
+            $url = add_query_arg( 'per_page', $per_page, self::get_current_request_url() );
             echo '<option value="' . esc_url( $url ) . '"' . selected( $pagination['per_page'], $per_page, false ) . '>';
             echo sprintf( esc_html__( '%d par page', 'ufsc-clubs' ), $per_page );
             echo '</option>';
@@ -510,7 +518,7 @@ class UFSC_Licences_List_Table {
         echo '<div class="tablenav bottom">';
         echo '<div class="tablenav-pages">';
         
-        $base_url = remove_query_arg( 'paged' );
+        $base_url = remove_query_arg( 'paged', self::get_current_request_url() );
         
         // Previous page
         if ( $current_page > 1 ) {
@@ -670,7 +678,7 @@ class UFSC_Licences_List_Table {
      */
     private static function get_sortable_header( $column, $title, $sorting ) {
         $order = ( $sorting['orderby'] === $column && $sorting['order'] === 'asc' ) ? 'desc' : 'asc';
-        $url = add_query_arg( array( 'orderby' => $column, 'order' => $order ) );
+        $url = add_query_arg( array( 'orderby' => $column, 'order' => $order ), self::get_current_request_url() );
         
         $arrow = '';
         if ( $sorting['orderby'] === $column ) {


### PR DESCRIPTION
### Motivation
- Corriger les alertes deprecate/nullable observées dans Query Monitor (appels `strpos`, `str_replace`, `strip_tags`) en évitant de transmettre des valeurs `null` aux fonctions cœur de WordPress. 
- Améliorer la lisibilité et l’UX des pages admin Clubs/Licences en affichant des titres explicites et une indication de la saison courante sans modifier la logique métier. 
- Préparer proprement la logique de saison pour usages admin futurs de façon non destructive et compatible avec l’existant.

### Description
- Ajout de helpers saisonniers non destructifs `ufsc_get_admin_current_season_label()` et `ufsc_get_admin_next_season_label()` dans `inc/common/season.php` pour calculer l’étiquette de saison (règle 01/09 → 31/08) tout en privilégiant une option stockée valide. 
- Durcissement de la lecture sécurisée des valeurs de requête avec `request_string()` et `get_admin_current_season_label()` dans `includes/admin/class-sql-admin.php` pour éviter de passer `NULL`/tableaux à `sanitize_text_field` et aux sorties admin. 
- Évitement de `null` lors de l’enregistrement de pages cachées en remplaçant `add_submenu_page(null, ...)` par `add_submenu_page('', ...)` dans `includes/admin/class-sql-admin.php` afin d’empêcher des chemins/titres `null` déclenchant `strpos`/`strip_tags` dépréciés. 
- Stabilisation des URLs de listes admin en forçant une base explicite pour `add_query_arg()` / `remove_query_arg()` via `get_current_request_url()` dans `includes/admin/list-tables/class-ufsc-clubs-list-table.php` et `includes/admin/list-tables/class-ufsc-licences-list-table.php` pour supprimer les cas où `str_replace` recevrait `null`. 
- Amélioration des libellés et textes d’accompagnement admin (titres, sous-titres, bloc d’aide de renouvellement et affichage `Saison affichée : {saison}`) sur les pages : liste Clubs, liste Licences, fiche Club et fiche Licence, en respectant les classes CSS admin existantes et sans modification front-end ou logique métier. 
- Fichiers modifiés : `inc/common/season.php`, `includes/admin/class-sql-admin.php`, `includes/admin/list-tables/class-ufsc-clubs-list-table.php`, `includes/admin/list-tables/class-ufsc-licences-list-table.php`.

### Testing
- Vérification syntaxique PHP réalisée avec `php -l` sur les fichiers modifiés : `php -l inc/common/season.php`, `php -l includes/admin/class-sql-admin.php`, `php -l includes/admin/list-tables/class-ufsc-clubs-list-table.php`, `php -l includes/admin/list-tables/class-ufsc-licences-list-table.php` — toutes les vérifications ont réussi (aucune erreur de syntaxe). 
- Le patch a été commité (message: "Stabilize admin null handling and improve Clubs/Licences season UX").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd8fc0760832b9c407692dc3ab423)