### PR TITLE
Add simplified admin interface for limited UFSC users

### DIFF
--- a/docs/simplified-admin.md
+++ b/docs/simplified-admin.md
@@ -1,0 +1,179 @@
+# Interface admin simplifiée UFSC
+
+## Principe
+
+UFSC Gestion fournit une interface d’administration simplifiée pour les utilisateurs WordPress non administrateurs qui disposent de droits UFSC opérationnels.
+
+Cette interface est un **confort d’usage** : elle masque les menus WordPress et les menus de plugins qui ne sont pas nécessaires à la mission de l’utilisateur, puis redirige l’utilisateur vers le premier module UFSC auquel il a droit.
+
+## Important : masquage UI ≠ sécurité serveur
+
+Le masquage des menus ne remplace jamais les contrôles serveur.
+
+Les actions sensibles doivent continuer à être protégées par :
+
+- `current_user_can()` ;
+- `ufsc_user_can()` ;
+- les nonces WordPress ;
+- les contrôles régionaux UFSC ;
+- les protections `POST`, `AJAX` et `admin_post` existantes.
+
+Aucune capability WordPress classique n’est accordée par ce mécanisme. Les utilisateurs UFSC limités ne reçoivent pas de droits tels que `manage_options`, `edit_posts`, `upload_files`, `edit_pages`, `manage_woocommerce`, `install_plugins`, `activate_plugins`, `edit_theme_options`, `list_users`, `create_users` ou `promote_users`.
+
+## Utilisateurs concernés
+
+L’interface simplifiée s’applique uniquement si toutes les conditions suivantes sont vraies :
+
+1. l’utilisateur est connecté ;
+2. l’utilisateur n’a pas `manage_options` ;
+3. l’utilisateur n’est pas un véritable administrateur WordPress ;
+4. l’utilisateur possède au moins une des capabilities UFSC suivantes :
+   - `ufsc_gestion_read` ;
+   - `ufsc_gestion_manage` ;
+   - `ufsc_licences_read` ;
+   - `ufsc_licences_manage` ;
+   - `ufsc_competitions_read` ;
+   - `ufsc_competitions_manage`.
+
+Les administrateurs WordPress réels, notamment ceux qui disposent de `manage_options`, ne sont jamais placés dans ce mode simplifié et conservent l’administration WordPress complète.
+
+## Option globale
+
+L’option globale est stockée dans :
+
+```text
+ufsc_enable_simplified_admin
+```
+
+Elle est activée par défaut.
+
+Elle peut être modifiée dans **UFSC Gestion > Droits & accès** par un administrateur WordPress disposant de `manage_options` via la case :
+
+> Activer l’interface admin simplifiée pour les utilisateurs UFSC limités
+
+Si l’option est désactivée, UFSC Gestion ne masque plus les menus et ne force plus les redirections d’interface simplifiée. Les protections serveur restent inchangées.
+
+## Menus conservés
+
+Pour un utilisateur UFSC limité, les seuls menus conservés sont :
+
+- **UFSC Gestion**, si l’utilisateur possède `ufsc_gestion_read` ou `ufsc_gestion_manage` ;
+- **UFSC Licences**, si l’utilisateur possède `ufsc_licences_read` ou `ufsc_licences_manage` ;
+- **Compétitions**, si l’utilisateur possède `ufsc_competitions_read` ou `ufsc_competitions_manage` ;
+- **Profil**, afin de laisser l’utilisateur gérer son compte si nécessaire.
+
+UFSC Gestion ajoute également une petite page **Accueil UFSC** qui rappelle que l’interface est limitée aux outils nécessaires et affiche les modules disponibles selon les droits de l’utilisateur.
+
+## Menus masqués
+
+Tous les menus non explicitement autorisés sont retirés pour les utilisateurs UFSC limités, par exemple :
+
+- Tableau de bord WordPress ;
+- Articles ;
+- Médias ;
+- Pages ;
+- Commentaires ;
+- Apparence ;
+- Extensions ;
+- Utilisateurs ;
+- Outils ;
+- Réglages ;
+- WooCommerce ;
+- Produits ;
+- Paiements ;
+- Marketing ;
+- Elementor ;
+- Astra ;
+- Rank Math SEO ;
+- Contact Form 7 ;
+- Flamingo ;
+- Événements ;
+- Monetico Paiement ;
+- tout autre menu qui n’est pas reconnu comme un module UFSC autorisé.
+
+Le filtrage est volontairement robuste : il inspecte les menus WordPress enregistrés et ne conserve que les slugs/titres UFSC explicitement autorisés par les capabilities de l’utilisateur.
+
+## Redirections et accès directs
+
+Après connexion, ou lors d’une arrivée sur `/wp-admin/`, un utilisateur UFSC limité est redirigé vers le premier écran autorisé selon la priorité suivante :
+
+1. Compétitions ;
+2. UFSC Licences ;
+3. UFSC Gestion / Accueil UFSC ;
+4. Profil utilisateur.
+
+Les accès directs aux pages admin non autorisées sont redirigés vers ce même premier écran autorisé. Les endpoints techniques nécessaires ne sont pas bloqués :
+
+- `admin-ajax.php` ;
+- `admin-post.php` ;
+- `async-upload.php` ;
+- `profile.php`.
+
+## Barre d’administration
+
+La barre d’administration est simplifiée pour les utilisateurs UFSC limités. Les raccourcis inutiles comme “Nouveau”, “Commentaires”, “Personnaliser”, Elementor, Rank Math, WooCommerce ou les mises à jour sont supprimés.
+
+Le compte utilisateur, l’accès au profil et la déconnexion sont conservés.
+
+## Tests à effectuer
+
+### Administrateur WordPress
+
+- Vérifier que l’administrateur voit tous les menus WordPress habituels.
+- Vérifier qu’il voit UFSC Gestion, UFSC Licences, Compétitions et Droits & accès.
+- Vérifier qu’il n’est pas redirigé vers l’interface simplifiée.
+
+### Utilisateur UFSC licences lecture seule
+
+Capabilities :
+
+- `ufsc_licences_read`
+
+Résultat attendu :
+
+- l’utilisateur voit uniquement UFSC Licences et Profil ;
+- il ne voit pas les menus WordPress ou plugins non nécessaires ;
+- il ne peut pas modifier les licences ;
+- l’accès direct à `/wp-admin/plugins.php` est redirigé.
+
+### Utilisateur UFSC compétition manager
+
+Capabilities :
+
+- `ufsc_competitions_read`
+- `ufsc_competitions_manage`
+
+Résultat attendu :
+
+- l’utilisateur voit uniquement Compétitions et Profil ;
+- il peut modifier les compétitions selon les protections serveur existantes ;
+- il ne voit aucun menu non nécessaire.
+
+### Utilisateur UFSC combiné
+
+Capabilities :
+
+- `ufsc_gestion_read`
+- `ufsc_licences_read`
+- `ufsc_competitions_read`
+- `ufsc_competitions_manage`
+
+Résultat attendu :
+
+- l’utilisateur voit uniquement UFSC Gestion, UFSC Licences, Compétitions et Profil ;
+- il ne voit pas Droits & accès ;
+- il ne voit pas les menus WordPress ou plugins non nécessaires.
+
+### Accès direct
+
+Tester les URL suivantes pour un utilisateur UFSC limité et pour un administrateur WordPress :
+
+- `/wp-admin/edit.php` ;
+- `/wp-admin/upload.php` ;
+- `/wp-admin/plugins.php` ;
+- `/wp-admin/users.php` ;
+- `/wp-admin/options-general.php` ;
+- `/wp-admin/admin.php?page=woocommerce` ;
+- `/wp-admin/admin.php?page=rank-math`.
+
+Résultat attendu : l’utilisateur UFSC limité est redirigé vers son espace UFSC autorisé, tandis que l’administrateur WordPress reste autorisé.

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -40,7 +40,7 @@ class UFSC_CL_Admin_Menu {
 			'ufsc-dashboard',
 			__( 'Licences', 'ufsc-clubs' ),
 			__( 'Licences', 'ufsc-clubs' ),
-			UFSC_Permissions::CAP_GESTION_READ,
+			UFSC_Permissions::CAP_LICENCES_READ,
 			'ufsc-licences',
 			array( 'UFSC_SQL_Admin', 'render_licences' )
 		);

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -736,9 +736,9 @@ class UFSC_SQL_Admin
     {
         // Enregistrer les pages cachées pour les actions directes (mentionnées dans les specs)
         add_submenu_page('', __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-clubs', [__CLASS__, 'render_clubs']);
-        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
+        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_LICENCES_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
         // Alias pour compatibilité avec la spec (licenses vs licences)
-        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-licenses', [__CLASS__, 'render_licences']);
+        add_submenu_page('', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_LICENCES_READ, 'ufsc-sql-licenses', [__CLASS__, 'render_licences']);
     }
 
     /* ---------------- Menus complets (obsolète - remplacé par menu unifié) ---------------- */
@@ -746,7 +746,7 @@ class UFSC_SQL_Admin
     {
         add_menu_page(__('UFSC – Données (SQL)', 'ufsc-clubs'), __('UFSC – Données (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql', [__CLASS__, 'render_dashboard'], 'dashicons-database', 59);
         add_submenu_page('ufsc-sql', __('Clubs (SQL)', 'ufsc-clubs'), __('Clubs (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-clubs', [__CLASS__, 'render_clubs']);
-        add_submenu_page('ufsc-sql', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
+        add_submenu_page('ufsc-sql', __('Licences (SQL)', 'ufsc-clubs'), __('Licences (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_LICENCES_READ, 'ufsc-sql-licences', [__CLASS__, 'render_licences']);
         add_submenu_page('ufsc-sql', __('Réglages (SQL)', 'ufsc-clubs'), __('Réglages (SQL)', 'ufsc-clubs'), UFSC_Permissions::CAP_SETTINGS_MANAGE, 'ufsc-sql-settings', [__CLASS__, 'render_settings']);
     }
 
@@ -2315,7 +2315,7 @@ class UFSC_SQL_Admin
 
     public static function render_licences()
     {
-        if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_READ ) ) {
+        if ( ! ufsc_user_can( UFSC_Permissions::CAP_LICENCES_READ ) ) {
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
 
@@ -2512,13 +2512,13 @@ class UFSC_SQL_Admin
         // Add nonce for AJAX operations
         echo '<input type="hidden" id="ufsc-ajax-nonce" value="' . wp_create_nonce('ufsc_ajax_nonce') . '" />';
 
-        if ( ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
+        if ( ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE ) ) {
             echo '<p><a href="' . esc_url(admin_url('admin.php?page=ufsc-sql-licences&action=new')) . '" class="button button-primary">' . esc_html__('Ajouter une licence', 'ufsc-clubs') . '</a> ';
             echo '<a href="' . esc_url(admin_url('admin.php?page=ufsc-exports')) . '" class="button">' . esc_html__('Exporter', 'ufsc-clubs') . '</a></p>';
         }
 
         if (isset($_GET['action']) && $_GET['action'] === 'edit') {
-            if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
+            if ( ! ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE ) ) {
                 wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
             }
             $id = (int) $_GET['id'];
@@ -2531,7 +2531,7 @@ class UFSC_SQL_Admin
             echo '</div>';
             return;
         } elseif (isset($_GET['action']) && $_GET['action'] === 'new') {
-            if ( ! ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
+            if ( ! ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE ) ) {
                 wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
             }
             self::render_licence_form(0);

--- a/includes/admin/class-ufsc-simplified-admin.php
+++ b/includes/admin/class-ufsc-simplified-admin.php
@@ -1,0 +1,486 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+
+/**
+ * Simplified WordPress admin interface for limited UFSC users.
+ *
+ * This class only hides/redirects admin UI entry points. It does not grant any
+ * WordPress capability and must not replace the existing server-side checks.
+ */
+class UFSC_Simplified_Admin {
+    const OPTION_ENABLED = 'ufsc_enable_simplified_admin';
+
+    /**
+     * Capabilities that identify a limited UFSC user for this interface.
+     *
+     * @return string[]
+     */
+    private static function limited_user_caps() {
+        return array(
+            UFSC_Permissions::CAP_GESTION_READ,
+            UFSC_Permissions::CAP_GESTION_MANAGE,
+            UFSC_Permissions::CAP_LICENCES_READ,
+            UFSC_Permissions::CAP_LICENCES_MANAGE,
+            UFSC_Permissions::CAP_COMPETITIONS_READ,
+            UFSC_Permissions::CAP_COMPETITIONS_MANAGE,
+        );
+    }
+
+    /**
+     * Bootstrap admin hooks.
+     */
+    public static function init() {
+        $pagenow = isset( $GLOBALS['pagenow'] ) ? (string) $GLOBALS['pagenow'] : '';
+        if ( ! is_admin() && 'wp-login.php' !== $pagenow ) {
+            return;
+        }
+
+        add_filter( 'login_redirect', array( __CLASS__, 'filter_login_redirect' ), 20, 3 );
+        add_action( 'admin_init', array( __CLASS__, 'maybe_redirect_from_dashboard' ), 1 );
+        add_action( 'admin_init', array( __CLASS__, 'maybe_block_direct_admin_access' ), 20 );
+        add_action( 'admin_menu', array( __CLASS__, 'register_licences_bridge_menu' ), 19 );
+        add_action( 'admin_menu', array( __CLASS__, 'register_welcome_page' ), 20 );
+        add_action( 'admin_menu', array( __CLASS__, 'filter_admin_menu' ), 9999 );
+        add_action( 'admin_bar_menu', array( __CLASS__, 'simplify_admin_bar' ), 9999 );
+    }
+
+    /**
+     * Whether the simplified admin mode is enabled globally.
+     */
+    public static function is_enabled() {
+        return '0' !== (string) get_option( self::OPTION_ENABLED, '1' );
+    }
+
+    /**
+     * Detect non-administrator users with at least one limited UFSC capability.
+     */
+    public static function is_limited_ufsc_user() {
+        if ( ! is_user_logged_in() ) {
+            return false;
+        }
+
+        if ( current_user_can( 'manage_options' ) || UFSC_Permissions::is_wordpress_administrator() ) {
+            return false;
+        }
+
+        foreach ( self::limited_user_caps() as $cap ) {
+            if ( current_user_can( $cap ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether simplified UI rules should currently apply.
+     */
+    private static function should_apply() {
+        return self::is_enabled() && self::is_limited_ufsc_user();
+    }
+
+    /**
+     * Does current user have a UFSC Gestion capability?
+     */
+    private static function can_access_gestion() {
+        return current_user_can( UFSC_Permissions::CAP_GESTION_READ ) || current_user_can( UFSC_Permissions::CAP_GESTION_MANAGE );
+    }
+
+    /**
+     * Does current user have a UFSC Licences capability?
+     */
+    private static function can_access_licences() {
+        return current_user_can( UFSC_Permissions::CAP_LICENCES_READ ) || current_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE );
+    }
+
+    /**
+     * Does current user have a UFSC Compétitions capability?
+     */
+    private static function can_access_competitions() {
+        return current_user_can( UFSC_Permissions::CAP_COMPETITIONS_READ ) || current_user_can( UFSC_Permissions::CAP_COMPETITIONS_MANAGE );
+    }
+
+    /**
+     * Register a dedicated UFSC Licences top-level menu for users who only have licence rights.
+     */
+    public static function register_licences_bridge_menu() {
+        if ( ! self::should_apply() || ! self::can_access_licences() || ! class_exists( 'UFSC_SQL_Admin' ) ) {
+            return;
+        }
+
+        add_menu_page(
+            __( 'UFSC Licences', 'ufsc-clubs' ),
+            __( 'UFSC Licences', 'ufsc-clubs' ),
+            UFSC_Permissions::CAP_LICENCES_READ,
+            'ufsc-licences',
+            array( 'UFSC_SQL_Admin', 'render_licences' ),
+            'dashicons-id',
+            59
+        );
+    }
+
+    /**
+     * Register a lightweight UFSC home page for limited users who can open UFSC Gestion.
+     */
+    public static function register_welcome_page() {
+        if ( ! self::should_apply() || ! self::can_access_gestion() ) {
+            return;
+        }
+
+        add_submenu_page(
+            'ufsc-dashboard',
+            __( 'Accueil UFSC', 'ufsc-clubs' ),
+            __( 'Accueil UFSC', 'ufsc-clubs' ),
+            UFSC_Permissions::CAP_GESTION_READ,
+            'ufsc-home',
+            array( __CLASS__, 'render_welcome_page' ),
+            0
+        );
+    }
+
+    /**
+     * Render simplified home page.
+     */
+    public static function render_welcome_page() {
+        if ( ! self::can_access_gestion() ) {
+            wp_die( esc_html__( 'Accès refusé.', 'ufsc-clubs' ), esc_html__( 'Accès refusé', 'ufsc-clubs' ), array( 'response' => 403 ) );
+        }
+
+        $is_read_only = ! current_user_can( UFSC_Permissions::CAP_GESTION_MANAGE )
+            && ! current_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE )
+            && ! current_user_can( UFSC_Permissions::CAP_COMPETITIONS_MANAGE );
+        $regions = function_exists( 'ufsc_current_user_allowed_regions' ) ? ufsc_current_user_allowed_regions() : array();
+
+        echo '<div class="wrap ufsc-simplified-home">';
+        echo '<h1>' . esc_html__( 'Bienvenue dans votre espace UFSC', 'ufsc-clubs' ) . '</h1>';
+        echo '<p>' . esc_html__( 'Votre interface est limitée aux outils nécessaires à votre mission.', 'ufsc-clubs' ) . '</p>';
+
+        if ( $is_read_only ) {
+            echo '<p><span class="ufsc-badge" style="display:inline-block;padding:4px 10px;border-radius:12px;background:#eef5ff;color:#0a4b78;font-weight:600;">' . esc_html__( 'Lecture seule', 'ufsc-clubs' ) . '</span></p>';
+        }
+
+        echo '<div class="ufsc-dashboard-cards" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;margin-top:20px;">';
+        if ( self::can_access_licences() ) {
+            echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'Licences', 'ufsc-clubs' ) . '</h2><p><a class="button button-primary" href="' . esc_url( self::get_licences_url() ) . '">' . esc_html__( 'Accéder aux licences', 'ufsc-clubs' ) . '</a></p></div>';
+        }
+        if ( self::can_access_competitions() ) {
+            echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'Compétitions', 'ufsc-clubs' ) . '</h2><p><a class="button button-primary" href="' . esc_url( self::get_competitions_url() ) . '">' . esc_html__( 'Accéder aux compétitions', 'ufsc-clubs' ) . '</a></p></div>';
+        }
+        if ( self::can_access_gestion() ) {
+            echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'UFSC Gestion', 'ufsc-clubs' ) . '</h2><p><a class="button" href="' . esc_url( admin_url( 'admin.php?page=ufsc-dashboard' ) ) . '">' . esc_html__( 'Accéder à UFSC Gestion', 'ufsc-clubs' ) . '</a></p></div>';
+        }
+        echo '</div>';
+
+        if ( ! empty( $regions ) ) {
+            echo '<h2>' . esc_html__( 'Régions autorisées', 'ufsc-clubs' ) . '</h2>';
+            echo '<p>' . esc_html( implode( ', ', $regions ) ) . '</p>';
+        }
+
+        echo '</div>';
+    }
+
+    /**
+     * Redirect limited users to the first authorized UFSC screen after login.
+     */
+    public static function filter_login_redirect( $redirect_to, $requested_redirect_to, $user ) {
+        if ( ! self::is_enabled() || ! ( $user instanceof WP_User ) ) {
+            return $redirect_to;
+        }
+
+        if ( user_can( $user, 'manage_options' ) || UFSC_Permissions::is_wordpress_administrator( $user->ID ) ) {
+            return $redirect_to;
+        }
+
+        foreach ( self::limited_user_caps() as $cap ) {
+            if ( user_can( $user, $cap ) ) {
+                return self::get_first_authorized_url_for_user( $user );
+            }
+        }
+
+        return $redirect_to;
+    }
+
+    /**
+     * Redirect /wp-admin/ dashboard visits to the first authorized UFSC screen.
+     */
+    public static function maybe_redirect_from_dashboard() {
+        if ( ! self::should_apply() || wp_doing_ajax() ) {
+            return;
+        }
+
+        $pagenow = isset( $GLOBALS['pagenow'] ) ? (string) $GLOBALS['pagenow'] : '';
+        if ( 'index.php' === $pagenow ) {
+            wp_safe_redirect( self::get_first_authorized_url() );
+            exit;
+        }
+    }
+
+    /**
+     * Block or redirect direct access to non-authorized admin pages.
+     */
+    public static function maybe_block_direct_admin_access() {
+        if ( ! self::should_apply() || wp_doing_ajax() ) {
+            return;
+        }
+
+        $pagenow = isset( $GLOBALS['pagenow'] ) ? (string) $GLOBALS['pagenow'] : '';
+        if ( in_array( $pagenow, self::always_allowed_admin_files(), true ) || self::is_authorized_admin_file_request( $pagenow ) ) {
+            return;
+        }
+
+        if ( 'admin.php' === $pagenow ) {
+            $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+            if ( '' !== $page && self::is_authorized_page_slug( $page ) ) {
+                return;
+            }
+            self::redirect_away_from_blocked_page();
+        }
+
+        if ( ! in_array( $pagenow, self::allowed_non_admin_php_files(), true ) ) {
+            self::redirect_away_from_blocked_page();
+        }
+    }
+
+    /**
+     * Keep only explicitly authorized top-level menus and safe profile items.
+     */
+    public static function filter_admin_menu() {
+        if ( ! self::should_apply() ) {
+            return;
+        }
+
+        global $menu, $submenu;
+
+        foreach ( (array) $menu as $index => $item ) {
+            $slug  = isset( $item[2] ) ? (string) $item[2] : '';
+            $title = isset( $item[0] ) ? wp_strip_all_tags( (string) $item[0] ) : '';
+
+            if ( ! self::is_authorized_top_level_menu( $slug, $title ) ) {
+                unset( $menu[ $index ] );
+            }
+        }
+
+        foreach ( (array) $submenu as $parent_slug => $items ) {
+            if ( ! self::is_authorized_parent_slug( (string) $parent_slug ) && 'profile.php' !== $parent_slug ) {
+                unset( $submenu[ $parent_slug ] );
+                continue;
+            }
+
+            foreach ( (array) $items as $index => $item ) {
+                $slug = isset( $item[2] ) ? (string) $item[2] : '';
+                if ( 'profile.php' === $parent_slug ) {
+                    if ( 'profile.php' !== $slug ) {
+                        unset( $submenu[ $parent_slug ][ $index ] );
+                    }
+                    continue;
+                }
+
+                if ( ! self::is_authorized_page_slug( $slug ) ) {
+                    unset( $submenu[ $parent_slug ][ $index ] );
+                }
+            }
+        }
+    }
+
+    /**
+     * Simplify admin bar for limited UFSC users.
+     */
+    public static function simplify_admin_bar( $wp_admin_bar ) {
+        if ( ! self::should_apply() || ! is_object( $wp_admin_bar ) || ! method_exists( $wp_admin_bar, 'get_nodes' ) ) {
+            return;
+        }
+
+        $allowed_nodes = array( 'top-secondary', 'my-account', 'user-actions', 'user-info', 'edit-profile', 'logout' );
+        foreach ( (array) $wp_admin_bar->get_nodes() as $node ) {
+            if ( ! in_array( $node->id, $allowed_nodes, true ) ) {
+                $wp_admin_bar->remove_node( $node->id );
+            }
+        }
+    }
+
+    /**
+     * Allow non-admin.php requests that belong to an authorized UFSC module.
+     */
+    private static function is_authorized_admin_file_request( $pagenow ) {
+        if ( ! self::can_access_competitions() ) {
+            return false;
+        }
+
+        if ( in_array( $pagenow, array( 'edit.php', 'post-new.php' ), true ) ) {
+            $post_type = isset( $_GET['post_type'] ) ? sanitize_key( wp_unslash( $_GET['post_type'] ) ) : '';
+            return self::is_competitions_slug( $post_type );
+        }
+
+        if ( 'post.php' === $pagenow && ! empty( $_GET['post'] ) ) {
+            $post = get_post( absint( $_GET['post'] ) );
+            return $post && self::is_competitions_slug( $post->post_type );
+        }
+
+        return false;
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function always_allowed_admin_files() {
+        return array( 'admin-ajax.php', 'admin-post.php', 'async-upload.php', 'profile.php' );
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function allowed_non_admin_php_files() {
+        return array_merge( self::always_allowed_admin_files(), array( 'index.php' ) );
+    }
+
+    /**
+     * Is the top-level menu authorized for the current limited user?
+     */
+    private static function is_authorized_top_level_menu( $slug, $title = '' ) {
+        if ( 'profile.php' === $slug ) {
+            return true;
+        }
+
+        if ( self::is_gestion_slug( $slug, $title ) ) {
+            return self::can_access_gestion();
+        }
+
+        if ( self::is_licences_slug( $slug, $title ) ) {
+            return self::can_access_licences();
+        }
+
+        if ( self::is_competitions_slug( $slug, $title ) ) {
+            return self::can_access_competitions();
+        }
+
+        return false;
+    }
+
+    /**
+     * Is a submenu parent authorized?
+     */
+    private static function is_authorized_parent_slug( $parent_slug ) {
+        return self::is_authorized_page_slug( $parent_slug );
+    }
+
+    /**
+     * Is an admin.php?page= slug authorized for the current limited user?
+     */
+    private static function is_authorized_page_slug( $slug ) {
+        $slug = sanitize_key( (string) $slug );
+
+        if ( self::is_gestion_slug( $slug ) ) {
+            return self::can_access_gestion();
+        }
+
+        if ( self::is_licences_slug( $slug ) ) {
+            return self::can_access_licences();
+        }
+
+        if ( self::is_competitions_slug( $slug ) ) {
+            return self::can_access_competitions();
+        }
+
+        return false;
+    }
+
+    /**
+     * Identify UFSC Gestion menu/page slugs without matching unrelated plugins.
+     */
+    private static function is_gestion_slug( $slug, $title = '' ) {
+        $slug = sanitize_key( (string) $slug );
+        if ( in_array( $slug, array( 'ufsc-dashboard', 'ufsc-home', 'ufsc-clubs', 'ufsc-exports' ), true ) ) {
+            return true;
+        }
+
+        return self::title_contains( $title, 'ufsc gestion' );
+    }
+
+    /**
+     * Identify UFSC Licences menu/page slugs.
+     */
+    private static function is_licences_slug( $slug, $title = '' ) {
+        $slug = sanitize_key( (string) $slug );
+        if ( in_array( $slug, array( 'ufsc-licences', 'ufsc-sql-licences', 'ufsc-licences-dashboard' ), true ) ) {
+            return true;
+        }
+
+        return ( 0 === strpos( $slug, 'ufsc-licence' ) || 0 === strpos( $slug, 'ufsc-licences' ) || self::title_contains( $title, 'ufsc licences' ) );
+    }
+
+    /**
+     * Identify competition menu/page slugs from the dedicated competition plugin.
+     */
+    private static function is_competitions_slug( $slug, $title = '' ) {
+        $slug = sanitize_key( (string) $slug );
+        if ( in_array( $slug, array( 'ufsc-competitions', 'competitions', 'edit.php?post_type=ufsc_competition' ), true ) ) {
+            return true;
+        }
+
+        return ( false !== strpos( $slug, 'competition' ) || false !== strpos( $slug, 'competitions' ) || self::title_contains( $title, 'compétitions' ) || self::title_contains( $title, 'competitions' ) );
+    }
+
+    /**
+     * Accent-insensitive-ish lowercase containment for admin menu labels.
+     */
+    private static function title_contains( $title, $needle ) {
+        $title  = strtolower( remove_accents( wp_strip_all_tags( (string) $title ) ) );
+        $needle = strtolower( remove_accents( (string) $needle ) );
+        return '' !== $needle && false !== strpos( $title, $needle );
+    }
+
+    /**
+     * First authorized URL for current user, with requested priority.
+     */
+    private static function get_first_authorized_url() {
+        return self::get_first_authorized_url_for_user( wp_get_current_user() );
+    }
+
+    /**
+     * First authorized URL for a user, with requested priority.
+     */
+    private static function get_first_authorized_url_for_user( WP_User $user ) {
+        if ( user_can( $user, UFSC_Permissions::CAP_COMPETITIONS_READ ) || user_can( $user, UFSC_Permissions::CAP_COMPETITIONS_MANAGE ) ) {
+            return self::get_competitions_url();
+        }
+
+        if ( user_can( $user, UFSC_Permissions::CAP_LICENCES_READ ) || user_can( $user, UFSC_Permissions::CAP_LICENCES_MANAGE ) ) {
+            return self::get_licences_url();
+        }
+
+        if ( user_can( $user, UFSC_Permissions::CAP_GESTION_READ ) || user_can( $user, UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
+            return admin_url( 'admin.php?page=ufsc-home' );
+        }
+
+        return admin_url( 'profile.php' );
+    }
+
+    /**
+     * Best-known UFSC Licences URL.
+     */
+    private static function get_licences_url() {
+        return admin_url( 'admin.php?page=ufsc-licences' );
+    }
+
+    /**
+     * Best-known UFSC Compétitions URL.
+     */
+    private static function get_competitions_url() {
+        return admin_url( 'admin.php?page=ufsc-competitions' );
+    }
+
+    /**
+     * Redirect blocked requests to the authorized UFSC entry point.
+     */
+    private static function redirect_away_from_blocked_page() {
+        $target = self::get_first_authorized_url();
+        $current = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
+
+        if ( $current && false !== strpos( $target, $current ) ) {
+            wp_die( esc_html__( 'Accès refusé : cette page ne fait pas partie de votre espace UFSC.', 'ufsc-clubs' ), esc_html__( 'Accès refusé', 'ufsc-clubs' ), array( 'response' => 403 ) );
+        }
+
+        wp_safe_redirect( $target );
+        exit;
+    }
+}

--- a/includes/permissions/class-ufsc-permissions.php
+++ b/includes/permissions/class-ufsc-permissions.php
@@ -184,10 +184,16 @@ class UFSC_Permissions {
         echo '<h1>' . esc_html__( 'Droits & accès UFSC', 'ufsc-clubs' ) . '</h1>';
         echo '<p class="description">' . esc_html__( 'Les restrictions UFSC sont vérifiées côté serveur. Le masquage des boutons n’est qu’un confort visuel.', 'ufsc-clubs' ) . '</p>';
 
+        $simplified_notice = self::maybe_handle_simplified_admin_save();
+        if ( $simplified_notice ) {
+            $notice = $simplified_notice;
+        }
+
         if ( $notice ) {
             printf( '<div class="notice notice-%1$s is-dismissible"><p>%2$s</p></div>', esc_attr( $notice['type'] ), esc_html( $notice['message'] ) );
         }
 
+        self::render_simplified_admin_option();
         self::render_users_table( $selected_user_id );
 
         if ( $selected_user_id ) {
@@ -195,6 +201,45 @@ class UFSC_Permissions {
         }
 
         echo '</div>';
+    }
+
+    /**
+     * Save global simplified admin interface option.
+     */
+    private static function maybe_handle_simplified_admin_save() {
+        if ( 'POST' !== strtoupper( $_SERVER['REQUEST_METHOD'] ?? '' ) || empty( $_POST['ufsc_simplified_admin_action'] ) ) {
+            return null;
+        }
+
+        check_admin_referer( 'ufsc_save_simplified_admin', 'ufsc_simplified_admin_nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Accès refusé : seuls les administrateurs WordPress peuvent modifier cette option.', 'ufsc-clubs' ) );
+        }
+
+        update_option( 'ufsc_enable_simplified_admin', ! empty( $_POST['ufsc_enable_simplified_admin'] ) ? '1' : '0', false );
+
+        return array( 'type' => 'success', 'message' => __( 'Option d’interface admin simplifiée sauvegardée.', 'ufsc-clubs' ) );
+    }
+
+    /**
+     * Render the global simplified admin interface option for WordPress administrators.
+     */
+    private static function render_simplified_admin_option() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $enabled = '0' !== (string) get_option( 'ufsc_enable_simplified_admin', '1' );
+
+        echo '<h2>' . esc_html__( 'Interface admin simplifiée', 'ufsc-clubs' ) . '</h2>';
+        echo '<form method="post" class="ufsc-simplified-admin-settings" style="max-width:900px;margin-bottom:24px;padding:16px;background:#fff;border:1px solid #dcdcde;">';
+        wp_nonce_field( 'ufsc_save_simplified_admin', 'ufsc_simplified_admin_nonce' );
+        echo '<input type="hidden" name="ufsc_simplified_admin_action" value="save" />';
+        echo '<label><input type="checkbox" name="ufsc_enable_simplified_admin" value="1" ' . checked( $enabled, true, false ) . '> ' . esc_html__( 'Activer l’interface admin simplifiée pour les utilisateurs UFSC limités', 'ufsc-clubs' ) . '</label>';
+        echo '<p class="description">' . esc_html__( 'Activée par défaut. Cette option masque les menus inutiles et redirige les utilisateurs UFSC limités, sans remplacer les contrôles serveur.', 'ufsc-clubs' ) . '</p>';
+        submit_button( __( 'Enregistrer cette option', 'ufsc-clubs' ), 'secondary', 'submit', false );
+        echo '</form>';
     }
 
     /**

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -62,6 +62,7 @@ require_once UFSC_CL_DIR.'includes/core/class-badge-helper.php';
 require_once UFSC_CL_DIR.'includes/core/class-user-club-mapping.php';
 require_once UFSC_CL_DIR.'includes/admin/class-user-club-admin.php';
 require_once UFSC_CL_DIR.'includes/admin/class-user-profile-scope-field.php';
+require_once UFSC_CL_DIR.'includes/admin/class-ufsc-simplified-admin.php';
 require_once UFSC_CL_DIR.'includes/cli/class-wp-cli-commands.php';
 //require_once UFSC_CL_DIR.'includes/front/redirect-check.php';
 
@@ -145,6 +146,7 @@ final class UFSC_CL_Bootstrap {
         add_action( 'init', array( 'UFSC_Cache_Manager', 'init' ) );
         add_action( 'init', array( 'UFSC_Capabilities', 'register_caps' ) );
         add_action( 'init', array( 'UFSC_Permissions', 'init' ) );
+        add_action( 'init', array( 'UFSC_Simplified_Admin', 'init' ) );
         add_action( 'init', array( 'UFSC_User_Profile_Scope_Field', 'init' ) );
         add_action( 'plugins_loaded', array( 'UFSC_DB_Migrations', 'run_migrations' ) );
 


### PR DESCRIPTION
### Motivation
- Simplifier l’interface admin pour les utilisateurs UFSC limités afin qu’ils voient uniquement les outils nécessaires (UFSC Gestion, UFSC Licences, Compétitions) sans toucher aux contrôles serveur existants.
- Centraliser le comportement dans le plugin `UFSC Gestion` et veiller à ce que les vrais administrateurs WordPress (`manage_options`) ne soient jamais affectés.

### Description
- Ajout d’un nouveau module chargé en admin : `includes/admin/class-ufsc-simplified-admin.php` qui gère le filtrage des menus, nettoyage de la barre admin, redirections (`login_redirect` / dashboard) et blocage/redirect des accès directs non autorisés tout en laissant passer `admin-ajax.php`, `admin-post.php`, `async-upload.php` et `profile.php`.
- Intégration du module au bootstrap du plugin via `ufsc-clubs-licences-sql.php` (`add_action( 'init', array( 'UFSC_Simplified_Admin', 'init' ) )`).
- Exposition d’une option globale `ufsc_enable_simplified_admin` (activée par défaut) et ajout d’une UI de configuration dans `UFSC Gestion > Droits & accès` via des ajouts dans `includes/permissions/class-ufsc-permissions.php`.
- Ajustements d’accès pour les écrans licences : menus et contrôles `render_licences` / pages cachées utilisent désormais `ufsc_licences_read` / `ufsc_licences_manage` (modifs dans `includes/admin/class-admin-menu.php` et `includes/admin/class-sql-admin.php`) et ajout d’un menu-pont `UFSC Licences` pour les utilisateurs licence-only.
- Documentation ajoutée `docs/simplified-admin.md` expliquant le principe, la différence UI vs sécurité serveur, menus conservés/masqués, flux de redirection et scénarios de test.

### Testing
- Lint PHP sur fichiers modifiés et nouveau module : `php -l includes/admin/class-ufsc-simplified-admin.php`, `php -l includes/permissions/class-ufsc-permissions.php`, `php -l includes/admin/class-admin-menu.php`, `php -l includes/admin/class-sql-admin.php`, `php -l ufsc-clubs-licences-sql.php` — tous OK.
- Vérification syntaxique sur l’ensemble des fichiers PHP (parcours `rg --files -g '*.php' -g '!vendor'` avec `php -l`) — OK.
- Contrôle statique `git diff --check` — OK.

All automated checks above passed; functional browser scenarios (A–E) should be validated on a running WordPress instance with representative users/roles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1982338308832b97f3b7320f4d2fbf)