### PR TITLE
Synchronize simplified UFSC admin with licences and competitions

### DIFF
--- a/includes/admin/class-ufsc-simplified-admin.php
+++ b/includes/admin/class-ufsc-simplified-admin.php
@@ -141,6 +141,80 @@ class UFSC_Simplified_Admin {
         return current_user_can( UFSC_Permissions::CAP_COMPETITIONS_READ ) || current_user_can( UFSC_Permissions::CAP_COMPETITIONS_MANAGE );
     }
 
+    /**
+     * Licence pages exposed by UFSC Licences / Compétitions that are safe for read access.
+     *
+     * @return string[]
+     */
+    private static function allowed_licence_page_slugs() {
+        return array(
+            'ufsc-sql-licences',
+            'ufsc-sql-licenses',
+            'ufsc-licences',
+            'ufsc_licences',
+            'ufsc_lc_licences',
+            'ufsc-licence',
+            'ufsc_licence',
+            'ufsc-licence-documents',
+            'ufsc-licences-dashboard',
+            'ufsc_lc',
+            'ufsc-lc',
+        );
+    }
+
+    /**
+     * Competition pages exposed by UFSC Licences / Compétitions that are safe for read/manage access.
+     *
+     * @return string[]
+     */
+    private static function allowed_competition_page_slugs() {
+        return array(
+            'ufsc-competitions',
+            'ufsc_competitions',
+            'ufsc-competition',
+            'ufsc_competition',
+            'ufsc-competition-dashboard',
+            'ufsc_competition_dashboard',
+            'ufsc-licence-competition',
+            'ufsc_licence_competition',
+            'ufsc_lc_competitions',
+            'competitions',
+            'ufsc-competitions-categories',
+            'ufsc-competitions-entries',
+            'ufsc-competitions-entries-import',
+            'ufsc-competitions-weighins',
+            'ufsc-competitions-bouts',
+            'ufsc-competitions-plateau',
+            'ufsc-competitions-timing-profiles',
+            'ufsc-competitions-quality',
+            'ufsc-competitions-print',
+            'ufsc-competitions-officials',
+            'ufsc-competitions-sensitive-ops',
+            'ufsc-competitions-estimation',
+            'ufsc-competitions-logs',
+            'ufsc-competitions-guide',
+            'ufsc-competitions-entry-validation',
+        );
+    }
+
+    /**
+     * Sensitive UFSC pages that must not be opened by limited users through the simplified allowlist.
+     *
+     * @return string[]
+     */
+    private static function blocked_limited_page_slugs() {
+        return array(
+            'ufsc-competitions-settings',
+            'ufsc-competitions-access-diagnostic',
+            'ufsc-permissions',
+            'ufsc-settings',
+            'ufsc-woocommerce',
+            'ufsc-sql-settings',
+            'ufsc_lc_settings',
+            'ufsc-lc-settings',
+        );
+    }
+
 
     /**
      * Register stable compatibility parents before companion plugins add their subpages.
@@ -216,6 +290,24 @@ class UFSC_Simplified_Admin {
                 'icon'       => 'dashicons-awards',
                 'position'   => 62,
             ),
+            array(
+                'slug'       => 'ufsc_lc_settings',
+                'page_title' => __( 'Paramètres UFSC LC', 'ufsc-clubs' ),
+                'menu_title' => __( 'Paramètres UFSC LC', 'ufsc-clubs' ),
+                'capability' => 'manage_options',
+                'callback'   => '__return_empty_string',
+                'icon'       => 'dashicons-admin-generic',
+                'position'   => 63,
+            ),
+            array(
+                'slug'       => 'ufsc-lc-settings',
+                'page_title' => __( 'Paramètres UFSC LC', 'ufsc-clubs' ),
+                'menu_title' => __( 'Paramètres UFSC LC', 'ufsc-clubs' ),
+                'capability' => 'manage_options',
+                'callback'   => '__return_empty_string',
+                'icon'       => 'dashicons-admin-generic',
+                'position'   => 64,
+            ),
         );
     }
 
@@ -249,7 +341,7 @@ class UFSC_Simplified_Admin {
         }
 
         if ( self::can_access_licences() && class_exists( 'UFSC_SQL_Admin' ) ) {
-            foreach ( array( 'ufsc_licences', 'ufsc-licence', 'ufsc_licence', 'ufsc-licences-dashboard', 'ufsc_lc_licences' ) as $slug ) {
+            foreach ( array( 'ufsc_licences', 'ufsc-licence', 'ufsc_licence', 'ufsc-licence-documents', 'ufsc-licences-dashboard', 'ufsc_lc_licences' ) as $slug ) {
                 if ( ! self::menu_slug_exists( $slug ) ) {
                     add_submenu_page( null, __( 'UFSC Licences', 'ufsc-clubs' ), __( 'UFSC Licences', 'ufsc-clubs' ), UFSC_Permissions::CAP_LICENCES_READ, $slug, array( 'UFSC_SQL_Admin', 'render_licences' ) );
                 }
@@ -660,7 +752,7 @@ class UFSC_Simplified_Admin {
      */
     private static function is_sensitive_ufsc_slug( $slug ) {
         $normalized = self::normalize_page_slug( $slug );
-        if ( self::slug_matches( $slug, array( 'ufsc-permissions', 'ufsc-settings', 'ufsc-woocommerce', 'ufsc-sql-settings' ) ) ) {
+        if ( self::slug_matches( $slug, self::blocked_limited_page_slugs() ) ) {
             return true;
         }
 
@@ -921,15 +1013,19 @@ class UFSC_Simplified_Admin {
             return true;
         }
 
+        if ( self::is_sensitive_ufsc_slug( $slug ) ) {
+            return false;
+        }
+
         if ( self::is_gestion_slug( $slug ) ) {
             return self::can_access_gestion();
         }
 
-        if ( self::is_licences_slug( $slug ) ) {
+        if ( self::slug_matches( $slug, self::allowed_licence_page_slugs() ) || self::is_licences_slug( $slug ) ) {
             return self::can_access_licences();
         }
 
-        if ( self::is_competitions_slug( $slug ) ) {
+        if ( self::slug_matches( $slug, self::allowed_competition_page_slugs() ) || self::is_competitions_slug( $slug ) ) {
             return self::can_access_competitions();
         }
 
@@ -951,7 +1047,7 @@ class UFSC_Simplified_Admin {
      * Identify UFSC Licences menu/page slugs.
      */
     private static function is_licences_slug( $slug, $title = '' ) {
-        if ( self::slug_matches( $slug, array( 'ufsc-licences', 'ufsc_licences', 'ufsc-licence', 'ufsc_licence', 'ufsc-licences-dashboard', 'ufsc_lc_licences', 'ufsc_lc', 'ufsc-lc', 'ufsc-sql-licences', 'ufsc-sql-licenses' ) ) ) {
+        if ( self::slug_matches( $slug, self::allowed_licence_page_slugs() ) ) {
             return true;
         }
 
@@ -968,7 +1064,7 @@ class UFSC_Simplified_Admin {
             return true;
         }
 
-        if ( self::slug_matches( $slug, array( 'ufsc-competitions', 'ufsc_competitions', 'ufsc-competition', 'ufsc_competition', 'ufsc-competition-dashboard', 'ufsc_competition_dashboard', 'ufsc-licence-competition', 'ufsc_licence_competition', 'competitions' ) ) ) {
+        if ( self::slug_matches( $slug, self::allowed_competition_page_slugs() ) ) {
             return true;
         }
 
@@ -1189,10 +1285,10 @@ class UFSC_Simplified_Admin {
             'dashboard'   => admin_url( 'admin.php?page=ufsc-limited-dashboard' ),
             'espace_ufsc' => admin_url( 'admin.php?page=ufsc-limited-dashboard' ),
             'articles'    => admin_url( 'edit.php' ),
-            'gestion'     => self::get_first_candidate_admin_url( 'gestion' ),
+            'gestion'     => self::get_gestion_admin_url(),
             'clubs'       => self::get_first_existing_slug_url( array( 'ufsc-clubs', 'ufsc-sql-clubs', 'ufsc_clubs' ), 'admin.php?page=ufsc-clubs' ),
             'licences'    => self::get_licences_admin_url(),
-            'competitions'=> self::get_first_candidate_admin_url( 'competitions' ),
+            'competitions'=> self::get_competitions_admin_url(),
             'profile'     => admin_url( 'profile.php' ),
             'profil'      => admin_url( 'profile.php' ),
         );
@@ -1202,13 +1298,27 @@ class UFSC_Simplified_Admin {
 
 
     /**
+     * Canonical UFSC Gestion URL for the simplified dashboard button.
+     */
+    private static function get_gestion_admin_url() {
+        return self::get_first_existing_slug_url(
+            array( 'ufsc-dashboard', 'ufsc-clubs', 'ufsc-sql-clubs', 'ufsc_clubs', 'ufsc-gestion', 'ufsc_gestion' ),
+            'admin.php?page=ufsc-dashboard'
+        );
+    }
+
+    /**
      * The canonical admin licences table URL, never a front-office/club dashboard URL.
      */
     private static function get_licences_admin_url() {
-        return self::get_first_existing_slug_url(
-            array( 'ufsc-sql-licences', 'ufsc-licences', 'ufsc_lc_licences', 'ufsc-sql-licenses' ),
-            'admin.php?page=ufsc-sql-licences'
-        );
+        return admin_url( 'admin.php?page=ufsc-sql-licences' );
+    }
+
+    /**
+     * Canonical UFSC Compétitions URL for the simplified dashboard button.
+     */
+    private static function get_competitions_admin_url() {
+        return admin_url( 'admin.php?page=ufsc-competitions' );
     }
 
     /**
@@ -1340,8 +1450,8 @@ class UFSC_Simplified_Admin {
         $module = sanitize_key( (string) $module );
         $paths  = array(
             'competitions' => array(
-                'admin.php?page=ufsc-licence-competition',
                 'admin.php?page=ufsc-competitions',
+                'admin.php?page=ufsc-licence-competition',
                 'admin.php?page=ufsc_competitions',
                 'admin.php?page=ufsc-competition',
                 'admin.php?page=ufsc_competition',
@@ -1360,11 +1470,12 @@ class UFSC_Simplified_Admin {
                 'admin.php?page=ufsc_lc',
             ),
             'gestion' => array(
+                'admin.php?page=ufsc-dashboard',
+                'admin.php?page=ufsc-clubs',
+                'admin.php?page=ufsc-sql-clubs',
+                'admin.php?page=ufsc_clubs',
                 'admin.php?page=ufsc-gestion',
                 'admin.php?page=ufsc_gestion',
-                'admin.php?page=ufsc-clubs',
-                'admin.php?page=ufsc_clubs',
-                'admin.php?page=ufsc-dashboard',
             ),
         );
 


### PR DESCRIPTION
### Motivation

- Ensure limited UFSC users (eg. role `ufsc_admin_limited`) can reach the actual UFSC Licences and Compétitions screens they are allowed to use without being redirected to the simplified dashboard or seeing sensitive settings notices.
- Prevent exposure of admin-only settings/diagnostics to limited users and stop the spurious “Paramètres UFSC LC” parent-slug notice being shown in the simplified UI.

### Description

- Add explicit allowlists: `allowed_licence_page_slugs()` and `allowed_competition_page_slugs()` to enumerate Licences and Compétitions slugs (including the requested competition subpages) that limited users may open.
- Add `blocked_limited_page_slugs()` and make `is_sensitive_ufsc_slug()` use it so sensitive pages (settings, permissions, diagnostics) remain blocked for limited users.
- Update `is_authorized_page_slug()` to refuse sensitive slugs first and to accept explicit licence/competition slugs, avoiding accidental redirects to the limited dashboard for allowed pages.
- Make module URLs canonical by adding `get_gestion_admin_url()`, `get_competitions_admin_url()` and returning `get_licences_admin_url()` = `admin.php?page=ufsc-sql-licences`, and add hidden compatibility parent pages `ufsc_lc_settings` / `ufsc-lc-settings` (capability `manage_options`) to prevent the settings notice for non-admins.

### Testing

- Ran `php -l includes/admin/class-ufsc-simplified-admin.php` to validate PHP syntax and it succeeded.
- Executed an inline PHP stub test that simulates Hicham-like capabilities and verified that allowed licence and competition slugs are accepted, blocked settings/diagnostics slugs are refused, and `get_module_urls()` returns the expected canonical URLs; the test passed.
- Ran `git diff --check` to ensure no whitespace/errors were introduced and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d9abbbc40832b90a19fb89fd0660a)