### PR TITLE
Add centralized UFSC permissions and regional access

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,100 @@
+# UFSC Gestion — rôles, droits et accès régionaux
+
+UFSC Gestion fournit un module centralisé de permissions pour l'écosystème UFSC. Les autres plugins UFSC peuvent consommer ces droits via les fonctions globales `ufsc_*` chargées par le plugin.
+
+## Rôles créés
+
+Les rôles sont créés de manière idempotente à l'activation et vérifiés en administration sans supprimer de droits ajoutés manuellement.
+
+| Rôle | Libellé | Droits par défaut |
+| --- | --- | --- |
+| `ufsc_region_viewer` | Lecture régionale | `read`, `ufsc_gestion_read`, `ufsc_licences_read` |
+| `ufsc_region_manager` | Gestion régionale | `read`, `ufsc_gestion_read`, `ufsc_gestion_manage`, `ufsc_licences_read`, `ufsc_licences_manage` |
+| `ufsc_competition_manager` | Gestion compétitions | `read`, `ufsc_gestion_read`, `ufsc_licences_read`, `ufsc_competitions_read`, `ufsc_competitions_manage` |
+| `ufsc_admin_limited` | Admin UFSC limité | `read`, `ufsc_gestion_read`, `ufsc_licences_read`, `ufsc_competitions_read`, `ufsc_competitions_manage` |
+
+Le rôle WordPress `administrator` reçoit toutes les capabilities UFSC sans retrait de ses droits WordPress existants.
+
+## Capabilities UFSC
+
+- `ufsc_gestion_read` : accès de consultation à UFSC Gestion.
+- `ufsc_gestion_manage` : actions de modification UFSC Gestion.
+- `ufsc_licences_read` : lecture des licences UFSC.
+- `ufsc_licences_manage` : modification des licences UFSC.
+- `ufsc_competitions_read` : lecture des compétitions.
+- `ufsc_competitions_manage` : gestion des compétitions.
+- `ufsc_settings_manage` : réglages sensibles UFSC.
+- `ufsc_regions_manage` : gestion des accès régionaux.
+- `ufsc_all_regions_access` : accès national à toutes les régions.
+
+## Lecture vs gestion
+
+Un utilisateur avec seulement `ufsc_gestion_read` peut voir les pages de consultation UFSC Gestion. Les actions de création, modification, suppression, import, validation et réglages doivent vérifier une capability de gestion côté serveur, principalement `ufsc_gestion_manage` ou `ufsc_settings_manage` selon la sensibilité de la page.
+
+Masquer un bouton n'est pas une protection suffisante : les handlers `POST`, AJAX et `admin_post` doivent également vérifier les droits.
+
+## Régions
+
+La liste des régions est exposée par :
+
+```php
+$regions = ufsc_get_regions();
+```
+
+Elle contient les régions françaises métropolitaines et ultramarines utilisées par l'UFSC et reste filtrable :
+
+```php
+add_filter( 'ufsc_regions_list', function( array $regions ) {
+    return $regions;
+} );
+```
+
+Les régions autorisées d'un utilisateur sont stockées dans la meta `_ufsc_allowed_regions`. L'accès national est accordé si l'utilisateur est administrateur WordPress, possède `ufsc_all_regions_access` ou a la meta `_ufsc_all_regions_access` à `1`.
+
+## Menu “Droits & accès”
+
+Le sous-menu **UFSC Gestion > Droits & accès** (`ufsc-permissions`) permet de :
+
+- voir les utilisateurs possédant un rôle UFSC ou une capability UFSC ;
+- attribuer ou retirer les capabilities UFSC autorisées ;
+- choisir les régions autorisées ;
+- activer l'accès toutes régions ;
+- sauvegarder avec nonce et whitelist stricte.
+
+Protections importantes :
+
+- un non-administrateur ne peut pas modifier un compte administrateur WordPress ;
+- un non-administrateur ne peut pas s'ajouter lui-même `ufsc_settings_manage`, `ufsc_regions_manage` ou `ufsc_all_regions_access` ;
+- aucune capability arbitraire envoyée depuis le navigateur n'est acceptée.
+
+## API pour autres plugins UFSC
+
+Vérifier une capability :
+
+```php
+if ( function_exists( 'ufsc_user_can' ) && ufsc_user_can( 'ufsc_competitions_manage' ) ) {
+    // Autoriser l'action compétition.
+}
+```
+
+Vérifier l'accès régional :
+
+```php
+if ( function_exists( 'ufsc_user_can_access_region' ) && ufsc_user_can_access_region( 'Bretagne' ) ) {
+    // Afficher ou modifier la donnée régionale.
+}
+```
+
+Obtenir les régions autorisées de l'utilisateur connecté :
+
+```php
+$regions = ufsc_current_user_allowed_regions();
+```
+
+Préparer prudemment un filtrage par régions :
+
+```php
+$args = ufsc_filter_query_by_allowed_regions( $args, 'region' );
+```
+
+Pour `WP_Query`, le helper ajoute une `meta_query`. Pour les requêtes SQL custom, le helper fournit `ufsc_allowed_regions` et `ufsc_region_field` afin que l'appelant construise explicitement le `WHERE` avec `$wpdb->prepare()`.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -23,8 +23,8 @@ Le rôle WordPress `administrator` reçoit toutes les capabilities UFSC sans ret
 - `ufsc_licences_manage` : modification des licences UFSC.
 - `ufsc_competitions_read` : lecture des compétitions.
 - `ufsc_competitions_manage` : gestion des compétitions.
-- `ufsc_settings_manage` : réglages sensibles UFSC.
-- `ufsc_regions_manage` : gestion des accès régionaux.
+- `ufsc_settings_manage` : réglages sensibles UFSC. Cette capability est conservée pour les pages de réglages et les évolutions futures, mais ne donne pas accès au menu **Droits & accès**.
+- `ufsc_regions_manage` : gestion des accès régionaux pour évolutions futures. Cette capability ne donne pas accès au menu **Droits & accès** dans la version actuelle.
 - `ufsc_all_regions_access` : accès national à toutes les régions.
 
 ## Lecture vs gestion
@@ -53,7 +53,9 @@ Les régions autorisées d'un utilisateur sont stockées dans la meta `_ufsc_all
 
 ## Menu “Droits & accès”
 
-Le sous-menu **UFSC Gestion > Droits & accès** (`ufsc-permissions`) permet de :
+Le sous-menu **UFSC Gestion > Droits & accès** (`ufsc-permissions`) est réservé exclusivement aux vrais administrateurs WordPress disposant de `manage_options`. Les capabilities UFSC `ufsc_settings_manage` et `ufsc_regions_manage` restent disponibles pour évolution future, mais ne permettent pas d'ouvrir cette page ni de gérer les droits d'autres utilisateurs.
+
+Ce menu permet aux administrateurs WordPress de :
 
 - voir les utilisateurs possédant un rôle UFSC ou une capability UFSC ;
 - attribuer ou retirer les capabilities UFSC autorisées ;
@@ -63,6 +65,8 @@ Le sous-menu **UFSC Gestion > Droits & accès** (`ufsc-permissions`) permet de :
 
 Protections importantes :
 
+- la visibilité du menu et l'accès serveur vérifient `current_user_can( 'manage_options' )` ;
+- aucun rôle UFSC limité ne peut gérer les droits d'autres utilisateurs ;
 - un non-administrateur ne peut pas modifier un compte administrateur WordPress ;
 - un non-administrateur ne peut pas s'ajouter lui-même `ufsc_settings_manage`, `ufsc_regions_manage` ou `ufsc_all_regions_access` ;
 - aucune capability arbitraire envoyée depuis le navigateur n'est acceptée.

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -97,7 +97,7 @@ if ( ! function_exists( 'ufsc_admin_date_to_wp_timestamp' ) ) {
     }
 }
 function ufsc_render_settings_page() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! ufsc_user_can( UFSC_Permissions::CAP_SETTINGS_MANAGE ) ) {
         wp_die( esc_html__( 'Accès refusé.', 'ufsc-clubs' ) );
     }
 

--- a/inc/woocommerce/settings-woocommerce.php
+++ b/inc/woocommerce/settings-woocommerce.php
@@ -110,7 +110,7 @@ function ufsc_validate_woocommerce_product( $product_id ) {
  * Render WooCommerce settings page
  */
 function ufsc_render_woocommerce_settings_page() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! ufsc_user_can( UFSC_Permissions::CAP_SETTINGS_MANAGE ) ) {
         wp_die( esc_html__( 'Accès refusé.', 'ufsc-clubs' ) );
     }
 

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -10,7 +10,7 @@ class UFSC_CL_Admin_Menu {
 		add_menu_page(
 			__( 'UFSC Gestion', 'ufsc-clubs' ),
 			__( 'UFSC Gestion', 'ufsc-clubs' ),
-			UFSC_Capabilities::CAP_MANAGE_READ,
+			UFSC_Permissions::CAP_GESTION_READ,
 			'ufsc-dashboard',
 			array( __CLASS__, 'render_dashboard' ),
 			'dashicons-groups',
@@ -22,7 +22,7 @@ class UFSC_CL_Admin_Menu {
 			'ufsc-dashboard',
 			__( 'Tableau de bord', 'ufsc-clubs' ),
 			__( 'Tableau de bord', 'ufsc-clubs' ),
-			UFSC_Capabilities::CAP_MANAGE_READ,
+			UFSC_Permissions::CAP_GESTION_READ,
 			'ufsc-dashboard',
 			array( __CLASS__, 'render_dashboard' )
 		);
@@ -31,7 +31,7 @@ class UFSC_CL_Admin_Menu {
 			'ufsc-dashboard',
 			__( 'Clubs', 'ufsc-clubs' ),
 			__( 'Clubs', 'ufsc-clubs' ),
-			UFSC_Capabilities::CAP_MANAGE_READ,
+			UFSC_Permissions::CAP_GESTION_READ,
 			'ufsc-clubs',
 			array( 'UFSC_SQL_Admin', 'render_clubs' )
 		);
@@ -40,7 +40,7 @@ class UFSC_CL_Admin_Menu {
 			'ufsc-dashboard',
 			__( 'Licences', 'ufsc-clubs' ),
 			__( 'Licences', 'ufsc-clubs' ),
-			UFSC_Capabilities::CAP_MANAGE_READ,
+			UFSC_Permissions::CAP_GESTION_READ,
 			'ufsc-licences',
 			array( 'UFSC_SQL_Admin', 'render_licences' )
 		);
@@ -49,7 +49,7 @@ class UFSC_CL_Admin_Menu {
 			'ufsc-dashboard',
 			__( 'Exports', 'ufsc-clubs' ),
 			__( 'Exports', 'ufsc-clubs' ),
-			UFSC_Capabilities::CAP_MANAGE_READ,
+			UFSC_Permissions::CAP_GESTION_READ,
 			'ufsc-exports',
 			array( 'UFSC_SQL_Admin', 'render_exports' )
 		);
@@ -58,7 +58,7 @@ class UFSC_CL_Admin_Menu {
 			'ufsc-dashboard',
 			__( 'Import', 'ufsc-clubs' ),
 			__( 'Import', 'ufsc-clubs' ),
-			UFSC_Capabilities::CAP_MANAGE_READ,
+			UFSC_Permissions::CAP_GESTION_MANAGE,
 			'ufsc-import',
 			array( 'UFSC_SQL_Admin', 'render_import' )
 		);
@@ -67,7 +67,7 @@ class UFSC_CL_Admin_Menu {
 			'ufsc-dashboard',
 			__( 'Paramètres', 'ufsc-clubs' ),
 			__( 'Paramètres', 'ufsc-clubs' ),
-			UFSC_Capabilities::CAP_MANAGE_READ,
+			UFSC_Permissions::CAP_SETTINGS_MANAGE,
 			'ufsc-settings',
 			array( 'UFSC_Settings_Page', 'render' )
 		);
@@ -76,7 +76,7 @@ class UFSC_CL_Admin_Menu {
 			'ufsc-dashboard',
 			__( 'WooCommerce', 'ufsc-clubs' ),
 			__( 'WooCommerce', 'ufsc-clubs' ),
-			UFSC_Capabilities::CAP_MANAGE_READ,
+			UFSC_Permissions::CAP_SETTINGS_MANAGE,
 			'ufsc-woocommerce',
 			array( 'UFSC_SQL_Admin', 'render_woocommerce_settings' )
 		);
@@ -173,7 +173,7 @@ class UFSC_CL_Admin_Menu {
 		echo '</div>';
 
 		// Cache refresh button
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
 			$refresh_url = add_query_arg( 'ufsc_refresh_cache', '1', admin_url( 'admin.php?page=ufsc-dashboard' ) );
 			$refresh_url = wp_nonce_url( $refresh_url, 'ufsc_refresh_cache' );
 			echo '<a href="' . esc_url( $refresh_url ) . '" class="button" style="color: white; border-color: rgba(255,255,255,0.3);" title="' . esc_attr__( 'Actualiser les données (cache: 10 min)', 'ufsc-clubs' ) . '">' . esc_html__( '⟳ Actualiser', 'ufsc-clubs' ) . '</a>';
@@ -182,7 +182,7 @@ class UFSC_CL_Admin_Menu {
 		echo '</div>';
 
 		// Handle cache refresh
-		if ( isset( $_GET['ufsc_refresh_cache'] ) && current_user_can( 'manage_options' ) ) {
+		if ( isset( $_GET['ufsc_refresh_cache'] ) && ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
 			check_admin_referer( 'ufsc_refresh_cache' );
 			self::clear_dashboard_cache();
 
@@ -386,7 +386,7 @@ class UFSC_CL_Admin_Menu {
 		// Actions rapides améliorées
 		echo '<div class="ufsc-quick-actions" style="margin-top: 30px;">';
 		echo '<h2>' . esc_html__( 'Actions Rapides', 'ufsc-clubs' ) . '</h2>';
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
 			echo '<div class="ufsc-button-group" style="gap: 12px; flex-wrap: wrap; margin-top: 15px;">';
 			echo '<a href="' . esc_url( admin_url( 'admin.php?page=ufsc-sql-clubs&action=new' ) ) . '" class="button button-primary">' . esc_html__( 'Nouveau Club', 'ufsc-clubs' ) . '</a>';
 			echo '<a href="' . esc_url( admin_url( 'admin.php?page=ufsc-sql-licences&action=new' ) ) . '" class="button button-primary">' . esc_html__( 'Nouvelle Licence', 'ufsc-clubs' ) . '</a>';

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -735,19 +735,19 @@ class UFSC_SQL_Admin
     public static function register_hidden_pages()
     {
         // Enregistrer les pages cachées pour les actions directes (mentionnées dans les specs)
-        add_submenu_page('', __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-clubs', [__CLASS__, 'render_clubs']);
-        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
+        add_submenu_page('', __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-clubs', [__CLASS__, 'render_clubs']);
+        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
         // Alias pour compatibilité avec la spec (licenses vs licences)
-        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-licenses', [__CLASS__, 'render_licences']);
+        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-licenses', [__CLASS__, 'render_licences']);
     }
 
     /* ---------------- Menus complets (obsolète - remplacé par menu unifié) ---------------- */
     public static function register_menus()
     {
-        add_menu_page(__('UFSC – Données (SQL)', 'ufsc-clubs'), __('UFSC – Données (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql', [__CLASS__, 'render_dashboard'], 'dashicons-database', 59);
-        add_submenu_page('ufsc-sql', __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-clubs', [__CLASS__, 'render_clubs']);
-        add_submenu_page('ufsc-sql', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
-        add_submenu_page('ufsc-sql', __('Réglages (SQL)', 'ufsc-clubs'), __('Réglages (SQL)', 'ufsc-clubs'), UFSC_Capabilities::CAP_MANAGE_READ, 'ufsc-sql-settings', [__CLASS__, 'render_settings']);
+        add_menu_page(__('UFSC – Données (SQL)', 'ufsc-clubs'), __('UFSC – Données (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql', [__CLASS__, 'render_dashboard'], 'dashicons-database', 59);
+        add_submenu_page('ufsc-sql', __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-clubs', [__CLASS__, 'render_clubs']);
+        add_submenu_page('ufsc-sql', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
+        add_submenu_page('ufsc-sql', __('Réglages (SQL)', 'ufsc-clubs'), __('Réglages (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_SETTINGS_MANAGE, 'ufsc-sql-settings', [__CLASS__, 'render_settings']);
     }
 
     /* ---------------- Dashboard ---------------- */
@@ -796,7 +796,7 @@ class UFSC_SQL_Admin
     /* ---------------- Liste Clubs ---------------- */
     public static function render_clubs()
     {
-        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_MANAGE_READ ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_READ ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         // Handle save first
@@ -805,18 +805,24 @@ class UFSC_SQL_Admin
         }
         // Check if we should show edit/new form
         if (isset($_GET['action']) && $_GET['action'] === 'edit') {
-            if ( ! current_user_can( 'manage_options' ) ) {
+            if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
                 wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
             }
             $id = (int) $_GET['id'];
+            if ( ! self::current_user_can_access_club_region( $id ) ) {
+                wp_die( __( 'Accès refusé : ce club appartient à une région non autorisée.', 'ufsc-clubs' ) );
+            }
             self::render_club_form($id);
             return;
         } elseif (isset($_GET['action']) && $_GET['action'] === 'view') {
             $id = (int) $_GET['id'];
+            if ( ! self::current_user_can_access_club_region( $id ) ) {
+                wp_die( __( 'Accès refusé : ce club appartient à une région non autorisée.', 'ufsc-clubs' ) );
+            }
             self::render_club_form($id, true); // true = readonly mode
             return;
         } elseif (isset($_GET['action']) && $_GET['action'] === 'new') {
-            if ( ! current_user_can( 'manage_options' ) ) {
+            if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
                 wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
             }
             self::render_club_form(0);
@@ -830,14 +836,45 @@ class UFSC_SQL_Admin
         UFSC_Clubs_List_Table::render();
     }
 
+
+    /**
+     * Check current user's regional access to a club row when the SQL table exposes a region column.
+     *
+     * @param int $club_id Club ID.
+     * @return bool
+     */
+    private static function current_user_can_access_club_region( $club_id ) {
+        $club_id = absint( $club_id );
+        if ( ! $club_id || ! function_exists( 'ufsc_user_has_all_regions_access' ) || ufsc_user_has_all_regions_access() ) {
+            return true;
+        }
+
+        global $wpdb;
+        $settings = UFSC_SQL::get_settings();
+        $table    = $settings['table_clubs'];
+        $pk       = $settings['pk_club'];
+        $columns  = self::get_table_columns( $table );
+
+        if ( ! in_array( 'region', $columns, true ) ) {
+            return true;
+        }
+
+        $region = $wpdb->get_var( $wpdb->prepare( "SELECT `region` FROM `{$table}` WHERE `{$pk}` = %d", $club_id ) );
+        if ( '' === (string) $region ) {
+            return true;
+        }
+
+        return function_exists( 'ufsc_is_region_allowed_for_current_user' ) && ufsc_is_region_allowed_for_current_user( (string) $region );
+    }
+
     /* ---------------- Handle clubs export ---------------- */
 
     private static function handle_clubs_export()
     {
-        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_MANAGE_READ ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_READ ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         global $wpdb;
@@ -1357,7 +1394,7 @@ class UFSC_SQL_Admin
             echo '</form>';
         } else {
             echo '<p><a class="button" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-clubs')) . '">' . esc_html__('Retour à la liste', 'ufsc-clubs') . '</a>';
-            if (current_user_can('manage_options')) {
+            if (ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )) {
                 echo ' <a class="button button-primary" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-clubs&action=edit&id=' . $id)) . '">' . esc_html__('Modifier', 'ufsc-clubs') . '</a>';
             }
             echo '</p>';
@@ -1551,7 +1588,7 @@ class UFSC_SQL_Admin
         $id      = isset($_POST['id']) ? (int) $_POST['id'] : 0;
 
         // Permission check to ensure user can manage this club
-        if (! current_user_can('manage_options') && ufsc_get_user_club_id($user_id) !== $id) {
+        if (! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) && ufsc_get_user_club_id($user_id) !== $id) {
             set_transient('ufsc_error_' . $user_id, __('Permissions insuffisantes', 'ufsc-clubs'), 30);
             self::maybe_redirect(wp_get_referer());
             return; // Abort processing if user lacks rights
@@ -1571,8 +1608,14 @@ class UFSC_SQL_Admin
         }
         if ( $id ) {
             UFSC_Scope::assert_club_in_scope( $id );
+            if ( ! self::current_user_can_access_club_region( $id ) ) {
+                wp_die( __( 'Accès refusé : ce club appartient à une région non autorisée.', 'ufsc-clubs' ) );
+            }
         } elseif ( isset( $data['region'] ) ) {
             UFSC_Scope::assert_in_scope( $data['region'] );
+            if ( function_exists( 'ufsc_user_can_access_region' ) && ! ufsc_user_can_access_region( $data['region'] ) ) {
+                wp_die( __( 'Accès refusé : région non autorisée.', 'ufsc-clubs' ) );
+            }
         }
         if (! isset($data['statut']) || $data['statut'] === '') {
             $data['statut'] = 'en_attente';
@@ -1667,7 +1710,7 @@ class UFSC_SQL_Admin
             if ($id) {
                 self::handle_club_document_uploads($id);
 
-                $can_manage_docs = current_user_can('manage_options') || current_user_can('edit_post', $id) || (class_exists('UFSC_Capabilities') && UFSC_Capabilities::user_can(UFSC_Capabilities::CAP_MANAGE_READ));
+                $can_manage_docs = ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) || current_user_can('edit_post', $id) || (class_exists('UFSC_Capabilities') && UFSC_Capabilities::user_can(UFSC_Capabilities::CAP_MANAGE_READ));
                 $has_docs_nonce  = isset($_POST['ufsc_club_docs_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['ufsc_club_docs_nonce'])), 'ufsc_club_docs_action');
                 $doc_errors      = [];
 
@@ -1943,7 +1986,7 @@ class UFSC_SQL_Admin
         if (! current_user_can('read')) {
             wp_die(__('Accès refusé.', 'ufsc-clubs'));
         }
-        if (! current_user_can('manage_options')) {
+        if (! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )) {
             wp_die('Accès refusé');
         }
         check_admin_referer('ufsc_sql_delete_club');
@@ -2272,7 +2315,7 @@ class UFSC_SQL_Admin
 
     public static function render_licences()
     {
-        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_MANAGE_READ ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_READ ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
 
@@ -2469,13 +2512,13 @@ class UFSC_SQL_Admin
         // Add nonce for AJAX operations
         echo '<input type="hidden" id="ufsc-ajax-nonce" value="' . wp_create_nonce('ufsc_ajax_nonce') . '" />';
 
-        if ( current_user_can( 'manage_options' ) ) {
+        if ( ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
             echo '<p><a href="' . esc_url(admin_url('admin.php?page=ufsc-sql-licences&action=new')) . '" class="button button-primary">' . esc_html__('Ajouter une licence', 'ufsc-clubs') . '</a> ';
             echo '<a href="' . esc_url(admin_url('admin.php?page=ufsc-exports')) . '" class="button">' . esc_html__('Exporter', 'ufsc-clubs') . '</a></p>';
         }
 
         if (isset($_GET['action']) && $_GET['action'] === 'edit') {
-            if ( ! current_user_can( 'manage_options' ) ) {
+            if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
                 wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
             }
             $id = (int) $_GET['id'];
@@ -2488,7 +2531,7 @@ class UFSC_SQL_Admin
             echo '</div>';
             return;
         } elseif (isset($_GET['action']) && $_GET['action'] === 'new') {
-            if ( ! current_user_can( 'manage_options' ) ) {
+            if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
                 wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
             }
             self::render_licence_form(0);
@@ -2986,7 +3029,7 @@ class UFSC_SQL_Admin
             echo '</form>';
         } else {
             echo '<p><a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Retour à la liste', 'ufsc-clubs') . '</a>';
-            if (current_user_can('manage_options')) {
+            if (ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )) {
                 echo ' <a class="button button-primary" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-licences&action=edit&id=' . $id . '&return_to=' . rawurlencode( $return_url ))) . '">' . esc_html__('Modifier', 'ufsc-clubs') . '</a>';
             }
             echo '</p>';
@@ -3236,7 +3279,7 @@ class UFSC_SQL_Admin
         }
 
         // Vérifier droits sur le club
-        if (! current_user_can('manage_options') && ufsc_get_user_club_id($user_id) !== $club_id) {
+        if (! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) && ufsc_get_user_club_id($user_id) !== $club_id) {
             set_transient('ufsc_error_' . $user_id, __('Permissions insuffisantes', 'ufsc-clubs'), 30);
             self::maybe_redirect(wp_get_referer());
             return;
@@ -3434,7 +3477,7 @@ class UFSC_SQL_Admin
         if (! current_user_can('read')) {
             wp_die(__('Accès refusé.', 'ufsc-clubs'));
         }
-        if (! current_user_can('manage_options')) {
+        if (! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )) {
             wp_die('Accès refusé');
         }
 
@@ -3678,7 +3721,7 @@ class UFSC_SQL_Admin
 
     public static function handle_delete_licence()
     {
-        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) ) {
+        if ( ! ( UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) || ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE ) ) ) {
             wp_die(__('Accès refusé.', 'ufsc-clubs'));
         }
 
@@ -3688,7 +3731,8 @@ class UFSC_SQL_Admin
 
     public static function handle_trash_licence( $check_nonce = true ) {
         $can_manage_licences = ( class_exists( 'UFSC_Capabilities' ) && UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) )
-            || current_user_can( 'manage_options' );
+            || ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE )
+            || ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE );
         if ( ! $can_manage_licences ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
@@ -3770,7 +3814,7 @@ class UFSC_SQL_Admin
     }
 
     public static function handle_restore_licence() {
-        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) ) {
+        if ( ! ( UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) || ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE ) ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         check_admin_referer( 'ufsc_sql_restore_licence' );
@@ -3817,7 +3861,7 @@ class UFSC_SQL_Admin
     }
 
     public static function handle_force_delete_licence() {
-        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) ) {
+        if ( ! ( UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) || ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE ) ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         check_admin_referer( 'ufsc_sql_force_delete_licence' );
@@ -3869,7 +3913,7 @@ class UFSC_SQL_Admin
     public static function handle_ajax_update_licence_status()
     {
         // Check nonce and permissions
-        if (! wp_verify_nonce($_POST['nonce'], 'ufsc_ajax_nonce') || ! current_user_can('manage_options')) {
+        if (! wp_verify_nonce($_POST['nonce'], 'ufsc_ajax_nonce') || ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )) {
             wp_die();
         }
 
@@ -3938,7 +3982,7 @@ class UFSC_SQL_Admin
     public static function handle_ajax_send_to_payment()
     {
         // Check nonce and permissions
-        if (! wp_verify_nonce($_POST['nonce'], 'ufsc_ajax_nonce') || ! current_user_can('manage_options')) {
+        if (! wp_verify_nonce($_POST['nonce'], 'ufsc_ajax_nonce') || ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )) {
             wp_die();
         }
 
@@ -4065,7 +4109,7 @@ class UFSC_SQL_Admin
         if (! current_user_can('read')) {
             wp_die(__('Accès refusé.', 'ufsc-clubs'));
         }
-        if (! current_user_can('manage_options')) {
+        if (! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )) {
             wp_die('Accès refusé');
         }
         check_admin_referer('ufsc_export_data');
@@ -4273,10 +4317,10 @@ class UFSC_SQL_Admin
      */
     public static function render_exports()
     {
-        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_MANAGE_READ ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_READ ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         echo '<div class="wrap">';
@@ -4427,10 +4471,10 @@ class UFSC_SQL_Admin
      */
     public static function render_import()
     {
-        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_MANAGE_READ ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_READ ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         echo '<div class="wrap">';
@@ -4715,7 +4759,7 @@ class UFSC_SQL_Admin
      */
     public static function handle_import_data()
     {
-        if (! current_user_can('manage_options')) {
+        if (! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )) {
             wp_die('Accès refusé');
         }
 
@@ -4760,7 +4804,7 @@ class UFSC_SQL_Admin
      */
     public static function handle_process_import()
     {
-        if (! current_user_can('manage_options')) {
+        if (! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )) {
             wp_die('Accès refusé');
         }
 
@@ -5255,7 +5299,7 @@ class UFSC_SQL_Admin
             self::debug_log_bulk_licences( 'Invalid nonce.' );
             self::maybe_redirect( add_query_arg( array( 'bulk_message' => 'invalid_nonce' ), $redirect_base ) );
         }
-        if ( ! UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) ) {
+        if ( ! ( UFSC_Capabilities::user_can( UFSC_Capabilities::CAP_LICENCE_EDIT ) || ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE ) ) ) {
             self::debug_log_bulk_licences( 'Forbidden action.' );
             self::maybe_redirect( add_query_arg( array( 'bulk_message' => 'forbidden' ), $redirect_base ) );
         }

--- a/includes/admin/list-tables/class-ufsc-clubs-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-clubs-list-table.php
@@ -81,6 +81,9 @@ class UFSC_Clubs_List_Table {
         echo '<div class="ufsc-season-pill"><span>' . esc_html__( 'Saison affichée', 'ufsc-clubs' ) . '</span><strong>' . esc_html( self::get_admin_season_label() ) . '</strong></div>';
         echo '</div>';
         echo '<div class="ufsc-renewal-notice"><span class="dashicons dashicons-info"></span><p>' . esc_html__( 'Renouvellement des affiliations : à chaque nouvelle saison, les clubs devront confirmer ou renouveler leur affiliation afin de maintenir leurs licences actives.', 'ufsc-clubs' ) . '</p></div>';
+        if ( function_exists( 'ufsc_user_has_all_regions_access' ) && ! ufsc_user_has_all_regions_access() ) {
+            echo '<div class="notice notice-info"><p>' . esc_html__( 'Résultats filtrés selon vos régions UFSC autorisées.', 'ufsc-clubs' ) . '</p></div>';
+        }
 
         // Affichage des notices
         if ( '1' === self::get_query_value( 'updated', 'key' ) ) {
@@ -306,6 +309,16 @@ class UFSC_Clubs_List_Table {
             if ( $scope_condition ) {
                 $conditions[] = $scope_condition;
             }
+
+            if ( function_exists( 'ufsc_user_has_all_regions_access' ) && ! ufsc_user_has_all_regions_access() ) {
+                $allowed_regions = function_exists( 'ufsc_current_user_allowed_regions' ) ? ufsc_current_user_allowed_regions() : array();
+                if ( empty( $allowed_regions ) ) {
+                    $conditions[] = '1 = 0';
+                } else {
+                    $placeholders = implode( ',', array_fill( 0, count( $allowed_regions ), '%s' ) );
+                    $conditions[] = $wpdb->prepare( "region IN ({$placeholders})", $allowed_regions );
+                }
+            }
         }
 
         return $conditions;
@@ -430,7 +443,7 @@ class UFSC_Clubs_List_Table {
      * Render action buttons
      */
     private static function render_action_buttons() {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
             return;
         }
         echo '<p class="ufsc-primary-actions">';
@@ -795,7 +808,7 @@ class UFSC_Clubs_List_Table {
     $documents_url = add_query_arg( array( 'page' => 'ufsc-sql-clubs', 'action' => 'edit', 'id' => $club_id, 'tab' => 'documents' ), admin_url( 'admin.php' ) );
     echo '<a href="' . esc_url( $view_url ) . '" class="button button-small">' . esc_html__( 'Consulter', 'ufsc-clubs' ) . '</a> ';
     echo '<a href="' . esc_url( $licence_url ) . '" class="button button-small">' . esc_html__( 'Licences', 'ufsc-clubs' ) . '</a> ';
-    if ( current_user_can( 'manage_options' ) ) {
+    if ( ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
         echo '<a href="' . esc_url( $edit_url ) . '" class="button button-small">' . esc_html__( 'Modifier', 'ufsc-clubs' ) . '</a> ';
         echo '<a href="' . esc_url( $documents_url ) . '" class="button button-small">' . esc_html__( 'Documents', 'ufsc-clubs' ) . '</a> ';
         echo '<button type="button" class="button button-small ufsc-button-disabled" disabled="disabled" aria-disabled="true" title="' . esc_attr__( 'Relance à brancher sur une action email sécurisée existante.', 'ufsc-clubs' ) . '">' . esc_html__( 'Relancer', 'ufsc-clubs' ) . '</button> ';
@@ -865,12 +878,14 @@ class UFSC_Clubs_List_Table {
         $scope_label = $scope_slug ? UFSC_Scope::get_region_label( $scope_slug ) : '';
         if ( $scope_label ) {
             $regions = array( $scope_label );
+        } elseif ( function_exists( 'ufsc_user_has_all_regions_access' ) && ! ufsc_user_has_all_regions_access() ) {
+            $regions = function_exists( 'ufsc_current_user_allowed_regions' ) ? ufsc_current_user_allowed_regions() : array();
         } else {
             $regions = $wpdb->get_col( "SELECT DISTINCT region FROM `{$clubs_table}` WHERE region IS NOT NULL AND region != '' ORDER BY region" );
         }
 
         echo '<select name="region">';
-        if ( ! $scope_label ) {
+        if ( ! $scope_label && ( ! function_exists( 'ufsc_user_has_all_regions_access' ) || ufsc_user_has_all_regions_access() ) ) {
             echo '<option value="">' . esc_html__( '— Toutes les régions —', 'ufsc-clubs' ) . '</option>';
         }
         foreach ( $regions as $region ) {
@@ -1056,7 +1071,7 @@ class UFSC_Clubs_List_Table {
         if ( 'ufsc-sql-clubs' !== $page ) {
             return;
         }
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
             return;
         }
 

--- a/includes/admin/list-tables/class-ufsc-licences-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-licences-list-table.php
@@ -295,7 +295,7 @@ class UFSC_Licences_List_Table {
      * Render action buttons
      */
     private static function render_action_buttons() {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
             return;
         }
         echo '<p>';
@@ -499,7 +499,7 @@ class UFSC_Licences_List_Table {
         $view_url = admin_url( 'admin.php?page=ufsc-sql-licences&action=view&id=' . $licence->id );
         $edit_url = admin_url( 'admin.php?page=ufsc-sql-licences&action=edit&id=' . $licence->id );
         echo '<a href="' . esc_url( $view_url ) . '" class="button button-small">' . esc_html__( 'Consulter', 'ufsc-clubs' ) . '</a> ';
-        if ( current_user_can( 'manage_options' ) ) {
+        if ( ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
             echo '<a href="' . esc_url( $edit_url ) . '" class="button button-small">' . esc_html__( 'Modifier', 'ufsc-clubs' ) . '</a>';
         }
         echo '</td>';

--- a/includes/permissions/class-ufsc-permissions.php
+++ b/includes/permissions/class-ufsc-permissions.php
@@ -17,7 +17,6 @@ class UFSC_Permissions {
     const CAP_SETTINGS_MANAGE       = 'ufsc_settings_manage';
     const CAP_REGIONS_MANAGE        = 'ufsc_regions_manage';
     const CAP_ALL_REGIONS_ACCESS    = 'ufsc_all_regions_access';
-    const CAP_PERMISSIONS_PAGE      = 'ufsc_permissions_page_access';
 
     /**
      * Bootstrap hooks.
@@ -25,7 +24,6 @@ class UFSC_Permissions {
     public static function init() {
         add_action( 'admin_init', array( __CLASS__, 'maybe_register_roles_and_caps' ) );
         add_action( 'admin_menu', array( __CLASS__, 'register_permissions_page' ), 30 );
-        add_filter( 'user_has_cap', array( __CLASS__, 'grant_virtual_caps' ), 10, 4 );
     }
 
     /**
@@ -68,7 +66,6 @@ class UFSC_Permissions {
             foreach ( self::get_capabilities() as $cap ) {
                 $administrator->add_cap( $cap );
             }
-            $administrator->add_cap( self::CAP_PERMISSIONS_PAGE );
         }
     }
 
@@ -136,23 +133,6 @@ class UFSC_Permissions {
     }
 
     /**
-     * Grant virtual OR capability for the Droits & accès page.
-     */
-    public static function grant_virtual_caps( $allcaps, $caps, $args, $user ) {
-        if ( ! is_array( $allcaps ) || empty( $args[0] ) || self::CAP_PERMISSIONS_PAGE !== $args[0] ) {
-            return $allcaps;
-        }
-
-        $user_id = $user instanceof WP_User ? (int) $user->ID : 0;
-        if ( $user_id && self::current_user_can_manage_permissions( $user_id ) ) {
-            $allcaps[ self::CAP_PERMISSIONS_PAGE ] = true;
-        }
-
-        return $allcaps;
-    }
-
-
-    /**
      * Check the immutable WordPress administrator role/capability.
      */
     public static function is_wordpress_administrator( $user_id = null ) {
@@ -165,17 +145,11 @@ class UFSC_Permissions {
     }
 
     /**
-     * Whether a user may open the permissions page.
+     * Whether the current user may open the permissions page.
      */
     public static function current_user_can_manage_permissions( $user_id = null ) {
-        $user_id = $user_id ? absint( $user_id ) : get_current_user_id();
-        if ( ! $user_id ) {
-            return false;
-        }
-        if ( self::is_wordpress_administrator( $user_id ) ) {
-            return true;
-        }
-        return user_can( $user_id, self::CAP_SETTINGS_MANAGE ) || user_can( $user_id, self::CAP_REGIONS_MANAGE );
+        unset( $user_id );
+        return current_user_can( 'manage_options' );
     }
 
     /**
@@ -186,7 +160,7 @@ class UFSC_Permissions {
             'ufsc-dashboard',
             __( 'Droits & accès', 'ufsc-clubs' ),
             __( 'Droits & accès', 'ufsc-clubs' ),
-            self::CAP_PERMISSIONS_PAGE,
+            'manage_options',
             'ufsc-permissions',
             array( __CLASS__, 'render_permissions_page' )
         );
@@ -196,8 +170,8 @@ class UFSC_Permissions {
      * Render and handle the permissions page.
      */
     public static function render_permissions_page() {
-        if ( ! self::current_user_can_manage_permissions() ) {
-            wp_die( esc_html__( 'Accès refusé : vous ne pouvez pas gérer les droits UFSC.', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Accès refusé : seuls les administrateurs WordPress peuvent gérer les droits UFSC.', 'ufsc-clubs' ) );
         }
 
         $notice = self::maybe_handle_permissions_save();
@@ -233,8 +207,8 @@ class UFSC_Permissions {
 
         check_admin_referer( 'ufsc_save_user_permissions', 'ufsc_permissions_nonce' );
 
-        if ( ! self::current_user_can_manage_permissions() ) {
-            wp_die( esc_html__( 'Accès refusé.', 'ufsc-clubs' ) );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Accès refusé : seuls les administrateurs WordPress peuvent gérer les droits UFSC.', 'ufsc-clubs' ) );
         }
 
         $target_user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;

--- a/includes/permissions/class-ufsc-permissions.php
+++ b/includes/permissions/class-ufsc-permissions.php
@@ -1,0 +1,549 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Central UFSC permissions, roles and regional access registry.
+ */
+class UFSC_Permissions {
+    const META_ALLOWED_REGIONS = '_ufsc_allowed_regions';
+    const META_ALL_REGIONS     = '_ufsc_all_regions_access';
+
+    const CAP_GESTION_READ          = 'ufsc_gestion_read';
+    const CAP_GESTION_MANAGE        = 'ufsc_gestion_manage';
+    const CAP_LICENCES_READ         = 'ufsc_licences_read';
+    const CAP_LICENCES_MANAGE       = 'ufsc_licences_manage';
+    const CAP_COMPETITIONS_READ     = 'ufsc_competitions_read';
+    const CAP_COMPETITIONS_MANAGE   = 'ufsc_competitions_manage';
+    const CAP_SETTINGS_MANAGE       = 'ufsc_settings_manage';
+    const CAP_REGIONS_MANAGE        = 'ufsc_regions_manage';
+    const CAP_ALL_REGIONS_ACCESS    = 'ufsc_all_regions_access';
+    const CAP_PERMISSIONS_PAGE      = 'ufsc_permissions_page_access';
+
+    /**
+     * Bootstrap hooks.
+     */
+    public static function init() {
+        add_action( 'admin_init', array( __CLASS__, 'maybe_register_roles_and_caps' ) );
+        add_action( 'admin_menu', array( __CLASS__, 'register_permissions_page' ), 30 );
+        add_filter( 'user_has_cap', array( __CLASS__, 'grant_virtual_caps' ), 10, 4 );
+    }
+
+    /**
+     * Idempotent role/capability registration.
+     */
+    public static function maybe_register_roles_and_caps() {
+        $version = '2026-05-29-1';
+        if ( get_option( 'ufsc_permissions_caps_version' ) === $version ) {
+            return;
+        }
+
+        self::register_roles_and_caps();
+        update_option( 'ufsc_permissions_caps_version', $version, false );
+    }
+
+    /**
+     * Register roles and capabilities without removing existing custom grants.
+     */
+    public static function register_roles_and_caps() {
+        $role_caps = self::get_role_capabilities();
+
+        foreach ( $role_caps as $role_key => $config ) {
+            $role = get_role( $role_key );
+            if ( ! $role ) {
+                add_role( $role_key, $config['label'], $config['caps'] );
+                $role = get_role( $role_key );
+            }
+
+            if ( $role ) {
+                foreach ( $config['caps'] as $cap => $grant ) {
+                    if ( $grant ) {
+                        $role->add_cap( $cap );
+                    }
+                }
+            }
+        }
+
+        $administrator = get_role( 'administrator' );
+        if ( $administrator ) {
+            foreach ( self::get_capabilities() as $cap ) {
+                $administrator->add_cap( $cap );
+            }
+            $administrator->add_cap( self::CAP_PERMISSIONS_PAGE );
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function get_capabilities() {
+        return array(
+            self::CAP_GESTION_READ,
+            self::CAP_GESTION_MANAGE,
+            self::CAP_LICENCES_READ,
+            self::CAP_LICENCES_MANAGE,
+            self::CAP_COMPETITIONS_READ,
+            self::CAP_COMPETITIONS_MANAGE,
+            self::CAP_SETTINGS_MANAGE,
+            self::CAP_REGIONS_MANAGE,
+            self::CAP_ALL_REGIONS_ACCESS,
+        );
+    }
+
+    /**
+     * @return array<string,array{label:string,caps:array<string,bool>}>
+     */
+    public static function get_role_capabilities() {
+        return array(
+            'ufsc_region_viewer' => array(
+                'label' => __( 'Lecture régionale', 'ufsc-clubs' ),
+                'caps'  => array(
+                    'read' => true,
+                    self::CAP_GESTION_READ  => true,
+                    self::CAP_LICENCES_READ => true,
+                ),
+            ),
+            'ufsc_region_manager' => array(
+                'label' => __( 'Gestion régionale', 'ufsc-clubs' ),
+                'caps'  => array(
+                    'read' => true,
+                    self::CAP_GESTION_READ    => true,
+                    self::CAP_GESTION_MANAGE  => true,
+                    self::CAP_LICENCES_READ   => true,
+                    self::CAP_LICENCES_MANAGE => true,
+                ),
+            ),
+            'ufsc_competition_manager' => array(
+                'label' => __( 'Gestion compétitions', 'ufsc-clubs' ),
+                'caps'  => array(
+                    'read' => true,
+                    self::CAP_GESTION_READ          => true,
+                    self::CAP_LICENCES_READ         => true,
+                    self::CAP_COMPETITIONS_READ     => true,
+                    self::CAP_COMPETITIONS_MANAGE   => true,
+                ),
+            ),
+            'ufsc_admin_limited' => array(
+                'label' => __( 'Admin UFSC limité', 'ufsc-clubs' ),
+                'caps'  => array(
+                    'read' => true,
+                    self::CAP_GESTION_READ          => true,
+                    self::CAP_LICENCES_READ         => true,
+                    self::CAP_COMPETITIONS_READ     => true,
+                    self::CAP_COMPETITIONS_MANAGE   => true,
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Grant virtual OR capability for the Droits & accès page.
+     */
+    public static function grant_virtual_caps( $allcaps, $caps, $args, $user ) {
+        if ( ! is_array( $allcaps ) || empty( $args[0] ) || self::CAP_PERMISSIONS_PAGE !== $args[0] ) {
+            return $allcaps;
+        }
+
+        $user_id = $user instanceof WP_User ? (int) $user->ID : 0;
+        if ( $user_id && self::current_user_can_manage_permissions( $user_id ) ) {
+            $allcaps[ self::CAP_PERMISSIONS_PAGE ] = true;
+        }
+
+        return $allcaps;
+    }
+
+
+    /**
+     * Check the immutable WordPress administrator role/capability.
+     */
+    public static function is_wordpress_administrator( $user_id = null ) {
+        $user_id = $user_id ? absint( $user_id ) : get_current_user_id();
+        if ( ! $user_id ) {
+            return false;
+        }
+        $user = get_userdata( $user_id );
+        return ( $user && in_array( 'administrator', (array) $user->roles, true ) ) || user_can( $user_id, 'manage_options' );
+    }
+
+    /**
+     * Whether a user may open the permissions page.
+     */
+    public static function current_user_can_manage_permissions( $user_id = null ) {
+        $user_id = $user_id ? absint( $user_id ) : get_current_user_id();
+        if ( ! $user_id ) {
+            return false;
+        }
+        if ( self::is_wordpress_administrator( $user_id ) ) {
+            return true;
+        }
+        return user_can( $user_id, self::CAP_SETTINGS_MANAGE ) || user_can( $user_id, self::CAP_REGIONS_MANAGE );
+    }
+
+    /**
+     * Add admin submenu.
+     */
+    public static function register_permissions_page() {
+        add_submenu_page(
+            'ufsc-dashboard',
+            __( 'Droits & accès', 'ufsc-clubs' ),
+            __( 'Droits & accès', 'ufsc-clubs' ),
+            self::CAP_PERMISSIONS_PAGE,
+            'ufsc-permissions',
+            array( __CLASS__, 'render_permissions_page' )
+        );
+    }
+
+    /**
+     * Render and handle the permissions page.
+     */
+    public static function render_permissions_page() {
+        if ( ! self::current_user_can_manage_permissions() ) {
+            wp_die( esc_html__( 'Accès refusé : vous ne pouvez pas gérer les droits UFSC.', 'ufsc-clubs' ) );
+        }
+
+        $notice = self::maybe_handle_permissions_save();
+        $selected_user_id = isset( $_GET['user_id'] ) ? absint( wp_unslash( $_GET['user_id'] ) ) : 0;
+        if ( ! $selected_user_id ) {
+            $selected_user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
+        }
+
+        echo '<div class="wrap ufsc-permissions-page">';
+        echo '<h1>' . esc_html__( 'Droits & accès UFSC', 'ufsc-clubs' ) . '</h1>';
+        echo '<p class="description">' . esc_html__( 'Les restrictions UFSC sont vérifiées côté serveur. Le masquage des boutons n’est qu’un confort visuel.', 'ufsc-clubs' ) . '</p>';
+
+        if ( $notice ) {
+            printf( '<div class="notice notice-%1$s is-dismissible"><p>%2$s</p></div>', esc_attr( $notice['type'] ), esc_html( $notice['message'] ) );
+        }
+
+        self::render_users_table( $selected_user_id );
+
+        if ( $selected_user_id ) {
+            self::render_user_permissions_form( $selected_user_id );
+        }
+
+        echo '</div>';
+    }
+
+    /**
+     * Save submitted permissions.
+     */
+    private static function maybe_handle_permissions_save() {
+        if ( 'POST' !== strtoupper( $_SERVER['REQUEST_METHOD'] ?? '' ) || empty( $_POST['ufsc_permissions_action'] ) ) {
+            return null;
+        }
+
+        check_admin_referer( 'ufsc_save_user_permissions', 'ufsc_permissions_nonce' );
+
+        if ( ! self::current_user_can_manage_permissions() ) {
+            wp_die( esc_html__( 'Accès refusé.', 'ufsc-clubs' ) );
+        }
+
+        $target_user_id = isset( $_POST['user_id'] ) ? absint( wp_unslash( $_POST['user_id'] ) ) : 0;
+        $target_user    = $target_user_id ? get_userdata( $target_user_id ) : false;
+        if ( ! $target_user ) {
+            return array( 'type' => 'error', 'message' => __( 'Utilisateur introuvable.', 'ufsc-clubs' ) );
+        }
+
+        $current_user_id = get_current_user_id();
+        $is_admin        = current_user_can( 'manage_options' );
+        $target_is_admin = user_can( $target_user_id, 'manage_options' ) || in_array( 'administrator', (array) $target_user->roles, true );
+
+        if ( ! $is_admin && $target_is_admin ) {
+            return array( 'type' => 'error', 'message' => __( 'Seul un administrateur WordPress peut modifier un compte administrateur.', 'ufsc-clubs' ) );
+        }
+
+        $submitted_caps = isset( $_POST['ufsc_caps'] ) && is_array( $_POST['ufsc_caps'] ) ? array_map( 'sanitize_key', wp_unslash( $_POST['ufsc_caps'] ) ) : array();
+        $submitted_caps = array_values( array_intersect( $submitted_caps, self::get_capabilities() ) );
+        $sensitive_caps = array( self::CAP_SETTINGS_MANAGE, self::CAP_REGIONS_MANAGE, self::CAP_ALL_REGIONS_ACCESS );
+
+        if ( ! $is_admin && $target_user_id === $current_user_id && array_intersect( $submitted_caps, $sensitive_caps ) ) {
+            return array( 'type' => 'error', 'message' => __( 'Vous ne pouvez pas vous attribuer vous-même des droits UFSC sensibles.', 'ufsc-clubs' ) );
+        }
+
+        if ( ! $is_admin && $target_user_id === $current_user_id ) {
+            $existing_sensitive = array_filter( $sensitive_caps, static function( $cap ) use ( $target_user_id ) {
+                return user_can( $target_user_id, $cap );
+            } );
+            $submitted_caps = array_values( array_unique( array_merge( $submitted_caps, $existing_sensitive ) ) );
+        }
+
+        foreach ( self::get_capabilities() as $cap ) {
+            if ( in_array( $cap, $submitted_caps, true ) ) {
+                $target_user->add_cap( $cap );
+            } else {
+                $target_user->remove_cap( $cap );
+            }
+        }
+
+        $regions = isset( $_POST['ufsc_allowed_regions'] ) && is_array( $_POST['ufsc_allowed_regions'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['ufsc_allowed_regions'] ) ) : array();
+        ufsc_set_user_regions( $target_user_id, $regions );
+
+        $all_regions = ! empty( $_POST['ufsc_all_regions_access'] ) ? '1' : '0';
+        update_user_meta( $target_user_id, self::META_ALL_REGIONS, $all_regions );
+
+        return array( 'type' => 'success', 'message' => __( 'Droits UFSC sauvegardés.', 'ufsc-clubs' ) );
+    }
+
+    /**
+     * Render UFSC users table.
+     */
+    private static function render_users_table( $selected_user_id ) {
+        $users = self::get_ufsc_users();
+
+        echo '<h2>' . esc_html__( 'Utilisateurs UFSC', 'ufsc-clubs' ) . '</h2>';
+        echo '<table class="widefat striped"><thead><tr>';
+        echo '<th>' . esc_html__( 'Utilisateur', 'ufsc-clubs' ) . '</th>';
+        echo '<th>' . esc_html__( 'Rôles', 'ufsc-clubs' ) . '</th>';
+        echo '<th>' . esc_html__( 'Droits UFSC', 'ufsc-clubs' ) . '</th>';
+        echo '<th>' . esc_html__( 'Régions autorisées', 'ufsc-clubs' ) . '</th>';
+        echo '<th>' . esc_html__( 'Action', 'ufsc-clubs' ) . '</th>';
+        echo '</tr></thead><tbody>';
+
+        if ( empty( $users ) ) {
+            echo '<tr><td colspan="5">' . esc_html__( 'Aucun utilisateur UFSC trouvé.', 'ufsc-clubs' ) . '</td></tr>';
+        }
+
+        foreach ( $users as $user ) {
+            $caps    = self::get_user_ufsc_caps( $user->ID );
+            $regions = ufsc_user_has_all_regions_access( $user->ID ) ? array( __( 'Toutes les régions', 'ufsc-clubs' ) ) : ufsc_get_user_regions( $user->ID );
+            $url     = add_query_arg( array( 'page' => 'ufsc-permissions', 'user_id' => (int) $user->ID ), admin_url( 'admin.php' ) );
+            echo '<tr' . ( (int) $selected_user_id === (int) $user->ID ? ' class="active"' : '' ) . '>';
+            echo '<td><strong>' . esc_html( $user->display_name ) . '</strong><br><code>' . esc_html( $user->user_login ) . '</code></td>';
+            echo '<td>' . esc_html( implode( ', ', (array) $user->roles ) ) . '</td>';
+            echo '<td>' . wp_kses_post( self::render_cap_badges( $caps ) ) . '</td>';
+            echo '<td>' . esc_html( implode( ', ', $regions ) ) . '</td>';
+            echo '<td><a class="button" href="' . esc_url( $url ) . '">' . esc_html__( 'Modifier les droits', 'ufsc-clubs' ) . '</a></td>';
+            echo '</tr>';
+        }
+
+        echo '</tbody></table>';
+    }
+
+    /**
+     * Render form for one user.
+     */
+    private static function render_user_permissions_form( $user_id ) {
+        $user = get_userdata( $user_id );
+        if ( ! $user ) {
+            return;
+        }
+
+        $user_caps = self::get_user_ufsc_caps( $user_id );
+        $regions   = ufsc_get_regions();
+        $allowed   = ufsc_get_user_regions( $user_id );
+        $all_access = ufsc_user_has_all_regions_access( $user_id );
+
+        echo '<hr><h2>' . esc_html( sprintf( __( 'Modifier les droits de %s', 'ufsc-clubs' ), $user->display_name ) ) . '</h2>';
+        echo '<form method="post" class="ufsc-permissions-form">';
+        wp_nonce_field( 'ufsc_save_user_permissions', 'ufsc_permissions_nonce' );
+        echo '<input type="hidden" name="ufsc_permissions_action" value="save" />';
+        echo '<input type="hidden" name="user_id" value="' . esc_attr( (string) $user_id ) . '" />';
+
+        echo '<h3>' . esc_html__( 'Capabilities UFSC', 'ufsc-clubs' ) . '</h3><div style="columns:2;max-width:900px;">';
+        foreach ( self::get_capabilities() as $cap ) {
+            echo '<label style="display:block;margin:6px 0;"><input type="checkbox" name="ufsc_caps[]" value="' . esc_attr( $cap ) . '" ' . checked( in_array( $cap, $user_caps, true ), true, false ) . '> <code>' . esc_html( $cap ) . '</code></label>';
+        }
+        echo '</div>';
+
+        echo '<h3>' . esc_html__( 'Accès régional', 'ufsc-clubs' ) . '</h3>';
+        echo '<label><input type="checkbox" name="ufsc_all_regions_access" value="1" ' . checked( $all_access, true, false ) . '> ' . esc_html__( 'Accès à toutes les régions', 'ufsc-clubs' ) . '</label>';
+        echo '<div style="columns:2;max-width:900px;margin-top:10px;">';
+        foreach ( $regions as $region ) {
+            echo '<label style="display:block;margin:6px 0;"><input type="checkbox" name="ufsc_allowed_regions[]" value="' . esc_attr( $region ) . '" ' . checked( in_array( $region, $allowed, true ), true, false ) . '> ' . esc_html( $region ) . '</label>';
+        }
+        echo '</div>';
+
+        submit_button( __( 'Enregistrer les droits', 'ufsc-clubs' ) );
+        echo '</form>';
+    }
+
+    /**
+     * @return WP_User[]
+     */
+    private static function get_ufsc_users() {
+        $users      = get_users( array( 'fields' => 'all_with_meta' ) );
+        $ufsc_roles = array_keys( self::get_role_capabilities() );
+
+        return array_values( array_filter( $users, static function( $user ) use ( $ufsc_roles ) {
+            if ( array_intersect( $ufsc_roles, (array) $user->roles ) ) {
+                return true;
+            }
+            foreach ( self::get_capabilities() as $cap ) {
+                if ( user_can( $user->ID, $cap ) ) {
+                    return true;
+                }
+            }
+            return false;
+        } ) );
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function get_user_ufsc_caps( $user_id ) {
+        return array_values( array_filter( self::get_capabilities(), static function( $cap ) use ( $user_id ) {
+            return user_can( $user_id, $cap );
+        } ) );
+    }
+
+    /**
+     * @param string[] $caps
+     * @return string
+     */
+    private static function render_cap_badges( array $caps ) {
+        if ( empty( $caps ) ) {
+            return '<span class="description">' . esc_html__( 'Aucun droit UFSC direct', 'ufsc-clubs' ) . '</span>';
+        }
+
+        $html = '';
+        foreach ( $caps as $cap ) {
+            $html .= '<span class="ufsc-badge" style="display:inline-block;margin:2px;padding:2px 6px;border-radius:10px;background:#eef5ff;color:#0a4b78;"><code>' . esc_html( $cap ) . '</code></span> ';
+        }
+        return $html;
+    }
+}
+
+if ( ! function_exists( 'ufsc_user_can' ) ) {
+    function ufsc_user_can( $capability, $user_id = null ) {
+        $capability = sanitize_key( (string) $capability );
+        $user_id    = $user_id ? absint( $user_id ) : get_current_user_id();
+        if ( ! $user_id || '' === $capability ) {
+            return false;
+        }
+        if ( UFSC_Permissions::is_wordpress_administrator( $user_id ) ) {
+            return true;
+        }
+        return user_can( $user_id, $capability );
+    }
+}
+
+if ( ! function_exists( 'ufsc_get_regions' ) ) {
+    function ufsc_get_regions() {
+        $regions = array(
+            'Auvergne-Rhône-Alpes',
+            'Bourgogne-Franche-Comté',
+            'Bretagne',
+            'Centre-Val de Loire',
+            'Corse',
+            'Grand Est',
+            'Hauts-de-France',
+            'Île-de-France',
+            'Normandie',
+            'Nouvelle-Aquitaine',
+            'Occitanie',
+            'Pays de la Loire',
+            'Provence-Alpes-Côte d’Azur',
+            'Guadeloupe',
+            'Martinique',
+            'Guyane',
+            'La Réunion',
+            'Mayotte',
+        );
+        return apply_filters( 'ufsc_regions_list', $regions );
+    }
+}
+
+if ( ! function_exists( 'ufsc_get_user_regions' ) ) {
+    function ufsc_get_user_regions( $user_id = null ) {
+        $user_id = $user_id ? absint( $user_id ) : get_current_user_id();
+        if ( ! $user_id ) {
+            return array();
+        }
+        $regions = get_user_meta( $user_id, UFSC_Permissions::META_ALLOWED_REGIONS, true );
+        if ( ! is_array( $regions ) ) {
+            $regions = array();
+        }
+        $valid = ufsc_get_regions();
+        $clean = array_map( 'sanitize_text_field', $regions );
+        return array_values( array_unique( array_intersect( $clean, $valid ) ) );
+    }
+}
+
+if ( ! function_exists( 'ufsc_set_user_regions' ) ) {
+    function ufsc_set_user_regions( $user_id, array $regions ) {
+        $user_id = absint( $user_id );
+        if ( ! $user_id || ! get_userdata( $user_id ) ) {
+            return false;
+        }
+        $valid = ufsc_get_regions();
+        $clean = array_map( 'sanitize_text_field', $regions );
+        $clean = array_values( array_unique( array_intersect( $clean, $valid ) ) );
+        return false !== update_user_meta( $user_id, UFSC_Permissions::META_ALLOWED_REGIONS, $clean );
+    }
+}
+
+if ( ! function_exists( 'ufsc_user_has_all_regions_access' ) ) {
+    function ufsc_user_has_all_regions_access( $user_id = null ) {
+        $user_id = $user_id ? absint( $user_id ) : get_current_user_id();
+        if ( ! $user_id ) {
+            return false;
+        }
+        if ( UFSC_Permissions::is_wordpress_administrator( $user_id ) ) {
+            return true;
+        }
+        if ( user_can( $user_id, UFSC_Permissions::CAP_ALL_REGIONS_ACCESS ) ) {
+            return true;
+        }
+        return '1' === (string) get_user_meta( $user_id, UFSC_Permissions::META_ALL_REGIONS, true );
+    }
+}
+
+if ( ! function_exists( 'ufsc_user_can_access_region' ) ) {
+    function ufsc_user_can_access_region( $region, $user_id = null ) {
+        $region = sanitize_text_field( (string) $region );
+        if ( '' === $region || ! in_array( $region, ufsc_get_regions(), true ) ) {
+            return false;
+        }
+        if ( ufsc_user_has_all_regions_access( $user_id ) ) {
+            return true;
+        }
+        return in_array( $region, ufsc_get_user_regions( $user_id ), true );
+    }
+}
+
+if ( ! function_exists( 'ufsc_current_user_allowed_regions' ) ) {
+    function ufsc_current_user_allowed_regions() {
+        if ( ufsc_user_has_all_regions_access() ) {
+            return ufsc_get_regions();
+        }
+        return ufsc_get_user_regions();
+    }
+}
+
+if ( ! function_exists( 'ufsc_is_region_allowed_for_current_user' ) ) {
+    function ufsc_is_region_allowed_for_current_user( $region ) {
+        return ufsc_user_can_access_region( $region, get_current_user_id() );
+    }
+}
+
+if ( ! function_exists( 'ufsc_filter_query_by_allowed_regions' ) ) {
+    function ufsc_filter_query_by_allowed_regions( $args, $region_field = 'region' ) {
+        if ( ! is_array( $args ) ) {
+            $args = array();
+        }
+        $region_field = sanitize_key( (string) $region_field );
+        if ( '' === $region_field || ufsc_user_has_all_regions_access() ) {
+            return $args;
+        }
+
+        $regions = ufsc_current_user_allowed_regions();
+        if ( empty( $regions ) ) {
+            $regions = array( '__ufsc_no_region_allowed__' );
+        }
+
+        if ( isset( $args['post_type'] ) || isset( $args['meta_query'] ) ) {
+            if ( empty( $args['meta_query'] ) || ! is_array( $args['meta_query'] ) ) {
+                $args['meta_query'] = array();
+            }
+            $args['meta_query'][] = array(
+                'key'     => $region_field,
+                'value'   => $regions,
+                'compare' => 'IN',
+            );
+            return $args;
+        }
+
+        $args['ufsc_allowed_regions'] = $regions;
+        $args['ufsc_region_field']    = $region_field;
+        return $args;
+    }
+}

--- a/includes/security/class-ufsc-capabilities.php
+++ b/includes/security/class-ufsc-capabilities.php
@@ -21,6 +21,17 @@ class UFSC_Capabilities {
     const CAP_SCOPE_ALL_REGIONS        = 'ufsc_scope_all_regions';
     const CAP_MANAGE_COMMUNICATION    = 'ufsc_manage_communication';
 
+    // UFSC Gestion central permissions (new canonical capabilities).
+    const CAP_GESTION_READ          = 'ufsc_gestion_read';
+    const CAP_GESTION_MANAGE        = 'ufsc_gestion_manage';
+    const CAP_LICENCES_READ         = 'ufsc_licences_read';
+    const CAP_LICENCES_MANAGE       = 'ufsc_licences_manage';
+    const CAP_COMPETITIONS_READ     = 'ufsc_competitions_read';
+    const CAP_COMPETITIONS_MANAGE   = 'ufsc_competitions_manage';
+    const CAP_SETTINGS_MANAGE       = 'ufsc_settings_manage';
+    const CAP_REGIONS_MANAGE        = 'ufsc_regions_manage';
+    const CAP_ALL_REGIONS_ACCESS    = 'ufsc_all_regions_access';
+
     /**
      * Register capabilities and roles (idempotent).
      */
@@ -36,6 +47,12 @@ class UFSC_Capabilities {
 
         $responsable_caps = array(
             'read'                         => true,
+            self::CAP_GESTION_READ        => true,
+            self::CAP_GESTION_MANAGE      => true,
+            self::CAP_LICENCES_READ       => true,
+            self::CAP_LICENCES_MANAGE     => true,
+            self::CAP_COMPETITIONS_READ   => true,
+            self::CAP_COMPETITIONS_MANAGE => true,
             self::CAP_MANAGE_READ          => true,
             self::CAP_LICENCE_READ         => true,
             self::CAP_LICENCE_CREATE       => true,
@@ -80,6 +97,15 @@ class UFSC_Capabilities {
             self::CAP_COMPETITION_EXPORT,
             self::CAP_SCOPE_ALL_REGIONS,
             self::CAP_MANAGE_COMMUNICATION,
+            self::CAP_GESTION_READ,
+            self::CAP_GESTION_MANAGE,
+            self::CAP_LICENCES_READ,
+            self::CAP_LICENCES_MANAGE,
+            self::CAP_COMPETITIONS_READ,
+            self::CAP_COMPETITIONS_MANAGE,
+            self::CAP_SETTINGS_MANAGE,
+            self::CAP_REGIONS_MANAGE,
+            self::CAP_ALL_REGIONS_ACCESS,
         );
     }
 
@@ -101,6 +127,11 @@ class UFSC_Capabilities {
 
         $aliases = array(
             self::CAP_MANAGE_READ => 'manage_options',
+            self::CAP_GESTION_READ => self::CAP_MANAGE_READ,
+            self::CAP_LICENCES_READ => self::CAP_LICENCE_READ,
+            self::CAP_LICENCES_MANAGE => self::CAP_LICENCE_EDIT,
+            self::CAP_COMPETITIONS_READ => self::CAP_COMPETITION_READ,
+            self::CAP_COMPETITIONS_MANAGE => self::CAP_COMPETITION_EDIT,
         );
 
         if ( isset( $aliases[ $cap ] ) ) {

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -17,6 +17,7 @@ require_once UFSC_CL_DIR.'includes/core/class-utils.php';
 require_once UFSC_CL_DIR.'includes/core/column-map.php';
 require_once UFSC_CL_DIR.'includes/security/class-ufsc-capabilities.php';
 require_once UFSC_CL_DIR.'includes/security/class-ufsc-scope.php';
+require_once UFSC_CL_DIR.'includes/permissions/class-ufsc-permissions.php';
 require_once UFSC_CL_DIR.'includes/admin/class-admin-menu.php';
 require_once UFSC_CL_DIR.'includes/admin/class-ufsc-settings-page.php';
 require_once UFSC_CL_DIR.'includes/core/class-sql.php';
@@ -143,6 +144,7 @@ final class UFSC_CL_Bootstrap {
         add_action( 'init', array( 'UFSC_Unified_Handlers', 'init' ) );
         add_action( 'init', array( 'UFSC_Cache_Manager', 'init' ) );
         add_action( 'init', array( 'UFSC_Capabilities', 'register_caps' ) );
+        add_action( 'init', array( 'UFSC_Permissions', 'init' ) );
         add_action( 'init', array( 'UFSC_User_Profile_Scope_Field', 'init' ) );
         add_action( 'plugins_loaded', array( 'UFSC_DB_Migrations', 'run_migrations' ) );
 
@@ -166,6 +168,7 @@ final class UFSC_CL_Bootstrap {
             ufsc_flush_table_columns_cache();
         }
         UFSC_Capabilities::register_caps();
+        UFSC_Permissions::register_roles_and_caps();
         UFSC_DB_Migrations::run_migrations();
         if ( class_exists( 'UFSC_Licence_Payments' ) ) { UFSC_Licence_Payments::maybe_migrate(); }
         flush_rewrite_rules();


### PR DESCRIPTION
### Motivation
- Provide a single, server-side module to manage UFSC roles, capabilities and regional access so other UFSC plugins can reliably consume rights via secure helpers. 
- Replace ad-hoc `manage_options` checks with canonical UFSC capabilities to support read-only vs manage scopes and per-region restrictions. 
- Preserve existing admin rights and avoid destructive DB or role removals while enabling fine-grained, auditable permission changes. 

### Description
- Added a new central permissions module `includes/permissions/class-ufsc-permissions.php` exposing idempotent role/capability registration, region handling, and global helpers such as `ufsc_user_can()`, `ufsc_get_regions()`, `ufsc_get_user_regions()`, `ufsc_set_user_regions()`, `ufsc_user_has_all_regions_access()`, `ufsc_user_can_access_region()`, `ufsc_current_user_allowed_regions()`, `ufsc_is_region_allowed_for_current_user()` and `ufsc_filter_query_by_allowed_regions()`. 
- Registered and loaded the module in the plugin bootstrap and activation path so capabilities/roles are created safely without removing existing grants, and ensured `administrator` keeps all WP rights. 
- Replaced or augmented admin checks across the admin UI and handlers to use the new capabilities (`ufsc_gestion_read`, `ufsc_gestion_manage`, `ufsc_licences_read`, `ufsc_licences_manage`, `ufsc_settings_manage`, `ufsc_regions_manage`, `ufsc_all_regions_access`) and added regional enforcement when listing, viewing or editing clubs (meta `_ufsc_allowed_regions` and `_ufsc_all_regions_access`). 
- Files added and modified: created `includes/permissions/class-ufsc-permissions.php` and `docs/permissions.md`; modified `ufsc-clubs-licences-sql.php`, `includes/security/class-ufsc-capabilities.php`, `includes/admin/class-admin-menu.php`, `includes/admin/class-sql-admin.php`, `includes/admin/list-tables/class-ufsc-clubs-list-table.php`, `includes/admin/list-tables/class-ufsc-licences-list-table.php`, `inc/settings.php`, and `inc/woocommerce/settings-woocommerce.php` to integrate the new system and keep backward compatibility. 

### Testing
- Ran PHP syntax checks across the codebase with `find . -name '*.php' | xargs php -l` and fixed issues; result: no syntax errors detected. 
- Ran `git diff --check` to catch whitespace/merge problems; result: clean. 
- Performed automated lint/parse validation for the changed files (`php -l` on the modified files) and observed no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197579d98c832b9f408d84daf2b017)