### PR TITLE
Refonte UI admin Clubs — cartes KPI, filtres avancés, badges et CSS/JS dédiés

### DIFF
--- a/assets/admin/css/ufsc-clubs-admin.css
+++ b/assets/admin/css/ufsc-clubs-admin.css
@@ -1,0 +1,341 @@
+/* UFSC Clubs admin: scoped to the clubs administration page only. */
+.ufsc-clubs-admin-page {
+    background: #f4f6fb;
+    margin-left: -20px;
+    padding: 24px 24px 40px;
+}
+
+.ufsc-clubs-shell {
+    max-width: 1500px;
+}
+
+.ufsc-clubs-hero {
+    background: linear-gradient(135deg, #123c7c 0%, #164fc4 72%, #d71920 100%);
+    border-radius: 18px;
+    box-shadow: 0 14px 35px rgba(18, 60, 124, 0.22);
+    color: #fff;
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 28px 32px;
+}
+
+.ufsc-clubs-kicker {
+    display: inline-flex;
+    margin-bottom: 8px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.16);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+}
+
+.ufsc-clubs-hero .ufsc-admin-title {
+    color: #fff;
+    font-size: 28px;
+    font-weight: 700;
+    margin: 0 0 10px;
+}
+
+.ufsc-clubs-hero .ufsc-admin-subtitle {
+    color: rgba(255, 255, 255, .9);
+    font-size: 15px;
+    line-height: 1.55;
+    max-width: 920px;
+    margin: 0;
+}
+
+.ufsc-season-pill {
+    align-self: flex-start;
+    min-width: 170px;
+    border: 1px solid rgba(255, 255, 255, .28);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, .12);
+    padding: 14px 16px;
+    text-align: right;
+}
+
+.ufsc-season-pill span,
+.ufsc-stat-card span {
+    display: block;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+}
+
+.ufsc-season-pill strong {
+    display: block;
+    margin-top: 4px;
+    font-size: 20px;
+}
+
+.ufsc-renewal-notice {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 18px 0;
+    padding: 14px 16px;
+    border-left: 4px solid #164fc4;
+    border-radius: 10px;
+    background: #ffffff;
+    box-shadow: 0 3px 14px rgba(18, 60, 124, .08);
+}
+
+.ufsc-renewal-notice p {
+    margin: 0;
+}
+
+.ufsc-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: 14px;
+    margin: 18px 0;
+}
+
+.ufsc-stat-card {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid #dbe3f2;
+    border-radius: 14px;
+    background: #fff;
+    padding: 18px;
+    box-shadow: 0 5px 18px rgba(18, 60, 124, .08);
+}
+
+.ufsc-stat-card::before {
+    content: '';
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 5px;
+    background: #164fc4;
+}
+
+.ufsc-stat-card--success::before { background: #1f9d55; }
+.ufsc-stat-card--warning::before { background: #f59e0b; }
+.ufsc-stat-card--danger::before { background: #d71920; }
+
+.ufsc-stat-card span {
+    color: #5d6b82;
+}
+
+.ufsc-stat-card strong {
+    display: block;
+    margin-top: 8px;
+    color: #102a56;
+    font-size: 30px;
+    line-height: 1;
+}
+
+.ufsc-clubs-admin-page p > .button,
+.ufsc-clubs-admin-page .button {
+    border-radius: 7px;
+}
+
+.ufsc-clubs-admin-page .button-primary {
+    background: #164fc4;
+    border-color: #123c7c;
+}
+
+.ufsc-filters-panel {
+    border: 1px solid #dbe3f2;
+    border-radius: 16px;
+    background: #fff;
+    margin: 20px 0;
+    padding: 20px;
+    box-shadow: 0 8px 22px rgba(18, 60, 124, .08);
+}
+
+.ufsc-panel-heading {
+    border-bottom: 1px solid #edf1f7;
+    margin: -2px 0 18px;
+    padding-bottom: 14px;
+}
+
+.ufsc-panel-heading h2 {
+    color: #123c7c;
+    margin: 0 0 4px;
+    font-size: 18px;
+}
+
+.ufsc-panel-heading p {
+    color: #667085;
+    margin: 0;
+}
+
+.ufsc-filters-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(185px, 1fr));
+    gap: 14px;
+}
+
+.ufsc-filters-grid label span {
+    display: block;
+    color: #344054;
+    font-weight: 700;
+    margin-bottom: 6px;
+}
+
+.ufsc-filters-grid input,
+.ufsc-filters-grid select {
+    min-height: 36px;
+    width: 100%;
+    max-width: 100%;
+}
+
+.ufsc-filters-actions,
+.ufsc-bulk-actions,
+.ufsc-quick-filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+
+.ufsc-filters-actions {
+    margin-top: 16px;
+}
+
+.ufsc-quick-filters {
+    margin: 18px 0 12px;
+}
+
+.ufsc-quick-filters .button {
+    background: #fff;
+    border-color: #c6d3ea;
+    color: #123c7c;
+    font-weight: 600;
+}
+
+.ufsc-results-info {
+    align-items: center;
+    background: #fff;
+    border: 1px solid #dbe3f2;
+    border-radius: 12px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: space-between;
+    margin: 12px 0;
+    padding: 12px 14px;
+}
+
+.ufsc-bulk-actions {
+    background: #fff;
+    border: 1px solid #dbe3f2;
+    border-radius: 12px 12px 0 0;
+    border-bottom: 0;
+    margin: 15px 0 0;
+    padding: 12px;
+}
+
+.ufsc-clubs-table {
+    border-color: #dbe3f2;
+    box-shadow: 0 7px 22px rgba(18, 60, 124, .08);
+}
+
+.ufsc-clubs-table thead th,
+.ufsc-clubs-table thead td {
+    background: #123c7c;
+    color: #fff;
+    font-weight: 700;
+}
+
+.ufsc-clubs-table thead a {
+    color: #fff;
+}
+
+.ufsc-clubs-table td,
+.ufsc-clubs-table th {
+    vertical-align: middle;
+}
+
+.ufsc-club-name-cell strong {
+    color: #102a56;
+    font-size: 14px;
+}
+
+.ufsc-club-name-cell small {
+    color: #667085;
+}
+
+.ufsc-badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1.2;
+    padding: 5px 9px;
+    white-space: nowrap;
+}
+
+.ufsc-badge--success { background: #dcfce7; color: #166534; }
+.ufsc-badge--warning { background: #fff7d6; color: #92400e; }
+.ufsc-badge--danger { background: #fee2e2; color: #991b1b; }
+.ufsc-badge--neutral,
+.ufsc-badge--muted { background: #eef2f7; color: #475467; }
+
+.ufsc-affiliation-number {
+    color: #123c7c;
+    font-weight: 700;
+}
+
+.ufsc-licence-link {
+    font-weight: 700;
+    text-decoration: none;
+}
+
+.ufsc-alert-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 8px;
+}
+
+.ufsc-alert-tags span {
+    border-radius: 999px;
+    background: #fff1f2;
+    color: #b42318;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 3px 7px;
+}
+
+.ufsc-row-actions {
+    min-width: 220px;
+}
+
+.ufsc-row-actions .button {
+    margin: 2px 2px 2px 0;
+}
+
+.ufsc-button-disabled {
+    cursor: not-allowed !important;
+    opacity: .65;
+}
+
+@media screen and (max-width: 782px) {
+    .ufsc-clubs-admin-page {
+        margin-left: -10px;
+        padding: 14px;
+    }
+
+    .ufsc-clubs-hero {
+        flex-direction: column;
+        padding: 22px;
+    }
+
+    .ufsc-season-pill {
+        text-align: left;
+        width: auto;
+    }
+
+    .ufsc-clubs-table {
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+    }
+}

--- a/assets/admin/js/ufsc-clubs-admin.js
+++ b/assets/admin/js/ufsc-clubs-admin.js
@@ -1,0 +1,22 @@
+/* UFSC Clubs admin page enhancements */
+jQuery(function($) {
+    var $selectAll = $('#select-all-club');
+    var $clubCheckboxes = $('input[name="club_ids[]"]');
+
+    $selectAll.on('change', function() {
+        $clubCheckboxes.prop('checked', $(this).prop('checked'));
+    });
+
+    $clubCheckboxes.on('change', function() {
+        var total = $clubCheckboxes.length;
+        var checked = $clubCheckboxes.filter(':checked').length;
+        $selectAll.prop('checked', total > 0 && total === checked);
+    });
+
+    $('#bulk-actions-form').on('submit', function(e) {
+        var action = $('#bulk-action-selector').val();
+        if ('delete' === action && ! window.confirm('Confirmer la suppression des clubs sélectionnés ?')) {
+            e.preventDefault();
+        }
+    });
+});

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -136,6 +136,11 @@ class UFSC_CL_Admin_Menu {
 			if ( false !== strpos( $hook, 'ufsc-sql-licences' ) || 'ufsc-sql-licences' === $page || 'ufsc-licences' === $page ) {
 				wp_enqueue_script( 'ufsc-license-form', UFSC_CL_URL . 'assets/js/ufsc-license-form.js', array( 'jquery' ), UFSC_CL_VERSION, true );
 			}
+
+			if ( false !== strpos( $hook, 'ufsc-sql-clubs' ) || 'ufsc-sql-clubs' === $page || 'ufsc-clubs' === $page ) {
+				wp_enqueue_style( 'ufsc-clubs-admin', UFSC_CL_URL . 'assets/admin/css/ufsc-clubs-admin.css', array( 'ufsc-admin' ), UFSC_CL_VERSION );
+				wp_enqueue_script( 'ufsc-clubs-admin', UFSC_CL_URL . 'assets/admin/js/ufsc-clubs-admin.js', array( 'jquery' ), UFSC_CL_VERSION, true );
+			}
 		}
 	}
 

--- a/includes/admin/list-tables/class-ufsc-clubs-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-clubs-list-table.php
@@ -32,6 +32,7 @@ class UFSC_Clubs_List_Table {
         $settings = UFSC_SQL::get_settings();
         $clubs_table = $settings['table_clubs'];
         $club_columns = function_exists( 'ufsc_table_columns' ) ? ufsc_table_columns( $clubs_table ) : array();
+        $licence_counts = UFSC_CL_Utils::get_valid_licence_counts_by_club();
 
         // Handle filters and search
         $filters = self::get_filters();
@@ -66,11 +67,17 @@ class UFSC_Clubs_List_Table {
         $total_pages = ceil( $total_items / $pagination['per_page'] );
 
         // Render the page
-        echo '<div class="wrap">';
+        echo '<div class="wrap ufsc-clubs-admin-page">';
+        echo '<div class="ufsc-clubs-shell">';
+        echo '<div class="ufsc-clubs-hero">';
+        echo '<div>';
+        echo '<span class="ufsc-clubs-kicker">' . esc_html__( 'Administration UFSC', 'ufsc-clubs' ) . '</span>';
         echo '<h1 class="ufsc-admin-title">' . esc_html__( 'Clubs UFSC — Affiliations et suivi administratif', 'ufsc-clubs' ) . '</h1>';
         echo '<p class="ufsc-admin-subtitle">' . esc_html__( 'Retrouvez ici l’ensemble des clubs enregistrés, leur région, leur statut d’affiliation, le nombre de licences associées et l’état des documents administratifs. Cette page permet de suivre les clubs actifs, en attente ou à renouveler.', 'ufsc-clubs' ) . '</p>';
-        echo '<p class="ufsc-admin-help">' . esc_html__( 'Saison affichée :', 'ufsc-clubs' ) . ' ' . esc_html( self::get_admin_season_label() ) . '</p>';
-        echo '<div class="notice notice-info inline"><p>' . esc_html__( 'Renouvellement des affiliations : à chaque nouvelle saison, les clubs devront confirmer ou renouveler leur affiliation afin de maintenir leurs licences actives.', 'ufsc-clubs' ) . '</p></div>';
+        echo '</div>';
+        echo '<div class="ufsc-season-pill"><span>' . esc_html__( 'Saison affichée', 'ufsc-clubs' ) . '</span><strong>' . esc_html( self::get_admin_season_label() ) . '</strong></div>';
+        echo '</div>';
+        echo '<div class="ufsc-renewal-notice"><span class="dashicons dashicons-info"></span><p>' . esc_html__( 'Renouvellement des affiliations : à chaque nouvelle saison, les clubs devront confirmer ou renouveler leur affiliation afin de maintenir leurs licences actives.', 'ufsc-clubs' ) . '</p></div>';
 
         // Affichage des notices
         if ( isset($_GET['updated']) && $_GET['updated'] == '1' ) {
@@ -90,11 +97,12 @@ class UFSC_Clubs_List_Table {
         // Action buttons
         self::render_action_buttons();
 
-        // Filters
-        self::render_filters( $filters, $club_columns, $clubs_table );
+        self::render_statistics_cards( $club_columns, $clubs_table, $licence_counts );
 
-        // Search
-        self::render_search( $search );
+        // Filters and search
+        self::render_filters( $filters, $club_columns, $clubs_table, $search );
+
+        self::render_quick_filters( $filters );
 
         //Action Grop
         //self::bulck_action_grop_by_club();
@@ -103,13 +111,27 @@ class UFSC_Clubs_List_Table {
         self::render_results_info( $total_items, $pagination );
 
         // Main table
-        $licence_counts = UFSC_CL_Utils::get_valid_licence_counts_by_club();
         self::render_clubs_table( $clubs, $sorting, $licence_counts );
 
         // Pagination
         self::render_pagination( $pagination['paged'], $total_pages );
 
         echo '</div>';
+        echo '</div>';
+    }
+
+
+
+    private static function get_query_value( $key, $type = 'text' ) {
+        if ( ! isset( $_GET[ $key ] ) ) {
+            return '';
+        }
+        $value = wp_unslash( $_GET[ $key ] );
+        if ( is_array( $value ) || null === $value ) {
+            return '';
+        }
+        $value = (string) $value;
+        return 'key' === $type ? sanitize_key( $value ) : sanitize_text_field( $value );
     }
 
     /**
@@ -117,10 +139,14 @@ class UFSC_Clubs_List_Table {
      */
     private static function get_filters() {
         $filters = array(
-            'region' => isset( $_GET['region'] ) ? sanitize_text_field( $_GET['region'] ) : '',
-            'statut' => isset( $_GET['statut'] ) ? sanitize_text_field( $_GET['statut'] ) : '',
-            'created_from' => isset( $_GET['created_from'] ) ? sanitize_text_field( $_GET['created_from'] ) : '',
-            'created_to' => isset( $_GET['created_to'] ) ? sanitize_text_field( $_GET['created_to'] ) : ''
+            'region' => self::get_query_value( 'region' ),
+            'statut' => self::get_query_value( 'statut' ),
+            'created_from' => self::get_query_value( 'created_from' ),
+            'created_to' => self::get_query_value( 'created_to' ),
+            'doc_status' => self::get_query_value( 'doc_status', 'key' ),
+            'affiliation_status' => self::get_query_value( 'affiliation_status', 'key' ),
+            'licence_range' => self::get_query_value( 'licence_range', 'key' ),
+            'season' => self::get_query_value( 'season' )
         );
 
         return $filters;
@@ -130,7 +156,7 @@ class UFSC_Clubs_List_Table {
      * Get search query
      */
     private static function get_search_query() {
-        return isset( $_GET['q'] ) ? sanitize_text_field( $_GET['q'] ) : '';
+        return self::get_query_value( 'q' );
     }
 
     /**
@@ -154,8 +180,8 @@ class UFSC_Clubs_List_Table {
         $allowed_order = array( 'asc', 'desc' );
 
         return array(
-            'orderby' => isset( $_GET['orderby'] ) && in_array( $_GET['orderby'], $allowed_orderby ) ? $_GET['orderby'] : 'date_creation',
-            'order' => isset( $_GET['order'] ) && in_array( $_GET['order'], $allowed_order ) ? $_GET['order'] : 'desc'
+            'orderby' => isset( $_GET['orderby'] ) && in_array( sanitize_key( wp_unslash( $_GET['orderby'] ) ), $allowed_orderby, true ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : 'date_creation',
+            'order' => isset( $_GET['order'] ) && in_array( sanitize_key( wp_unslash( $_GET['order'] ) ), $allowed_order, true ) ? sanitize_key( wp_unslash( $_GET['order'] ) ) : 'desc'
         );
     }
 
@@ -206,6 +232,45 @@ class UFSC_Clubs_List_Table {
             $conditions[] = $wpdb->prepare( "DATE(date_creation) <= %s", $filters['created_to'] );
         }
 
+        $doc_fields = self::get_available_document_fields( $columns, $clubs_table );
+        if ( ! empty( $doc_fields ) && ! empty( $filters['doc_status'] ) ) {
+            $doc_conditions = array();
+            foreach ( $doc_fields as $field ) {
+                $doc_conditions[] = "(`{$field}` IS NOT NULL AND `{$field}` != '')";
+            }
+            if ( 'complete' === $filters['doc_status'] ) {
+                $conditions[] = '(' . implode( ' AND ', $doc_conditions ) . ')';
+            } elseif ( 'incomplete' === $filters['doc_status'] ) {
+                $conditions[] = 'NOT (' . implode( ' AND ', $doc_conditions ) . ')';
+            }
+        }
+
+        if ( ! empty( $filters['affiliation_status'] ) && self::has_column( $columns, $clubs_table, 'num_affiliation' ) ) {
+            if ( 'assigned' === $filters['affiliation_status'] ) {
+                $conditions[] = "(num_affiliation IS NOT NULL AND num_affiliation != '')";
+            } elseif ( 'missing' === $filters['affiliation_status'] ) {
+                $conditions[] = "(num_affiliation IS NULL OR num_affiliation = '')";
+            }
+        }
+
+        $licence_expression = self::get_licence_count_expression( $clubs_table );
+        if ( '' !== $licence_expression && ! empty( $filters['licence_range'] ) ) {
+            if ( 'zero' === $filters['licence_range'] ) {
+                $conditions[] = $licence_expression . ' = 0';
+            } elseif ( 'one_to_nine' === $filters['licence_range'] ) {
+                $conditions[] = $licence_expression . ' BETWEEN 1 AND 9';
+            } elseif ( 'ten_plus' === $filters['licence_range'] ) {
+                $conditions[] = $licence_expression . ' >= 10';
+            } elseif ( 'under_ten' === $filters['licence_range'] ) {
+                $conditions[] = $licence_expression . ' < 10';
+            }
+        }
+
+        $season_column = self::get_season_column( $columns, $clubs_table );
+        if ( '' !== $season_column && ! empty( $filters['season'] ) ) {
+            $conditions[] = $wpdb->prepare( "`{$season_column}` = %s", $filters['season'] );
+        }
+
         if ( self::has_column( $columns, $clubs_table, 'region' ) ) {
             $scope_condition = UFSC_Scope::build_scope_condition( 'region' );
             if ( $scope_condition ) {
@@ -214,6 +279,69 @@ class UFSC_Clubs_List_Table {
         }
 
         return $conditions;
+    }
+
+
+    /**
+     * Return document fields that are physically available on the clubs table.
+     */
+    private static function get_available_document_fields( $columns, $clubs_table ) {
+        $doc_fields = array(
+            'doc_statuts',
+            'doc_recepisse',
+            'doc_jo',
+            'doc_pv_ag',
+            'doc_cer',
+            'doc_attestation_cer'
+        );
+        $available = array();
+        foreach ( $doc_fields as $field ) {
+            if ( self::has_column( $columns, $clubs_table, $field ) ) {
+                $available[] = $field;
+            }
+        }
+        return $available;
+    }
+
+    /**
+     * Find the safest season column to use for optional filtering.
+     */
+    private static function get_season_column( $columns, $clubs_table ) {
+        foreach ( array( 'season', 'saison', 'paid_season', 'season_end_year' ) as $column ) {
+            if ( self::has_column( $columns, $clubs_table, $column ) ) {
+                return $column;
+            }
+        }
+        return '';
+    }
+
+    /**
+     * Build a correlated licence count expression only if the licence table supports it.
+     */
+    private static function get_licence_count_expression( $clubs_table ) {
+        global $wpdb;
+        $settings       = UFSC_SQL::get_settings();
+        $licences_table = isset( $settings['table_licences'] ) ? $settings['table_licences'] : '';
+        if ( '' === $licences_table ) {
+            return '';
+        }
+        if ( function_exists( 'ufsc_table_exists' ) && ! ufsc_table_exists( $licences_table ) ) {
+            return '';
+        }
+        $licence_columns = function_exists( 'ufsc_table_columns' ) ? ufsc_table_columns( $licences_table ) : array();
+        if ( ! self::has_column( $licence_columns, $licences_table, 'club_id' ) || ! self::has_column( array(), $clubs_table, 'id' ) ) {
+            return '';
+        }
+
+        $parts = array( "l.club_id = `{$clubs_table}`.id" );
+        if ( self::has_column( $licence_columns, $licences_table, 'statut' ) ) {
+            $parts[] = $wpdb->prepare( 'l.statut = %s', 'valide' );
+        }
+        if ( self::has_column( $licence_columns, $licences_table, 'deleted_at' ) ) {
+            $parts[] = "(l.deleted_at IS NULL OR l.deleted_at = '0000-00-00 00:00:00')";
+        }
+
+        return "(SELECT COUNT(*) FROM `{$licences_table}` l WHERE " . implode( ' AND ', $parts ) . ')';
     }
 
     /**
@@ -268,29 +396,130 @@ class UFSC_Clubs_List_Table {
     }
 
     /**
-     * Render filters
+     * Render statistics cards.
      */
-    private static function render_filters( $filters, $columns, $clubs_table ) {
+    private static function render_statistics_cards( $columns, $clubs_table, $licence_counts ) {
+        global $wpdb;
+        $where_scope = '';
+        if ( self::has_column( $columns, $clubs_table, 'region' ) ) {
+            $scope_condition = UFSC_Scope::build_scope_condition( 'region' );
+            if ( $scope_condition ) {
+                $where_scope = 'WHERE ' . $scope_condition;
+            }
+        }
+
+        $stats = array(
+            'total' => (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$clubs_table}` {$where_scope}" ),
+            'active' => 0,
+            'pending' => 0,
+            'documents_complete' => null,
+            'documents_incomplete' => null,
+            'licences' => array_sum( array_map( 'intval', (array) $licence_counts ) ),
+            'missing_affiliation' => null,
+        );
+
+        if ( self::has_column( $columns, $clubs_table, 'statut' ) ) {
+            $scope_prefix = '' === $where_scope ? 'WHERE' : $where_scope . ' AND';
+            $active_statuses = array( 'actif', 'active', 'valide', 'validated' );
+            $pending_statuses = array( 'en_attente', 'pending', 'a_regler', 'creating', 'en_cours_de_creation' );
+            $active_placeholders = implode( ',', array_fill( 0, count( $active_statuses ), '%s' ) );
+            $pending_placeholders = implode( ',', array_fill( 0, count( $pending_statuses ), '%s' ) );
+            $stats['active'] = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM `{$clubs_table}` {$scope_prefix} statut IN ({$active_placeholders})", $active_statuses ) );
+            $stats['pending'] = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM `{$clubs_table}` {$scope_prefix} statut IN ({$pending_placeholders})", $pending_statuses ) );
+        }
+
+        $doc_fields = self::get_available_document_fields( $columns, $clubs_table );
+        if ( ! empty( $doc_fields ) ) {
+            $doc_conditions = array();
+            foreach ( $doc_fields as $field ) {
+                $doc_conditions[] = "(`{$field}` IS NOT NULL AND `{$field}` != '')";
+            }
+            $scope_prefix = '' === $where_scope ? 'WHERE' : $where_scope . ' AND';
+            $complete_condition = '(' . implode( ' AND ', $doc_conditions ) . ')';
+            $stats['documents_complete'] = (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$clubs_table}` {$scope_prefix} {$complete_condition}" );
+            $stats['documents_incomplete'] = max( 0, $stats['total'] - $stats['documents_complete'] );
+        }
+
+        if ( self::has_column( $columns, $clubs_table, 'num_affiliation' ) ) {
+            $scope_prefix = '' === $where_scope ? 'WHERE' : $where_scope . ' AND';
+            $stats['missing_affiliation'] = (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$clubs_table}` {$scope_prefix} (num_affiliation IS NULL OR num_affiliation = '')" );
+        }
+
+        $cards = array(
+            array( 'label' => __( 'Clubs enregistrés', 'ufsc-clubs' ), 'value' => $stats['total'], 'tone' => 'primary' ),
+            array( 'label' => __( 'Clubs actifs', 'ufsc-clubs' ), 'value' => $stats['active'], 'tone' => 'success' ),
+            array( 'label' => __( 'Clubs en attente', 'ufsc-clubs' ), 'value' => $stats['pending'], 'tone' => 'warning' ),
+        );
+        if ( null !== $stats['documents_complete'] ) {
+            $cards[] = array( 'label' => __( 'Documents complets', 'ufsc-clubs' ), 'value' => $stats['documents_complete'], 'tone' => 'success' );
+            $cards[] = array( 'label' => __( 'Documents incomplets', 'ufsc-clubs' ), 'value' => $stats['documents_incomplete'], 'tone' => 'danger' );
+        }
+        $cards[] = array( 'label' => __( 'Licences associées', 'ufsc-clubs' ), 'value' => $stats['licences'], 'tone' => 'primary' );
+        if ( null !== $stats['missing_affiliation'] ) {
+            $cards[] = array( 'label' => __( 'Sans n° affiliation', 'ufsc-clubs' ), 'value' => $stats['missing_affiliation'], 'tone' => 'danger' );
+        }
+
+        echo '<div class="ufsc-stats-grid">';
+        foreach ( $cards as $card ) {
+            echo '<div class="ufsc-stat-card ufsc-stat-card--' . esc_attr( $card['tone'] ) . '">';
+            echo '<span>' . esc_html( $card['label'] ) . '</span>';
+            echo '<strong>' . esc_html( number_format_i18n( (int) $card['value'] ) ) . '</strong>';
+            echo '</div>';
+        }
+        echo '</div>';
+    }
+
+    /**
+     * Render filters and search in a single panel.
+     */
+    private static function render_filters( $filters, $columns, $clubs_table, $search = '' ) {
         echo '<div class="ufsc-filters-panel">';
+        echo '<div class="ufsc-panel-heading"><h2>' . esc_html__( 'Filtres de recherche', 'ufsc-clubs' ) . '</h2><p>' . esc_html__( 'Affinez la liste sans modifier les exports, la pagination ou les actions existantes.', 'ufsc-clubs' ) . '</p></div>';
         echo '<form method="get" class="ufsc-filters-form">';
         echo '<input type="hidden" name="page" value="ufsc-sql-clubs">';
 
-        echo '<div class="ufsc-filters-row">';
-
-        // Region filter
+        echo '<div class="ufsc-filters-grid">';
+        echo '<label><span>' . esc_html__( 'Région', 'ufsc-clubs' ) . '</span>';
         self::render_region_filter( $filters['region'], $columns, $clubs_table );
+        echo '</label>';
 
-        // Status filter
+        echo '<label><span>' . esc_html__( 'Statut', 'ufsc-clubs' ) . '</span>';
         self::render_status_filter( $filters['statut'] );
+        echo '</label>';
 
-        // Date range filters
-        self::render_date_filters( $filters['created_from'], $filters['created_to'] );
+        echo '<label><span>' . esc_html__( 'Créé du', 'ufsc-clubs' ) . '</span><input type="date" name="created_from" value="' . esc_attr( $filters['created_from'] ) . '"></label>';
+        echo '<label><span>' . esc_html__( 'Créé au', 'ufsc-clubs' ) . '</span><input type="date" name="created_to" value="' . esc_attr( $filters['created_to'] ) . '"></label>';
 
+        echo '<label><span>' . esc_html__( 'Recherche', 'ufsc-clubs' ) . '</span><input type="search" name="q" value="' . esc_attr( $search ) . '" placeholder="' . esc_attr__( 'Nom ou email...', 'ufsc-clubs' ) . '"></label>';
+
+        echo '<label><span>' . esc_html__( 'Documents', 'ufsc-clubs' ) . '</span><select name="doc_status">';
+        echo '<option value="">' . esc_html__( 'Tous', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="complete"' . selected( $filters['doc_status'], 'complete', false ) . '>' . esc_html__( 'Complets', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="incomplete"' . selected( $filters['doc_status'], 'incomplete', false ) . '>' . esc_html__( 'Incomplets', 'ufsc-clubs' ) . '</option>';
+        echo '</select></label>';
+
+        echo '<label><span>' . esc_html__( 'N° affiliation', 'ufsc-clubs' ) . '</span><select name="affiliation_status">';
+        echo '<option value="">' . esc_html__( 'Tous', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="assigned"' . selected( $filters['affiliation_status'], 'assigned', false ) . '>' . esc_html__( 'Attribué', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="missing"' . selected( $filters['affiliation_status'], 'missing', false ) . '>' . esc_html__( 'Non attribué', 'ufsc-clubs' ) . '</option>';
+        echo '</select></label>';
+
+        echo '<label><span>' . esc_html__( 'Licences', 'ufsc-clubs' ) . '</span><select name="licence_range">';
+        echo '<option value="">' . esc_html__( 'Toutes', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="zero"' . selected( $filters['licence_range'], 'zero', false ) . '>' . esc_html__( '0 licence', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="one_to_nine"' . selected( $filters['licence_range'], 'one_to_nine', false ) . '>' . esc_html__( '1 à 9 licences', 'ufsc-clubs' ) . '</option>';
+        echo '<option value="ten_plus"' . selected( $filters['licence_range'], 'ten_plus', false ) . '>' . esc_html__( '10 licences et +', 'ufsc-clubs' ) . '</option>';
+        echo '</select></label>';
+
+        $season_column = self::get_season_column( $columns, $clubs_table );
+        if ( '' !== $season_column ) {
+            echo '<label><span>' . esc_html__( 'Saison', 'ufsc-clubs' ) . '</span><input type="text" name="season" value="' . esc_attr( $filters['season'] ) . '" placeholder="' . esc_attr( self::get_admin_season_label() ) . '"></label>';
+        }
         echo '</div>';
 
         echo '<div class="ufsc-filters-actions">';
-        submit_button( __( 'Filtrer', 'ufsc-clubs' ), 'secondary', null, false );
-        echo ' <a href="' . esc_url( admin_url( 'admin.php?page=ufsc-sql-clubs' ) ) . '" class="button">' . esc_html__( 'Reset', 'ufsc-clubs' ) . '</a>';
+        submit_button( __( 'Filtrer', 'ufsc-clubs' ), 'primary', null, false );
+        echo ' <a href="' . esc_url( admin_url( 'admin.php?page=ufsc-sql-clubs' ) ) . '" class="button ufsc-reset-button">' . esc_html__( 'Réinitialiser', 'ufsc-clubs' ) . '</a>';
         echo '</div>';
 
         echo '</form>';
@@ -298,32 +527,41 @@ class UFSC_Clubs_List_Table {
     }
 
     /**
-     * Render search form
+     * Backward-compatible no-op search renderer: search now lives in the filter panel.
      */
     private static function render_search( $search ) {
-        echo '<div class="ufsc-search-panel">';
-        echo '<form method="get" class="ufsc-search-form">';
-        echo '<input type="hidden" name="page" value="ufsc-sql-clubs">';
+        unset( $search );
+    }
 
-        // Preserve current filters
-        foreach ( self::get_filters() as $key => $value ) {
-            if ( ! empty( $value ) ) {
-                echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( $value ) . '">';
-            }
+    /**
+     * Render quick GET filters above the table.
+     */
+    private static function render_quick_filters( $filters ) {
+        unset( $filters );
+        $base = admin_url( 'admin.php?page=ufsc-sql-clubs' );
+        $links = array(
+            array( 'label' => __( 'Tous les clubs', 'ufsc-clubs' ), 'args' => array() ),
+            array( 'label' => __( 'Actifs', 'ufsc-clubs' ), 'args' => array( 'statut' => 'actif' ) ),
+            array( 'label' => __( 'En attente', 'ufsc-clubs' ), 'args' => array( 'statut' => 'en_attente' ) ),
+            array( 'label' => __( 'Documents incomplets', 'ufsc-clubs' ), 'args' => array( 'doc_status' => 'incomplete' ) ),
+            array( 'label' => __( 'Sans n° affiliation', 'ufsc-clubs' ), 'args' => array( 'affiliation_status' => 'missing' ) ),
+            array( 'label' => __( 'Moins de 10 licences', 'ufsc-clubs' ), 'args' => array( 'licence_range' => 'under_ten' ) ),
+            array( 'label' => __( 'Clubs sans licence', 'ufsc-clubs' ), 'args' => array( 'licence_range' => 'zero' ) ),
+        );
+
+        echo '<div class="ufsc-quick-filters" aria-label="' . esc_attr__( 'Filtres rapides', 'ufsc-clubs' ) . '">';
+        foreach ( $links as $link ) {
+            $url = empty( $link['args'] ) ? $base : add_query_arg( $link['args'], $base );
+            echo '<a class="button" href="' . esc_url( $url ) . '">' . esc_html( $link['label'] ) . '</a>';
         }
-
-        echo '<input type="search" name="q" value="' . esc_attr( $search ) . '" placeholder="' . esc_attr__( 'Rechercher par nom ou email...', 'ufsc-clubs' ) . '">';
-        submit_button( __( 'Rechercher', 'ufsc-clubs' ), 'secondary', null, false );
-        echo '</form>';
         echo '</div>';
-        
     }
 
     //add action groppe
     // private static function bulck_action_grop_by_club(){
     //     echo '<form method="post" id="bulk-actions-form">';
     //     // Bulk actions
-    //     echo '<div class="ufsc-bulk-actions" style="margin: 15px 0;">';
+    //     echo '<div class="ufsc-bulk-actions">';
 
     //     wp_nonce_field('ufsc_bulk_actions');
     //     echo '<select name="bulk_action" id="bulk-action-selector">';
@@ -341,7 +579,7 @@ class UFSC_Clubs_List_Table {
      * Render results info
      */
     private static function render_results_info( $total_items, $pagination ) {
-        $start = ( ( $pagination['paged'] - 1 ) * $pagination['per_page'] ) + 1;
+        $start = $total_items > 0 ? ( ( $pagination['paged'] - 1 ) * $pagination['per_page'] ) + 1 : 0;
         $end = min( $pagination['paged'] * $pagination['per_page'], $total_items );
 
         echo '<div class="ufsc-results-info">';
@@ -381,7 +619,7 @@ class UFSC_Clubs_List_Table {
         echo '<form method="post" id="bulk-actions-form">';
         echo '<input type="hidden" name="page" value="ufsc-sql-clubs" />';
         // Bulk actions
-        echo '<div class="ufsc-bulk-actions" style="margin: 15px 0;">';
+        echo '<div class="ufsc-bulk-actions">';
 
         wp_nonce_field('ufsc_bulk_clubs_actions');
         echo '<select name="bulk_action" id="bulk-action-selector">';
@@ -390,12 +628,15 @@ class UFSC_Clubs_List_Table {
         echo '<option value="actif">'.esc_html__('Actif', 'ufsc-clubs').'</option>';
         echo '<option value="en_attente">'.esc_html__('En attente', 'ufsc-clubs').'</option>';
         echo '<option value="creating">'.esc_html__('En cours de création', 'ufsc-clubs').'</option>';
+        echo '<option value="export_selection" disabled="disabled">'.esc_html__('Exporter la sélection (bientôt)', 'ufsc-clubs').'</option>';
+        echo '<option value="remind_documents" disabled="disabled">'.esc_html__('Relance documents (bientôt)', 'ufsc-clubs').'</option>';
+        echo '<option value="remind_affiliation" disabled="disabled">'.esc_html__('Relance affiliation (bientôt)', 'ufsc-clubs').'</option>';
         echo '</select>';
         echo ' <button type="submit" class="button">'.esc_html__('Appliquer', 'ufsc-clubs').'</button>';
         echo '</div>';
 
         //table
-        echo '<table class="wp-list-table widefat fixed striped">';
+        echo '<table class="wp-list-table widefat fixed striped ufsc-clubs-table">';
         echo '<thead>';
         echo '<tr>';
         echo '<td class="check-column"><input type="checkbox" id="select-all-club" /></td>';
@@ -443,10 +684,11 @@ class UFSC_Clubs_List_Table {
     // Nom + Email
     $club_name = isset( $club->nom ) ? $club->nom : '';
     $club_email = isset( $club->email ) ? $club->email : '';
-    echo '<td><strong>' . esc_html( $club_name ) . '</strong>';
+    echo '<td class="ufsc-club-name-cell"><strong>' . esc_html( $club_name ) . '</strong>';
     if ( ! empty( $club_email ) ) {
         echo '<br><small>' . esc_html( $club_email ) . '</small>';
     }
+    echo self::render_alerts( $club, $licence_counts );
     echo '</td>';
 
     // Région
@@ -454,7 +696,7 @@ class UFSC_Clubs_List_Table {
 
     // Numéro d’affiliation
     echo '<td>';
-    echo ! empty( $club->num_affiliation ) ? esc_html( $club->num_affiliation ) : '<em>' . esc_html__( 'Non attribué', 'ufsc-clubs' ) . '</em>';
+    echo self::render_affiliation_number( isset( $club->num_affiliation ) ? $club->num_affiliation : '' );
     echo '</td>';
 
     // Statut
@@ -472,7 +714,8 @@ class UFSC_Clubs_List_Table {
         ),
         admin_url( 'admin.php' )
     );
-    echo '<td><a href="' . esc_url( $licence_url ) . '">' . esc_html( $licence_count ) . '</a></td>';
+    $licence_label = sprintf( _n( '%d licence', '%d licences', $licence_count, 'ufsc-clubs' ), $licence_count );
+    echo '<td><a class="ufsc-licence-link" href="' . esc_url( $licence_url ) . '">' . esc_html( $licence_label ) . '</a></td>';
 
     // Documents
     echo '<td>' . self::render_documents_badge( $club ) . '</td>';
@@ -482,7 +725,7 @@ class UFSC_Clubs_List_Table {
     echo '<td>' . ( $date_creation ? esc_html( mysql2date( 'd/m/Y', $date_creation ) ) : '<em>' . esc_html__( 'Non défini', 'ufsc-clubs' ) . '</em>' ) . '</td>';
 
     // Actions
-    echo '<td>';
+    echo '<td class="ufsc-row-actions">';
     $club_id = (int) ( $club->id ?? 0 );
     $view_url = admin_url( 'admin.php?page=ufsc-sql-clubs&action=view&id=' . $club_id );
     $edit_url = admin_url( 'admin.php?page=ufsc-sql-clubs&action=edit&id=' . $club_id );
@@ -490,9 +733,13 @@ class UFSC_Clubs_List_Table {
         admin_url( 'admin-post.php?action=ufsc_sql_delete_club&id=' . $club_id ),
         'ufsc_sql_delete_club'
     );
+    $documents_url = add_query_arg( array( 'page' => 'ufsc-sql-clubs', 'action' => 'edit', 'id' => $club_id, 'tab' => 'documents' ), admin_url( 'admin.php' ) );
     echo '<a href="' . esc_url( $view_url ) . '" class="button button-small">' . esc_html__( 'Consulter', 'ufsc-clubs' ) . '</a> ';
+    echo '<a href="' . esc_url( $licence_url ) . '" class="button button-small">' . esc_html__( 'Licences', 'ufsc-clubs' ) . '</a> ';
     if ( current_user_can( 'manage_options' ) ) {
         echo '<a href="' . esc_url( $edit_url ) . '" class="button button-small">' . esc_html__( 'Modifier', 'ufsc-clubs' ) . '</a> ';
+        echo '<a href="' . esc_url( $documents_url ) . '" class="button button-small">' . esc_html__( 'Documents', 'ufsc-clubs' ) . '</a> ';
+        echo '<button type="button" class="button button-small ufsc-button-disabled" disabled="disabled" title="' . esc_attr__( 'Relance à brancher sur une action email sécurisée existante.', 'ufsc-clubs' ) . '">' . esc_html__( 'Relancer', 'ufsc-clubs' ) . '</button> ';
         echo '<a href="' . esc_url( $delete_url ) . '" class="button button-small button-link-delete" onclick="return confirm(\'' . esc_js( __( 'Êtes-vous sûr de vouloir supprimer ce club ?', 'ufsc-clubs' ) ) . '\')">' . esc_html__( 'Supprimer', 'ufsc-clubs' ) . '</a>';
     }
     echo '</td>';
@@ -618,7 +865,23 @@ class UFSC_Clubs_List_Table {
     }
 
     private static function render_status_badge( $status ) {
-        return UFSC_Badges::render_club_badge( $status );
+        $raw        = is_scalar( $status ) ? (string) $status : '';
+        $normalized = sanitize_key( strtolower( remove_accents( $raw ) ) );
+        $label      = '' !== $raw ? $raw : __( 'Inconnu', 'ufsc-clubs' );
+        $class      = 'ufsc-badge ufsc-badge--neutral';
+
+        if ( in_array( $normalized, array( 'actif', 'active', 'valide', 'validated' ), true ) ) {
+            $label = __( 'Actif', 'ufsc-clubs' );
+            $class = 'ufsc-badge ufsc-badge--success';
+        } elseif ( in_array( $normalized, array( 'en_attente', 'pending', 'a_regler', 'creating', 'en_cours_de_creation' ), true ) ) {
+            $label = __( 'En attente', 'ufsc-clubs' );
+            $class = 'ufsc-badge ufsc-badge--warning';
+        } elseif ( in_array( $normalized, array( 'suspendu', 'suspended', 'refuse', 'rejected', 'desactive', 'inactive' ), true ) ) {
+            $label = __( 'Suspendu / refusé', 'ufsc-clubs' );
+            $class = 'ufsc-badge ufsc-badge--danger';
+        }
+
+        return '<span class="' . esc_attr( $class ) . '" data-status="' . esc_attr( $normalized ) . '">' . esc_html( $label ) . '</span>';
     }
 
     private static function render_documents_badge( $club ) {
@@ -641,12 +904,67 @@ class UFSC_Clubs_List_Table {
         }
 
         if ( $complete_count === $total_count ) {
-            return '<span class="ufsc-badge badge-success" title="' . esc_attr__( 'Documents complets', 'ufsc-clubs' ) . '">' .
+            return '<span class="ufsc-badge ufsc-badge--success" title="' . esc_attr__( 'Documents complets', 'ufsc-clubs' ) . '">' .
                    esc_html__( 'Complet', 'ufsc-clubs' ) . '</span>';
         } else {
-            return '<span class="ufsc-badge badge-warning" title="' . esc_attr( sprintf( __( '%d/%d documents', 'ufsc-clubs' ), $complete_count, $total_count ) ) . '">' .
+            return '<span class="ufsc-badge ufsc-badge--warning" title="' . esc_attr( sprintf( __( '%d/%d documents', 'ufsc-clubs' ), $complete_count, $total_count ) ) . '">' .
                    esc_html__( 'Incomplet', 'ufsc-clubs' ) . '</span>';
         }
+    }
+
+
+    private static function is_documents_complete( $club ) {
+        $doc_fields = array(
+            'doc_statuts',
+            'doc_recepisse',
+            'doc_jo',
+            'doc_pv_ag',
+            'doc_cer',
+            'doc_attestation_cer'
+        );
+        foreach ( $doc_fields as $field ) {
+            if ( ! isset( $club->$field ) || empty( $club->$field ) ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static function render_affiliation_number( $number ) {
+        $number = is_scalar( $number ) ? trim( (string) $number ) : '';
+        if ( '' === $number ) {
+            return '<span class="ufsc-badge ufsc-badge--muted">' . esc_html__( 'Non attribué', 'ufsc-clubs' ) . '</span>';
+        }
+        return '<span class="ufsc-affiliation-number">' . esc_html( $number ) . '</span>';
+    }
+
+    private static function render_alerts( $club, $licence_counts ) {
+        $club_id       = (int) ( $club->id ?? 0 );
+        $licence_count = isset( $licence_counts[ $club_id ] ) ? (int) $licence_counts[ $club_id ] : 0;
+        $alerts        = array();
+
+        if ( ! self::is_documents_complete( $club ) ) {
+            $alerts[] = __( 'Documents incomplets', 'ufsc-clubs' );
+        }
+        if ( empty( $club->num_affiliation ) ) {
+            $alerts[] = __( 'N° affiliation manquant', 'ufsc-clubs' );
+        }
+        if ( 0 === $licence_count ) {
+            $alerts[] = __( 'Club sans licence', 'ufsc-clubs' );
+        } elseif ( $licence_count < 10 ) {
+            $alerts[] = __( 'Moins de 10 licences', 'ufsc-clubs' );
+        }
+
+        if ( empty( $alerts ) ) {
+            return '';
+        }
+
+        $html = '<div class="ufsc-alert-tags">';
+        foreach ( $alerts as $alert ) {
+            $html .= '<span>' . esc_html( $alert ) . '</span>';
+        }
+        $html .= '</div>';
+        return $html;
     }
 
     /**
@@ -683,7 +1001,7 @@ class UFSC_Clubs_List_Table {
             return;
         }
 
-        if (!isset($_POST['_wpnonce']) || !wp_verify_nonce($_POST['_wpnonce'], 'ufsc_bulk_clubs_actions')) {
+        if (!isset($_POST['_wpnonce']) || !wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'ufsc_bulk_clubs_actions')) {
             return;
         }
 
@@ -699,7 +1017,7 @@ class UFSC_Clubs_List_Table {
         }
         $settings  = UFSC_SQL::get_settings();
         $table     = $settings['table_clubs'];
-        $action    = sanitize_text_field($_POST['bulk_action']);
+        $action    = isset( $_POST['bulk_action'] ) ? sanitize_key( wp_unslash( $_POST['bulk_action'] ) ) : '';
         $item_ids  = array_values( array_unique( array_filter( array_map( 'intval', (array) $_POST['club_ids'] ) ) ) );
         if ( empty( $item_ids ) ) {
             return;
@@ -732,7 +1050,7 @@ class UFSC_Clubs_List_Table {
         $deleteds = [];
         foreach ($item_ids as $item_id) {
             UFSC_Scope::assert_club_in_scope( $item_id );
-            $row = $wpdb->get_row( "SELECT count(*) as nb FROM `{$settings['table_licences']}` WHERE club_id = ". (int) $item_id );
+            $row = $wpdb->get_row( $wpdb->prepare( "SELECT count(*) as nb FROM `{$settings['table_licences']}` WHERE club_id = %d", $item_id ) );
             if($row->nb <= 0){
                 $deleteds[] = $item_id;
                 $wpdb->delete(


### PR DESCRIPTION
### Motivation
- Améliorer l'ergonomie, la lisibilité et le rendu professionnel de la page admin «Clubs UFSC — Affiliations et suivi administratif» tout en conservant strictement les fonctionnalités existantes (export, import, pagination, recherche, actions). 
- Afficher des KPI utiles en haut de page et des filtres avancés/rapides pour faciliter le suivi administratif des clubs dans l’interface WordPress.

### Description
- Ajout d’un habillage dédié et responsive pour la page Clubs : header/hero, pill saison, notice de renouvellement, cartes statistiques et panneau de filtres (`includes/admin/list-tables/class-ufsc-clubs-list-table.php`), plus création des assets `assets/admin/css/ufsc-clubs-admin.css` et `assets/admin/js/ufsc-clubs-admin.js` et enqueue uniquement sur la page Clubs (`includes/admin/class-admin-menu.php`).
- Filtres robustes et non intrusifs : lecture sécurisée des GET (`self::get_query_value`), filtres optionnels pour documents, `num_affiliation`, tranches de licences et `season` si la colonne existe, avec fallbacks pour éviter les erreurs SQL (`get_available_document_fields`, `get_season_column`, `get_licence_count_expression`).
- Cartes statistiques calculées de façon sûre (vérif colonnes, scope région) affichant : clubs total, actifs, en attente, documents complets/incomplets, licences totales, clubs sans n° affiliation (affichage conditionnel selon disponibilité des colonnes).
- Tableau amélioré sans casser `WP_List_Table` : nouvelle classe `ufsc-clubs-table`, statuts rendus en badges colorés, documents en badges, affichage lisible des licences (`0/1/X licences`), alertes non intrusives sous le nom (documents incomplets, n° manquant, moins de 10 licences, sans licence) et actions par ligne conservées (ajout visuel `Licences`/`Documents` et `Relancer` désactivé si non implémenté).
- Actions groupées conservées et enrichies visuellement (nouvelles options désactivées «Exporter la sélection», «Relance…» en TODO), sécurisation et petites corrections : `wpdb->prepare` pour requêtes dynamiques, nonce sanitization, `wp_unslash` + `sanitize_*` pour GET/POST.
- Ajouts utilitaires et refactorings locaux : fonctions `is_documents_complete`, `render_affiliation_number`, `render_alerts`, meilleur rendu du badge statut (normalisation), et déplacement/usage de `UFSC_CL_Utils::get_valid_licence_counts_by_club()` pour calculs.

### Testing
- Vérifications de syntaxe PHP réussies : `php -l includes/admin/list-tables/class-ufsc-clubs-list-table.php` et `php -l includes/admin/class-admin-menu.php` (OK).
- Contrôle de l’ensemble des fichiers list-tables PHP : `find includes/admin/list-tables -name '*.php' -print0 | xargs -0 -n1 php -l` (OK) et vérification JS : `node --check assets/admin/js/ufsc-clubs-admin.js` (OK).
- Contrôle de style/erreurs basiques : `git diff --check` (OK).
All tests listés ci‑dessus ont été exécutés et sont passés sans erreurs de syntaxe ou check automatique.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1856ddbbe8832b8e668f59f14732f2)