### PR TITLE
Stabilize simplified UFSC admin access

### DIFF
--- a/includes/admin/class-ufsc-simplified-admin.php
+++ b/includes/admin/class-ufsc-simplified-admin.php
@@ -54,6 +54,7 @@ class UFSC_Simplified_Admin {
         add_action( 'admin_init', array( __CLASS__, 'force_allow_wp_admin_for_limited_ufsc_users' ), 0 );
         add_action( 'admin_init', array( __CLASS__, 'maybe_redirect_from_dashboard' ), 1 );
         add_action( 'admin_init', array( __CLASS__, 'maybe_block_direct_admin_access' ), 20 );
+        add_action( 'admin_menu', array( __CLASS__, 'register_compatibility_parent_pages' ), 1 );
         add_action( 'admin_menu', array( __CLASS__, 'register_authorized_alias_pages' ), 18 );
         add_action( 'admin_menu', array( __CLASS__, 'register_licences_bridge_menu' ), 19 );
         add_action( 'admin_menu', array( __CLASS__, 'register_welcome_page' ), 20 );
@@ -132,6 +133,36 @@ class UFSC_Simplified_Admin {
         return current_user_can( UFSC_Permissions::CAP_COMPETITIONS_READ ) || current_user_can( UFSC_Permissions::CAP_COMPETITIONS_MANAGE );
     }
 
+
+    /**
+     * Register stable compatibility parents before companion plugins add their subpages.
+     *
+     * Some UFSC LC installations attach settings pages to historical parents such as
+     * ufsc_lc or ufsc-licence-competition. Registering hidden parents prevents the
+     * WordPress "parent slug missing" admin notice without exposing sensitive pages.
+     */
+    public static function register_compatibility_parent_pages() {
+        if ( ! self::is_enabled() ) {
+            return;
+        }
+
+        if ( self::can_access_licences() && class_exists( 'UFSC_SQL_Admin' ) ) {
+            foreach ( array( 'ufsc_lc', 'ufsc-lc', 'ufsc_lc_licences' ) as $slug ) {
+                if ( ! self::menu_slug_exists( $slug ) ) {
+                    add_submenu_page( null, __( 'UFSC Licences', 'ufsc-clubs' ), __( 'UFSC Licences', 'ufsc-clubs' ), UFSC_Permissions::CAP_LICENCES_READ, $slug, array( 'UFSC_SQL_Admin', 'render_licences' ) );
+                }
+            }
+        }
+
+        if ( self::can_access_competitions() ) {
+            foreach ( array( 'ufsc_lc_competitions', 'ufsc-licence-competition' ) as $slug ) {
+                if ( ! self::menu_slug_exists( $slug ) ) {
+                    add_submenu_page( null, __( 'Compétitions', 'ufsc-clubs' ), __( 'Compétitions', 'ufsc-clubs' ), UFSC_Permissions::CAP_COMPETITIONS_READ, $slug, array( __CLASS__, 'render_competitions_bridge_page' ) );
+                }
+            }
+        }
+    }
+
     /**
      * Register hidden aliases for UFSC Gestion/Licences slugs used by existing installs.
      */
@@ -141,17 +172,17 @@ class UFSC_Simplified_Admin {
         }
 
         if ( self::can_access_gestion() ) {
-            add_submenu_page( '', __( 'UFSC Gestion', 'ufsc-clubs' ), __( 'UFSC Gestion', 'ufsc-clubs' ), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-gestion', array( 'UFSC_CL_Admin_Menu', 'render_dashboard' ) );
-            add_submenu_page( '', __( 'UFSC Gestion', 'ufsc-clubs' ), __( 'UFSC Gestion', 'ufsc-clubs' ), UFSC_Permissions::CAP_GESTION_READ, 'ufsc_gestion', array( 'UFSC_CL_Admin_Menu', 'render_dashboard' ) );
+            add_submenu_page( null, __( 'UFSC Gestion', 'ufsc-clubs' ), __( 'UFSC Gestion', 'ufsc-clubs' ), UFSC_Permissions::CAP_GESTION_READ, 'ufsc-gestion', array( 'UFSC_CL_Admin_Menu', 'render_dashboard' ) );
+            add_submenu_page( null, __( 'UFSC Gestion', 'ufsc-clubs' ), __( 'UFSC Gestion', 'ufsc-clubs' ), UFSC_Permissions::CAP_GESTION_READ, 'ufsc_gestion', array( 'UFSC_CL_Admin_Menu', 'render_dashboard' ) );
             if ( class_exists( 'UFSC_SQL_Admin' ) ) {
-                add_submenu_page( '', __( 'Clubs UFSC', 'ufsc-clubs' ), __( 'Clubs UFSC', 'ufsc-clubs' ), UFSC_Permissions::CAP_GESTION_READ, 'ufsc_clubs', array( 'UFSC_SQL_Admin', 'render_clubs' ) );
+                add_submenu_page( null, __( 'Clubs UFSC', 'ufsc-clubs' ), __( 'Clubs UFSC', 'ufsc-clubs' ), UFSC_Permissions::CAP_GESTION_READ, 'ufsc_clubs', array( 'UFSC_SQL_Admin', 'render_clubs' ) );
             }
         }
 
         if ( self::can_access_licences() && class_exists( 'UFSC_SQL_Admin' ) ) {
             foreach ( array( 'ufsc_licences', 'ufsc-licence', 'ufsc_licence', 'ufsc-licences-dashboard', 'ufsc_lc_licences' ) as $slug ) {
                 if ( ! self::menu_slug_exists( $slug ) ) {
-                    add_submenu_page( '', __( 'UFSC Licences', 'ufsc-clubs' ), __( 'UFSC Licences', 'ufsc-clubs' ), UFSC_Permissions::CAP_LICENCES_READ, $slug, array( 'UFSC_SQL_Admin', 'render_licences' ) );
+                    add_submenu_page( null, __( 'UFSC Licences', 'ufsc-clubs' ), __( 'UFSC Licences', 'ufsc-clubs' ), UFSC_Permissions::CAP_LICENCES_READ, $slug, array( 'UFSC_SQL_Admin', 'render_licences' ) );
                 }
             }
         }
@@ -159,7 +190,7 @@ class UFSC_Simplified_Admin {
         if ( self::can_access_competitions() ) {
             foreach ( array( 'ufsc-licence-competition', 'ufsc_licence_competition', 'ufsc-competitions', 'ufsc_competitions', 'ufsc-competition', 'ufsc_competition', 'ufsc-competition-dashboard', 'ufsc_competition_dashboard' ) as $slug ) {
                 if ( ! self::menu_slug_exists( $slug ) ) {
-                    add_submenu_page( '', __( 'Compétitions', 'ufsc-clubs' ), __( 'Compétitions', 'ufsc-clubs' ), UFSC_Permissions::CAP_COMPETITIONS_READ, $slug, array( __CLASS__, 'render_competitions_bridge_page' ) );
+                    add_submenu_page( null, __( 'Compétitions', 'ufsc-clubs' ), __( 'Compétitions', 'ufsc-clubs' ), UFSC_Permissions::CAP_COMPETITIONS_READ, $slug, array( __CLASS__, 'render_competitions_bridge_page' ) );
                 }
             }
         }
@@ -196,6 +227,10 @@ class UFSC_Simplified_Admin {
             return;
         }
 
+        if ( self::has_visible_module_menu( 'licences' ) ) {
+            return;
+        }
+
         add_menu_page(
             __( 'UFSC Licences', 'ufsc-clubs' ),
             __( 'UFSC Licences', 'ufsc-clubs' ),
@@ -211,18 +246,27 @@ class UFSC_Simplified_Admin {
      * Register a lightweight UFSC home page for limited users who can open UFSC Gestion.
      */
     public static function register_welcome_page() {
-        if ( ! self::should_apply() || ! self::can_access_gestion() ) {
+        if ( ! self::should_apply() ) {
             return;
         }
 
-        add_submenu_page(
-            'ufsc-dashboard',
-            __( 'Accueil UFSC', 'ufsc-clubs' ),
-            __( 'Accueil UFSC', 'ufsc-clubs' ),
-            UFSC_Permissions::CAP_GESTION_READ,
-            'ufsc-home',
+        add_menu_page(
+            __( 'Espace UFSC', 'ufsc-clubs' ),
+            __( 'Espace UFSC', 'ufsc-clubs' ),
+            'read',
+            'ufsc-limited-dashboard',
             array( __CLASS__, 'render_welcome_page' ),
-            0
+            'dashicons-admin-home',
+            57
+        );
+
+        add_submenu_page(
+            null,
+            __( 'Espace UFSC', 'ufsc-clubs' ),
+            __( 'Espace UFSC', 'ufsc-clubs' ),
+            'read',
+            'ufsc-home',
+            array( __CLASS__, 'render_welcome_page' )
         );
     }
 
@@ -230,7 +274,7 @@ class UFSC_Simplified_Admin {
      * Render simplified home page.
      */
     public static function render_welcome_page() {
-        if ( ! self::can_access_gestion() ) {
+        if ( ! self::should_apply() ) {
             wp_die( esc_html__( 'Accès refusé.', 'ufsc-clubs' ), esc_html__( 'Accès refusé', 'ufsc-clubs' ), array( 'response' => 403 ) );
         }
 
@@ -238,6 +282,7 @@ class UFSC_Simplified_Admin {
             && ! current_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE )
             && ! current_user_can( UFSC_Permissions::CAP_COMPETITIONS_MANAGE );
         $regions = function_exists( 'ufsc_current_user_allowed_regions' ) ? ufsc_current_user_allowed_regions() : array();
+        $urls    = self::get_module_urls();
 
         echo '<div class="wrap ufsc-simplified-home">';
         echo '<h1>' . esc_html__( 'Bienvenue dans votre espace UFSC', 'ufsc-clubs' ) . '</h1>';
@@ -249,14 +294,15 @@ class UFSC_Simplified_Admin {
 
         echo '<div class="ufsc-dashboard-cards" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;margin-top:20px;">';
         if ( self::can_access_licences() ) {
-            echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'Licences', 'ufsc-clubs' ) . '</h2><p><a class="button button-primary" href="' . esc_url( self::get_licences_url() ) . '">' . esc_html__( 'Accéder aux licences', 'ufsc-clubs' ) . '</a></p></div>';
+            echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'Licences', 'ufsc-clubs' ) . '</h2><p><a class="button button-primary" href="' . esc_url( $urls['licences'] ) . '">' . esc_html__( 'Accéder aux licences', 'ufsc-clubs' ) . '</a></p></div>';
         }
         if ( self::can_access_competitions() ) {
-            echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'Compétitions', 'ufsc-clubs' ) . '</h2><p><a class="button button-primary" href="' . esc_url( self::get_competitions_url() ) . '">' . esc_html__( 'Accéder aux compétitions', 'ufsc-clubs' ) . '</a></p></div>';
+            echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'Compétitions', 'ufsc-clubs' ) . '</h2><p><a class="button button-primary" href="' . esc_url( $urls['competitions'] ) . '">' . esc_html__( 'Accéder aux compétitions', 'ufsc-clubs' ) . '</a></p></div>';
         }
         if ( self::can_access_gestion() ) {
-            echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'UFSC Gestion', 'ufsc-clubs' ) . '</h2><p><a class="button" href="' . esc_url( admin_url( 'admin.php?page=ufsc-dashboard' ) ) . '">' . esc_html__( 'Accéder à UFSC Gestion', 'ufsc-clubs' ) . '</a></p></div>';
+            echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'UFSC Gestion', 'ufsc-clubs' ) . '</h2><p><a class="button" href="' . esc_url( $urls['gestion'] ) . '">' . esc_html__( 'Accéder à UFSC Gestion', 'ufsc-clubs' ) . '</a></p></div>';
         }
+        echo '<div class="ufsc-dashboard-card"><h2>' . esc_html__( 'Profil', 'ufsc-clubs' ) . '</h2><p><a class="button" href="' . esc_url( $urls['profil'] ) . '">' . esc_html__( 'Modifier mon profil', 'ufsc-clubs' ) . '</a></p></div>';
         echo '</div>';
 
         if ( ! empty( $regions ) ) {
@@ -506,6 +552,29 @@ class UFSC_Simplified_Admin {
                 }
             }
         }
+
+        self::deduplicate_limited_top_level_menus();
+    }
+
+    /**
+     * Ensure only one visible top-level entry remains for each simplified UFSC module.
+     */
+    private static function deduplicate_limited_top_level_menus() {
+        global $menu;
+        $seen = array();
+        foreach ( (array) $menu as $index => $item ) {
+            $slug   = isset( $item[2] ) ? (string) $item[2] : '';
+            $title  = isset( $item[0] ) ? wp_strip_all_tags( (string) $item[0] ) : '';
+            $module = 'profile.php' === $slug ? 'profil' : self::module_for_slug( $slug, $title );
+            if ( ! $module ) {
+                continue;
+            }
+            if ( isset( $seen[ $module ] ) ) {
+                unset( $menu[ $index ] );
+                continue;
+            }
+            $seen[ $module ] = true;
+        }
     }
 
     /**
@@ -567,6 +636,10 @@ class UFSC_Simplified_Admin {
             return true;
         }
 
+        if ( self::slug_matches( $slug, array( 'ufsc-limited-dashboard', 'ufsc-home' ) ) ) {
+            return true;
+        }
+
         if ( self::is_gestion_slug( $slug, $title ) ) {
             return self::can_access_gestion();
         }
@@ -594,6 +667,10 @@ class UFSC_Simplified_Admin {
      */
     private static function is_authorized_page_slug( $slug ) {
         $slug = sanitize_key( (string) $slug );
+
+        if ( self::slug_matches( $slug, array( 'ufsc-limited-dashboard', 'ufsc-home' ) ) ) {
+            return true;
+        }
 
         if ( self::is_gestion_slug( $slug ) ) {
             return self::can_access_gestion();
@@ -690,24 +767,47 @@ class UFSC_Simplified_Admin {
      * Whether a menu/submenu slug is already registered in WordPress menu globals.
      */
     private static function menu_slug_exists( $slug ) {
-        global $menu, $submenu;
         $slug = self::normalize_page_slug( $slug );
+        $map  = self::get_registered_menu_slug_map();
+        return isset( $map[ $slug ] );
+    }
 
+    /**
+     * Request-local map of registered admin slugs to avoid repeated menu scans.
+     *
+     * @return array<string,bool>
+     */
+    private static function get_registered_menu_slug_map() {
+        global $menu, $submenu;
+        static $cache = null;
+        static $signature = '';
+
+        $submenu_items = 0;
+        foreach ( (array) $submenu as $items ) {
+            $submenu_items += count( (array) $items );
+        }
+        $current_signature = count( (array) $menu ) . ':' . count( (array) $submenu ) . ':' . $submenu_items;
+        if ( null !== $cache && $signature === $current_signature ) {
+            return $cache;
+        }
+
+        $cache = array();
         foreach ( (array) $menu as $item ) {
-            if ( isset( $item[2] ) && self::normalize_page_slug( (string) $item[2] ) === $slug ) {
-                return true;
+            if ( isset( $item[2] ) ) {
+                $cache[ self::normalize_page_slug( (string) $item[2] ) ] = true;
             }
         }
 
         foreach ( (array) $submenu as $items ) {
             foreach ( (array) $items as $item ) {
-                if ( isset( $item[2] ) && self::normalize_page_slug( (string) $item[2] ) === $slug ) {
-                    return true;
+                if ( isset( $item[2] ) ) {
+                    $cache[ self::normalize_page_slug( (string) $item[2] ) ] = true;
                 }
             }
         }
 
-        return false;
+        $signature = $current_signature;
+        return $cache;
     }
 
     /**
@@ -771,6 +871,9 @@ class UFSC_Simplified_Admin {
         if ( self::is_licences_slug( $slug, $title ) ) {
             return 'licences';
         }
+        if ( self::slug_matches( $slug, array( 'ufsc-limited-dashboard', 'ufsc-home' ) ) ) {
+            return 'espace_ufsc';
+        }
         if ( self::is_gestion_slug( $slug, $title ) ) {
             return 'gestion';
         }
@@ -814,19 +917,64 @@ class UFSC_Simplified_Admin {
             return admin_url( 'profile.php' );
         }
 
-        if ( user_can( $user, UFSC_Permissions::CAP_COMPETITIONS_READ ) || user_can( $user, UFSC_Permissions::CAP_COMPETITIONS_MANAGE ) ) {
-            return self::get_first_candidate_admin_url( 'competitions' );
-        }
-
-        if ( user_can( $user, UFSC_Permissions::CAP_LICENCES_READ ) || user_can( $user, UFSC_Permissions::CAP_LICENCES_MANAGE ) ) {
-            return self::get_first_candidate_admin_url( 'licences' );
-        }
-
-        if ( user_can( $user, UFSC_Permissions::CAP_GESTION_READ ) || user_can( $user, UFSC_Permissions::CAP_GESTION_MANAGE ) ) {
-            return self::get_first_candidate_admin_url( 'gestion' );
+        if ( self::is_limited_ufsc_user( $user->ID ) ) {
+            return admin_url( 'admin.php?page=ufsc-limited-dashboard' );
         }
 
         return admin_url( 'profile.php' );
+    }
+
+
+    /**
+     * Central source of truth for simplified UFSC admin URLs.
+     *
+     * @return array<string,string>
+     */
+    public static function get_module_urls() {
+        static $urls = null;
+        if ( null !== $urls ) {
+            return $urls;
+        }
+
+        $urls = array(
+            'espace_ufsc' => admin_url( 'admin.php?page=ufsc-limited-dashboard' ),
+            'gestion'     => self::get_first_candidate_admin_url( 'gestion' ),
+            'clubs'       => self::get_first_existing_slug_url( array( 'ufsc-clubs', 'ufsc-sql-clubs', 'ufsc_clubs' ), 'admin.php?page=ufsc-clubs' ),
+            'licences'    => self::get_first_candidate_admin_url( 'licences' ),
+            'competitions'=> self::get_first_candidate_admin_url( 'competitions' ),
+            'profil'      => admin_url( 'profile.php' ),
+        );
+
+        return $urls;
+    }
+
+    /**
+     * First URL for an already registered slug in a preferred list.
+     */
+    private static function get_first_existing_slug_url( array $slugs, $fallback_path ) {
+        foreach ( $slugs as $slug ) {
+            if ( self::menu_slug_exists( $slug ) ) {
+                return admin_url( 'admin.php?page=' . rawurlencode( self::normalize_page_slug( $slug ) ) );
+            }
+        }
+
+        return admin_url( $fallback_path );
+    }
+
+    /**
+     * Detect whether a visible top-level menu for a module already exists.
+     */
+    private static function has_visible_module_menu( $module ) {
+        global $menu;
+        $module = sanitize_key( (string) $module );
+        foreach ( (array) $menu as $item ) {
+            $slug  = isset( $item[2] ) ? (string) $item[2] : '';
+            $title = isset( $item[0] ) ? wp_strip_all_tags( (string) $item[0] ) : '';
+            if ( $module === self::module_for_slug( $slug, $title ) ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -875,9 +1023,15 @@ class UFSC_Simplified_Admin {
     private static function get_first_candidate_admin_url( $module ) {
         $detected = self::get_detected_ufsc_menus( $module );
         if ( ! empty( $detected ) ) {
-            $first = reset( $detected );
-            if ( ! empty( $first['slug'] ) ) {
-                return admin_url( 'admin.php?page=' . rawurlencode( $first['slug'] ) );
+            foreach ( $detected as $item ) {
+                if ( 'menu' === $item['type'] && ! empty( $item['slug'] ) ) {
+                    return admin_url( 'admin.php?page=' . rawurlencode( $item['slug'] ) );
+                }
+            }
+            foreach ( $detected as $item ) {
+                if ( 'submenu' === $item['type'] && ! empty( $item['parent'] ) && ! empty( $item['slug'] ) ) {
+                    return admin_url( 'admin.php?page=' . rawurlencode( $item['slug'] ) );
+                }
             }
         }
 

--- a/includes/admin/list-tables/class-ufsc-clubs-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-clubs-list-table.php
@@ -82,7 +82,12 @@ class UFSC_Clubs_List_Table {
         echo '</div>';
         echo '<div class="ufsc-renewal-notice"><span class="dashicons dashicons-info"></span><p>' . esc_html__( 'Renouvellement des affiliations : à chaque nouvelle saison, les clubs devront confirmer ou renouveler leur affiliation afin de maintenir leurs licences actives.', 'ufsc-clubs' ) . '</p></div>';
         if ( function_exists( 'ufsc_user_has_all_regions_access' ) && ! ufsc_user_has_all_regions_access() ) {
-            echo '<div class="notice notice-info"><p>' . esc_html__( 'Résultats filtrés selon vos régions UFSC autorisées.', 'ufsc-clubs' ) . '</p></div>';
+            $allowed_regions = function_exists( 'ufsc_current_user_allowed_regions' ) ? ufsc_current_user_allowed_regions() : array();
+            if ( empty( $allowed_regions ) ) {
+                echo '<div class="notice notice-warning"><p>' . esc_html__( 'Aucune région n’est associée à votre compte. Contactez un administrateur UFSC.', 'ufsc-clubs' ) . '</p></div>';
+            } else {
+                echo '<div class="notice notice-info"><p>' . esc_html__( 'Résultats filtrés selon vos régions UFSC autorisées.', 'ufsc-clubs' ) . '</p></div>';
+            }
         }
 
         // Affichage des notices
@@ -485,7 +490,7 @@ class UFSC_Clubs_List_Table {
             'pending' => 0,
             'documents_complete' => null,
             'documents_incomplete' => null,
-            'licences' => array_sum( array_map( 'intval', (array) $licence_counts ) ),
+            'licences' => self::sum_licence_counts_for_scope( $columns, $clubs_table, $licence_counts, $where_scope ),
             'missing_affiliation' => null,
         );
 
@@ -538,6 +543,31 @@ class UFSC_Clubs_List_Table {
             echo '</div>';
         }
         echo '</div>';
+    }
+
+
+    /**
+     * Sum licence counts only for clubs in the same regional perimeter as the cards/table.
+     */
+    private static function sum_licence_counts_for_scope( $columns, $clubs_table, $licence_counts, $where_scope ) {
+        if ( '' === $where_scope ) {
+            return array_sum( array_map( 'intval', (array) $licence_counts ) );
+        }
+
+        global $wpdb;
+        $id_column = function_exists( 'ufsc_club_col' ) ? ufsc_club_col( 'id' ) : 'id';
+        if ( ! self::has_verified_column( $columns, $clubs_table, $id_column ) ) {
+            $id_column = 'id';
+        }
+
+        $club_ids = $wpdb->get_col( "SELECT `{$id_column}` FROM `{$clubs_table}` {$where_scope}" );
+        $total    = 0;
+        foreach ( (array) $club_ids as $club_id ) {
+            $club_id = (int) $club_id;
+            $total  += isset( $licence_counts[ $club_id ] ) ? (int) $licence_counts[ $club_id ] : 0;
+        }
+
+        return $total;
     }
 
     /**

--- a/includes/permissions/class-ufsc-permissions.php
+++ b/includes/permissions/class-ufsc-permissions.php
@@ -33,7 +33,7 @@ class UFSC_Permissions {
     public static function maybe_register_roles_and_caps() {
         self::ensure_ufsc_roles_have_read();
 
-        $version = '2026-05-29-2';
+        $version = '2026-05-29-3';
         if ( get_option( 'ufsc_permissions_caps_version' ) === $version ) {
             return;
         }
@@ -78,8 +78,13 @@ class UFSC_Permissions {
     public static function ensure_ufsc_roles_have_read() {
         foreach ( array_keys( self::get_role_capabilities() ) as $role_key ) {
             $role = get_role( $role_key );
-            if ( $role && ! $role->has_cap( 'read' ) ) {
-                $role->add_cap( 'read' );
+            if ( ! $role ) {
+                continue;
+            }
+            foreach ( array( 'read', 'level_0' ) as $native_cap ) {
+                if ( ! $role->has_cap( $native_cap ) ) {
+                    $role->add_cap( $native_cap );
+                }
             }
         }
     }
@@ -110,6 +115,7 @@ class UFSC_Permissions {
                 'label' => __( 'Lecture régionale', 'ufsc-clubs' ),
                 'caps'  => array(
                     'read' => true,
+                    'level_0' => true,
                     self::CAP_GESTION_READ  => true,
                     self::CAP_LICENCES_READ => true,
                 ),
@@ -118,6 +124,7 @@ class UFSC_Permissions {
                 'label' => __( 'Gestion régionale', 'ufsc-clubs' ),
                 'caps'  => array(
                     'read' => true,
+                    'level_0' => true,
                     self::CAP_GESTION_READ    => true,
                     self::CAP_GESTION_MANAGE  => true,
                     self::CAP_LICENCES_READ   => true,
@@ -128,6 +135,7 @@ class UFSC_Permissions {
                 'label' => __( 'Gestion compétitions', 'ufsc-clubs' ),
                 'caps'  => array(
                     'read' => true,
+                    'level_0' => true,
                     self::CAP_GESTION_READ          => true,
                     self::CAP_LICENCES_READ         => true,
                     self::CAP_COMPETITIONS_READ     => true,
@@ -138,6 +146,7 @@ class UFSC_Permissions {
                 'label' => __( 'Admin UFSC limité', 'ufsc-clubs' ),
                 'caps'  => array(
                     'read' => true,
+                    'level_0' => true,
                     self::CAP_GESTION_READ          => true,
                     self::CAP_LICENCES_READ         => true,
                     self::CAP_COMPETITIONS_READ     => true,

--- a/includes/security/class-ufsc-scope.php
+++ b/includes/security/class-ufsc-scope.php
@@ -85,11 +85,19 @@ class UFSC_Scope {
             return false;
         }
 
-        if ( user_can( $user_id, UFSC_Capabilities::CAP_SCOPE_ALL_REGIONS ) ) {
+        if ( user_can( $user_id, 'manage_options' ) ) {
             return true;
         }
 
-        return user_can( $user_id, 'manage_options' );
+        if ( class_exists( 'UFSC_Permissions' ) && user_can( $user_id, UFSC_Permissions::CAP_ALL_REGIONS_ACCESS ) ) {
+            return true;
+        }
+
+        if ( class_exists( 'UFSC_Capabilities' ) && user_can( $user_id, UFSC_Capabilities::CAP_SCOPE_ALL_REGIONS ) ) {
+            return true;
+        }
+
+        return class_exists( 'UFSC_Permissions' ) && '1' === (string) get_user_meta( $user_id, UFSC_Permissions::META_ALL_REGIONS, true );
     }
 
     /**
@@ -131,9 +139,20 @@ class UFSC_Scope {
      * @return array
      */
     public static function get_scope_region_values() {
+        if ( self::user_has_all_regions() ) {
+            return array();
+        }
+
+        if ( function_exists( 'ufsc_get_user_regions' ) ) {
+            $regions = ufsc_get_user_regions();
+            if ( ! empty( $regions ) ) {
+                return array_values( array_unique( array_map( 'sanitize_text_field', $regions ) ) );
+            }
+        }
+
         $slug = self::get_user_scope_region();
         if ( ! $slug ) {
-            return array();
+            return array( '__ufsc_no_region_allowed__' );
         }
 
         $label = self::get_region_label( $slug );


### PR DESCRIPTION
### Motivation

- Stabiliser l’interface admin simplifiée pour utilisateurs UFSC limités (HichamUFSC) en supprimant la dépendance au rôle `contributor`, en corrigeant les doublons de menu, les slugs/links erronés et les erreurs parent_slug visibles.
- Assurer une navigation propre et performante (entrée unique « Espace UFSC »), tout en conservant les protections serveur existantes et sans donner de capacités WordPress élevées.

### Description

- Ajout d’un vrai point d’entrée « Espace UFSC » et centralisation des URLs UFSC via `UFSC_Simplified_Admin::get_module_urls()` pour garantir que les boutons ouvrent les bons écrans; redirection post-login des utilisateurs limités vers `ufsc-limited-dashboard`. (fichier modifié: `includes/admin/class-ufsc-simplified-admin.php`).
- Prévention des doublons et compatibilité historique: enregistrement précoce de parents/aliases cachés (`add_submenu_page( null, ...)`) pour éviter la notice « parent slug missing », logique `has_visible_module_menu()` et déduplication finale des top-level menus pour garder une seule entrée par module visible. (fichier modifié: `includes/admin/class-ufsc-simplified-admin.php`).
- Rôle et capacités: `ufsc_admin_limited` reçoit maintenant proprement les capacités natives minimales `read` + `level_0` (pas de `manage_options` ni autres capacités sensibles), via la routine d’enregistrement des rôles/caps; version bump du registre de caps. (fichier modifié: `includes/permissions/class-ufsc-permissions.php`).
- Cohérence régionale et statistiques: `UFSC_Scope::user_has_all_regions()` et `get_scope_region_values()` clarifiés pour distinguer administrateurs, accès « toutes régions », listes de régions explicites et absence de régions (affichage d’une notice claire); les cartes KPI et le tableau Clubs utilisent désormais le même périmètre et le total des licences est recalculé pour le scope courant (`sum_licence_counts_for_scope`). (fichiers modifiés: `includes/security/class-ufsc-scope.php`, `includes/admin/list-tables/class-ufsc-clubs-list-table.php`).
- Optimisations et robustesse: mise en cache locale de la détection des slugs/menu (`get_registered_menu_slug_map()`), meilleure détection des menus actifs (priorité menu > submenu) et protections inchangées côté serveur (`current_user_can`, nonces, assertions scope). (fichier modifié: `includes/admin/class-ufsc-simplified-admin.php`).

Fichiers modifiés
- `includes/admin/class-ufsc-simplified-admin.php`
- `includes/admin/list-tables/class-ufsc-clubs-list-table.php`
- `includes/permissions/class-ufsc-permissions.php`
- `includes/security/class-ufsc-scope.php`

### Testing

- `php -l` sur les fichiers modifiés (`includes/admin/class-ufsc-simplified-admin.php`, `includes/permissions/class-ufsc-permissions.php`, `includes/security/class-ufsc-scope.php`, `includes/admin/list-tables/class-ufsc-clubs-list-table.php`) — OK.
- Lint PHP sur l’ensemble du repo (exclusion vendor via la commande utilisée) — OK (pas d’erreurs de syntaxe détectées).
- `git diff --check` — OK (pas d’espaces fin de ligne ni erreurs détectées).
- Commit produit et PR préparée (message: "Stabilize simplified UFSC admin access").

Tous les tests automatiques listés ci‑dessus sont passés avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a1374c730832bafb33d5edce7ce97)