### PR TITLE
Add slug allowlists and capability mapping; refactor clubs table markup and admin CSS for read-only/manage modes

### DIFF
--- a/assets/admin/css/ufsc-clubs-admin.css
+++ b/assets/admin/css/ufsc-clubs-admin.css
@@ -374,9 +374,19 @@
     border-spacing: 0;
     box-shadow: none;
     margin: 0;
-    min-width: 1220px;
-    table-layout: auto;
+    min-width: 1180px;
+    table-layout: auto !important;
     width: 100%;
+}
+
+.ufsc-clubs-table--readonly {
+    min-width: 1040px;
+}
+
+.ufsc-clubs-table th,
+.ufsc-clubs-table td {
+    overflow-wrap: normal;
+    word-break: normal;
 }
 
 .ufsc-clubs-table thead th,
@@ -411,11 +421,6 @@
     vertical-align: middle;
 }
 
-.ufsc-clubs-table tbody td:not(.ufsc-row-actions),
-.ufsc-clubs-table tbody th:not(.check-column) {
-    overflow-wrap: anywhere;
-}
-
 .ufsc-clubs-table tbody tr:last-child td,
 .ufsc-clubs-table tbody tr:last-child th {
     border-bottom: 0;
@@ -433,26 +438,35 @@
     background: #eef5ff;
 }
 
-.ufsc-clubs-table th:nth-child(1),
-.ufsc-clubs-table td:nth-child(1) { width: 42px; }
-.ufsc-clubs-table th:nth-child(2),
-.ufsc-clubs-table td:nth-child(2) { width: 64px; text-align: center; }
-.ufsc-clubs-table th:nth-child(3),
-.ufsc-clubs-table td:nth-child(3) { min-width: 260px; width: 26%; }
-.ufsc-clubs-table th:nth-child(4),
-.ufsc-clubs-table td:nth-child(4) { min-width: 150px; }
-.ufsc-clubs-table th:nth-child(5),
-.ufsc-clubs-table td:nth-child(5) { min-width: 145px; }
-.ufsc-clubs-table th:nth-child(6),
-.ufsc-clubs-table td:nth-child(6) { min-width: 130px; }
-.ufsc-clubs-table th:nth-child(7),
-.ufsc-clubs-table td:nth-child(7) { min-width: 120px; }
-.ufsc-clubs-table th:nth-child(8),
-.ufsc-clubs-table td:nth-child(8) { min-width: 125px; }
-.ufsc-clubs-table th:nth-child(9),
-.ufsc-clubs-table td:nth-child(9) { min-width: 118px; }
-.ufsc-clubs-table th:nth-child(10),
-.ufsc-clubs-table td:nth-child(10) { min-width: 285px; width: 285px; }
+.ufsc-clubs-table .column-checkbox { width: 42px; }
+.ufsc-clubs-table .column-id { text-align: center; width: 64px; }
+.ufsc-clubs-table .column-club {
+    min-width: 280px;
+    overflow-wrap: normal;
+    white-space: normal;
+    width: 28%;
+    word-break: normal;
+}
+.ufsc-clubs-table .column-region {
+    min-width: 150px;
+    white-space: nowrap;
+}
+.ufsc-clubs-table .column-affiliation { min-width: 145px; }
+.ufsc-clubs-table .column-status { min-width: 130px; }
+.ufsc-clubs-table .column-licences { min-width: 120px; }
+.ufsc-clubs-table .column-documents { min-width: 150px; }
+.ufsc-clubs-table .column-created {
+    min-width: 118px;
+    white-space: nowrap;
+}
+.ufsc-clubs-table .column-actions {
+    min-width: 220px;
+    width: 220px;
+}
+.ufsc-clubs-table--manage .column-actions {
+    min-width: 285px;
+    width: 285px;
+}
 
 .ufsc-clubs-table .check-column input {
     margin-top: 0;
@@ -465,12 +479,20 @@
     font-weight: 800;
     line-height: 1.35;
     margin-bottom: 3px;
+    overflow-wrap: normal;
+    white-space: normal;
+    word-break: normal;
 }
 
 .ufsc-club-name-cell small {
     color: #344054;
+    display: inline-block;
     font-size: 12px;
     line-height: 1.4;
+    max-width: 100%;
+    overflow-wrap: normal;
+    white-space: nowrap;
+    word-break: normal;
 }
 
 .ufsc-badge {
@@ -527,6 +549,10 @@
 }
 
 .ufsc-row-actions {
+    min-width: 220px;
+}
+
+.ufsc-clubs-table--manage .ufsc-row-actions {
     min-width: 285px;
 }
 

--- a/includes/admin/class-ufsc-simplified-admin.php
+++ b/includes/admin/class-ufsc-simplified-admin.php
@@ -141,6 +141,129 @@ class UFSC_Simplified_Admin {
         return current_user_can( UFSC_Permissions::CAP_COMPETITIONS_READ ) || current_user_can( UFSC_Permissions::CAP_COMPETITIONS_MANAGE );
     }
 
+    /**
+     * Licence pages exposed by UFSC Licences / Compétitions that are safe for read access.
+     *
+     * @return string[]
+     */
+    private static function allowed_licence_page_slugs() {
+        return array(
+            'ufsc-sql-licences',
+            'ufsc-sql-licenses',
+            'ufsc-licences',
+            'ufsc_licences',
+            'ufsc_lc_licences',
+            'ufsc-licence',
+            'ufsc_licence',
+            'ufsc-licence-documents',
+            'ufsc-licences-dashboard',
+            'ufsc_lc',
+            'ufsc-lc',
+        );
+    }
+
+    /**
+     * Competition pages exposed by UFSC Licences / Compétitions that are safe with read access.
+     *
+     * @return string[]
+     */
+    private static function read_competition_page_slugs() {
+        return array(
+            'ufsc-competitions',
+            'ufsc_competitions',
+            'ufsc-competition',
+            'ufsc_competition',
+            'ufsc-competition-dashboard',
+            'ufsc_competition_dashboard',
+            'ufsc-licence-competition',
+            'ufsc_licence_competition',
+            'ufsc_lc_competitions',
+            'competitions',
+            'ufsc-competitions-categories',
+            'ufsc-competitions-entries',
+            'ufsc-competitions-weighins',
+            'ufsc-competitions-bouts',
+            'ufsc-competitions-plateau',
+            'ufsc-competitions-timing-profiles',
+            'ufsc-competitions-quality',
+            'ufsc-competitions-print',
+            'ufsc-competitions-officials',
+            'ufsc-competitions-estimation',
+            'ufsc-competitions-logs',
+            'ufsc-competitions-guide',
+        );
+    }
+
+    /**
+     * Competition business-action pages that require the UFSC competition manage capability.
+     *
+     * @return string[]
+     */
+    private static function manage_competition_page_slugs() {
+        return array(
+            'ufsc-competitions-entries-import',
+            'ufsc-competitions-sensitive-ops',
+            'ufsc-competitions-entry-validation',
+        );
+    }
+
+    /**
+     * All non-settings competition pages allowed by the simplified admin when the matching capability is present.
+     *
+     * @return string[]
+     */
+    private static function allowed_competition_page_slugs() {
+        return array_merge( self::read_competition_page_slugs(), self::manage_competition_page_slugs() );
+    }
+
+    /**
+     * Sensitive UFSC pages that must not be opened by limited users through the simplified allowlist.
+     *
+     * @return string[]
+     */
+    private static function blocked_limited_page_slugs() {
+        return array(
+            'ufsc-competitions-settings',
+            'ufsc-competitions-access-diagnostic',
+            'ufsc-permissions',
+            'ufsc-settings',
+            'ufsc-woocommerce',
+            'ufsc-sql-settings',
+            'ufsc_lc_settings',
+            'ufsc-lc-settings',
+        );
+    }
+
+    /**
+     * Whether the current user can open a specific non-sensitive competition page.
+     */
+    private static function can_access_competition_page_slug( $slug ) {
+        if ( self::slug_matches( $slug, self::manage_competition_page_slugs() ) ) {
+            return current_user_can( UFSC_Permissions::CAP_COMPETITIONS_MANAGE );
+        }
+
+        if ( self::slug_matches( $slug, self::read_competition_page_slugs() ) ) {
+            return self::can_access_competitions();
+        }
+
+        return self::is_competitions_slug( $slug ) && self::can_access_competitions();
+    }
+
+    /**
+     * Capability required for a competition page after menu normalization.
+     */
+    private static function capability_for_competition_slug( $slug ) {
+        if ( self::slug_matches( $slug, self::manage_competition_page_slugs() ) ) {
+            return UFSC_Permissions::CAP_COMPETITIONS_MANAGE;
+        }
+
+        if ( self::slug_matches( $slug, self::read_competition_page_slugs() ) || self::is_competitions_slug( $slug ) ) {
+            return UFSC_Permissions::CAP_COMPETITIONS_READ;
+        }
+
+        return null;
+    }
+
 
     /**
      * Register stable compatibility parents before companion plugins add their subpages.
@@ -216,6 +339,24 @@ class UFSC_Simplified_Admin {
                 'icon'       => 'dashicons-awards',
                 'position'   => 62,
             ),
+            array(
+                'slug'       => 'ufsc_lc_settings',
+                'page_title' => __( 'Paramètres UFSC LC', 'ufsc-clubs' ),
+                'menu_title' => __( 'Paramètres UFSC LC', 'ufsc-clubs' ),
+                'capability' => 'manage_options',
+                'callback'   => '__return_empty_string',
+                'icon'       => 'dashicons-admin-generic',
+                'position'   => 63,
+            ),
+            array(
+                'slug'       => 'ufsc-lc-settings',
+                'page_title' => __( 'Paramètres UFSC LC', 'ufsc-clubs' ),
+                'menu_title' => __( 'Paramètres UFSC LC', 'ufsc-clubs' ),
+                'capability' => 'manage_options',
+                'callback'   => '__return_empty_string',
+                'icon'       => 'dashicons-admin-generic',
+                'position'   => 64,
+            ),
         );
     }
 
@@ -249,7 +390,7 @@ class UFSC_Simplified_Admin {
         }
 
         if ( self::can_access_licences() && class_exists( 'UFSC_SQL_Admin' ) ) {
-            foreach ( array( 'ufsc_licences', 'ufsc-licence', 'ufsc_licence', 'ufsc-licences-dashboard', 'ufsc_lc_licences' ) as $slug ) {
+            foreach ( array( 'ufsc_licences', 'ufsc-licence', 'ufsc_licence', 'ufsc-licence-documents', 'ufsc-licences-dashboard', 'ufsc_lc_licences' ) as $slug ) {
                 if ( ! self::menu_slug_exists( $slug ) ) {
                     add_submenu_page( null, __( 'UFSC Licences', 'ufsc-clubs' ), __( 'UFSC Licences', 'ufsc-clubs' ), UFSC_Permissions::CAP_LICENCES_READ, $slug, array( 'UFSC_SQL_Admin', 'render_licences' ) );
                 }
@@ -640,8 +781,9 @@ class UFSC_Simplified_Admin {
             return null;
         }
 
-        if ( self::is_competitions_slug( $slug, $title ) ) {
-            return UFSC_Permissions::CAP_COMPETITIONS_READ;
+        $competition_capability = self::capability_for_competition_slug( $slug );
+        if ( $competition_capability ) {
+            return $competition_capability;
         }
 
         if ( self::is_licences_slug( $slug, $title ) ) {
@@ -660,7 +802,7 @@ class UFSC_Simplified_Admin {
      */
     private static function is_sensitive_ufsc_slug( $slug ) {
         $normalized = self::normalize_page_slug( $slug );
-        if ( self::slug_matches( $slug, array( 'ufsc-permissions', 'ufsc-settings', 'ufsc-woocommerce', 'ufsc-sql-settings' ) ) ) {
+        if ( self::slug_matches( $slug, self::blocked_limited_page_slugs() ) ) {
             return true;
         }
 
@@ -921,16 +1063,20 @@ class UFSC_Simplified_Admin {
             return true;
         }
 
+        if ( self::is_sensitive_ufsc_slug( $slug ) ) {
+            return false;
+        }
+
         if ( self::is_gestion_slug( $slug ) ) {
             return self::can_access_gestion();
         }
 
-        if ( self::is_licences_slug( $slug ) ) {
+        if ( self::slug_matches( $slug, self::allowed_licence_page_slugs() ) || self::is_licences_slug( $slug ) ) {
             return self::can_access_licences();
         }
 
-        if ( self::is_competitions_slug( $slug ) ) {
-            return self::can_access_competitions();
+        if ( self::slug_matches( $slug, self::allowed_competition_page_slugs() ) || self::is_competitions_slug( $slug ) ) {
+            return self::can_access_competition_page_slug( $slug );
         }
 
         return false;
@@ -940,7 +1086,7 @@ class UFSC_Simplified_Admin {
      * Identify UFSC Gestion menu/page slugs without matching unrelated plugins.
      */
     private static function is_gestion_slug( $slug, $title = '' ) {
-        if ( self::slug_matches( $slug, array( 'ufsc-gestion', 'ufsc_gestion', 'ufsc-clubs', 'ufsc_clubs', 'ufsc-dashboard', 'ufsc-home', 'ufsc-exports' ) ) ) {
+        if ( self::slug_matches( $slug, array( 'ufsc-gestion', 'ufsc_gestion', 'ufsc-clubs', 'ufsc-sql-clubs', 'ufsc_clubs', 'ufsc-dashboard', 'ufsc-home', 'ufsc-exports' ) ) ) {
             return true;
         }
 
@@ -951,7 +1097,7 @@ class UFSC_Simplified_Admin {
      * Identify UFSC Licences menu/page slugs.
      */
     private static function is_licences_slug( $slug, $title = '' ) {
-        if ( self::slug_matches( $slug, array( 'ufsc-licences', 'ufsc_licences', 'ufsc-licence', 'ufsc_licence', 'ufsc-licences-dashboard', 'ufsc_lc_licences', 'ufsc_lc', 'ufsc-lc', 'ufsc-sql-licences', 'ufsc-sql-licenses' ) ) ) {
+        if ( self::slug_matches( $slug, self::allowed_licence_page_slugs() ) ) {
             return true;
         }
 
@@ -968,7 +1114,7 @@ class UFSC_Simplified_Admin {
             return true;
         }
 
-        if ( self::slug_matches( $slug, array( 'ufsc-competitions', 'ufsc_competitions', 'ufsc-competition', 'ufsc_competition', 'ufsc-competition-dashboard', 'ufsc_competition_dashboard', 'ufsc-licence-competition', 'ufsc_licence_competition', 'competitions' ) ) ) {
+        if ( self::slug_matches( $slug, self::allowed_competition_page_slugs() ) ) {
             return true;
         }
 
@@ -1189,10 +1335,10 @@ class UFSC_Simplified_Admin {
             'dashboard'   => admin_url( 'admin.php?page=ufsc-limited-dashboard' ),
             'espace_ufsc' => admin_url( 'admin.php?page=ufsc-limited-dashboard' ),
             'articles'    => admin_url( 'edit.php' ),
-            'gestion'     => self::get_first_candidate_admin_url( 'gestion' ),
+            'gestion'     => self::get_gestion_admin_url(),
             'clubs'       => self::get_first_existing_slug_url( array( 'ufsc-clubs', 'ufsc-sql-clubs', 'ufsc_clubs' ), 'admin.php?page=ufsc-clubs' ),
             'licences'    => self::get_licences_admin_url(),
-            'competitions'=> self::get_first_candidate_admin_url( 'competitions' ),
+            'competitions'=> self::get_competitions_admin_url(),
             'profile'     => admin_url( 'profile.php' ),
             'profil'      => admin_url( 'profile.php' ),
         );
@@ -1202,13 +1348,27 @@ class UFSC_Simplified_Admin {
 
 
     /**
+     * Canonical UFSC Gestion URL for the simplified dashboard button.
+     */
+    private static function get_gestion_admin_url() {
+        return self::get_first_existing_slug_url(
+            array( 'ufsc-dashboard', 'ufsc-clubs', 'ufsc-sql-clubs', 'ufsc_clubs', 'ufsc-gestion', 'ufsc_gestion' ),
+            'admin.php?page=ufsc-dashboard'
+        );
+    }
+
+    /**
      * The canonical admin licences table URL, never a front-office/club dashboard URL.
      */
     private static function get_licences_admin_url() {
-        return self::get_first_existing_slug_url(
-            array( 'ufsc-sql-licences', 'ufsc-licences', 'ufsc_lc_licences', 'ufsc-sql-licenses' ),
-            'admin.php?page=ufsc-sql-licences'
-        );
+        return admin_url( 'admin.php?page=ufsc-sql-licences' );
+    }
+
+    /**
+     * Canonical UFSC Compétitions URL for the simplified dashboard button.
+     */
+    private static function get_competitions_admin_url() {
+        return admin_url( 'admin.php?page=ufsc-competitions' );
     }
 
     /**
@@ -1340,8 +1500,8 @@ class UFSC_Simplified_Admin {
         $module = sanitize_key( (string) $module );
         $paths  = array(
             'competitions' => array(
-                'admin.php?page=ufsc-licence-competition',
                 'admin.php?page=ufsc-competitions',
+                'admin.php?page=ufsc-licence-competition',
                 'admin.php?page=ufsc_competitions',
                 'admin.php?page=ufsc-competition',
                 'admin.php?page=ufsc_competition',
@@ -1360,11 +1520,12 @@ class UFSC_Simplified_Admin {
                 'admin.php?page=ufsc_lc',
             ),
             'gestion' => array(
+                'admin.php?page=ufsc-dashboard',
+                'admin.php?page=ufsc-clubs',
+                'admin.php?page=ufsc-sql-clubs',
+                'admin.php?page=ufsc_clubs',
                 'admin.php?page=ufsc-gestion',
                 'admin.php?page=ufsc_gestion',
-                'admin.php?page=ufsc-clubs',
-                'admin.php?page=ufsc_clubs',
-                'admin.php?page=ufsc-dashboard',
             ),
         );
 

--- a/includes/admin/list-tables/class-ufsc-clubs-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-clubs-list-table.php
@@ -719,8 +719,9 @@ class UFSC_Clubs_List_Table {
         }
 
         $can_manage_clubs = ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE );
+        $table_mode_class = $can_manage_clubs ? 'ufsc-clubs-table-form--manage' : 'ufsc-clubs-table-form--readonly';
 
-        echo '<form method="post" id="bulk-actions-form" class="ufsc-clubs-table-form">';
+        echo '<form method="post" id="bulk-actions-form" class="ufsc-clubs-table-form ' . esc_attr( $table_mode_class ) . '">';
         echo '<input type="hidden" name="page" value="ufsc-sql-clubs" />';
         if ( $can_manage_clubs ) {
             // Bulk actions are write operations and are hidden for read-only users.
@@ -742,21 +743,21 @@ class UFSC_Clubs_List_Table {
         }
 
         //table
-        echo '<table class="wp-list-table widefat fixed striped ufsc-clubs-table">';
+        echo '<table class="wp-list-table widefat striped ufsc-clubs-table ' . ( $can_manage_clubs ? 'ufsc-clubs-table--manage' : 'ufsc-clubs-table--readonly' ) . '">';
         echo '<thead>';
         echo '<tr>';
         if ( $can_manage_clubs ) {
-            echo '<td class="check-column"><input type="checkbox" id="select-all-club" /></td>';
+            echo '<td class="check-column column-checkbox"><input type="checkbox" id="select-all-club" /></td>';
         }
-        echo '<th>ID</th>';
-        echo '<th>' . self::get_sortable_header( 'nom', __( 'Nom du club', 'ufsc-clubs' ), $sorting ) . '</th>';
-        echo '<th>' . self::get_sortable_header( 'region', __( 'Région', 'ufsc-clubs' ), $sorting ) . '</th>';
-        echo '<th>' . esc_html__( 'N° Affiliation', 'ufsc-clubs' ) . '</th>';
-        echo '<th>' . esc_html__( 'Statut', 'ufsc-clubs' ) . '</th>';
-        echo '<th>' . esc_html__( 'Licences', 'ufsc-clubs' ) . '</th>';
-        echo '<th>' . esc_html__( 'Documents', 'ufsc-clubs' ) . '</th>';
-        echo '<th>' . self::get_sortable_header( 'date_creation', __( 'Créé le', 'ufsc-clubs' ), $sorting ) . '</th>';
-        echo '<th>' . esc_html__( 'Actions', 'ufsc-clubs' ) . '</th>';
+        echo '<th class="column-id">ID</th>';
+        echo '<th class="column-club">' . self::get_sortable_header( 'nom', __( 'Nom du club', 'ufsc-clubs' ), $sorting ) . '</th>';
+        echo '<th class="column-region">' . self::get_sortable_header( 'region', __( 'Région', 'ufsc-clubs' ), $sorting ) . '</th>';
+        echo '<th class="column-affiliation">' . esc_html__( 'N° Affiliation', 'ufsc-clubs' ) . '</th>';
+        echo '<th class="column-status">' . esc_html__( 'Statut', 'ufsc-clubs' ) . '</th>';
+        echo '<th class="column-licences">' . esc_html__( 'Licences', 'ufsc-clubs' ) . '</th>';
+        echo '<th class="column-documents">' . esc_html__( 'Documents', 'ufsc-clubs' ) . '</th>';
+        echo '<th class="column-created">' . self::get_sortable_header( 'date_creation', __( 'Créé le', 'ufsc-clubs' ), $sorting ) . '</th>';
+        echo '<th class="column-actions">' . esc_html__( 'Actions', 'ufsc-clubs' ) . '</th>';
         echo '</tr>';
         echo '</thead>';
         echo '<tbody>';
@@ -788,16 +789,16 @@ class UFSC_Clubs_List_Table {
 
     // Checkbox (write-only bulk actions)
     if ( $can_manage_clubs ) {
-        echo '<th class="check-column"><input type="checkbox" name="club_ids[]" value="' . (int) ( $club->id ?? 0 ) . '" /></th>';
+        echo '<th class="check-column column-checkbox"><input type="checkbox" name="club_ids[]" value="' . (int) ( $club->id ?? 0 ) . '" /></th>';
     }
 
     // ID
-    echo '<td>' . (int) ( $club->id ?? 0 ) . '</td>';
+    echo '<td class="column-id">' . (int) ( $club->id ?? 0 ) . '</td>';
 
     // Nom + Email
     $club_name = isset( $club->nom ) ? $club->nom : '';
     $club_email = isset( $club->email ) ? $club->email : '';
-    echo '<td class="ufsc-club-name-cell"><strong>' . esc_html( $club_name ) . '</strong>';
+    echo '<td class="column-club ufsc-club-name-cell"><strong>' . esc_html( $club_name ) . '</strong>';
     if ( ! empty( $club_email ) ) {
         echo '<br><small>' . esc_html( $club_email ) . '</small>';
     }
@@ -805,16 +806,16 @@ class UFSC_Clubs_List_Table {
     echo '</td>';
 
     // Région
-    echo '<td>' . esc_html( isset( $club->region ) ? $club->region : '' ) . '</td>';
+    echo '<td class="column-region">' . esc_html( isset( $club->region ) ? $club->region : '' ) . '</td>';
 
     // Numéro d’affiliation
-    echo '<td>';
+    echo '<td class="column-affiliation">';
     echo self::render_affiliation_number( isset( $club->num_affiliation ) ? $club->num_affiliation : '' );
     echo '</td>';
 
     // Statut
     $status_value = isset( $club->statut ) ? $club->statut : '';
-    echo '<td>' . self::render_status_badge( $status_value ) . '</td>';
+    echo '<td class="column-status">' . self::render_status_badge( $status_value ) . '</td>';
 
     // Licences validées
     $club_id = (int) ( $club->id ?? 0 );
@@ -828,17 +829,17 @@ class UFSC_Clubs_List_Table {
         admin_url( 'admin.php' )
     );
     $licence_label = sprintf( _n( '%d licence', '%d licences', $licence_count, 'ufsc-clubs' ), $licence_count );
-    echo '<td><a class="ufsc-licence-link" href="' . esc_url( $licence_url ) . '">' . esc_html( $licence_label ) . '</a></td>';
+    echo '<td class="column-licences"><a class="ufsc-licence-link" href="' . esc_url( $licence_url ) . '">' . esc_html( $licence_label ) . '</a></td>';
 
     // Documents
-    echo '<td>' . self::render_documents_badge( $club ) . '</td>';
+    echo '<td class="column-documents">' . self::render_documents_badge( $club ) . '</td>';
 
     // Date de création
     $date_creation = isset( $club->date_creation ) ? $club->date_creation : '';
-    echo '<td>' . ( $date_creation ? esc_html( mysql2date( 'd/m/Y', $date_creation ) ) : '<em>' . esc_html__( 'Non défini', 'ufsc-clubs' ) . '</em>' ) . '</td>';
+    echo '<td class="column-created">' . ( $date_creation ? esc_html( mysql2date( 'd/m/Y', $date_creation ) ) : '<em>' . esc_html__( 'Non défini', 'ufsc-clubs' ) . '</em>' ) . '</td>';
 
     // Actions
-    echo '<td class="ufsc-row-actions"><div class="ufsc-actions-grid">';
+    echo '<td class="column-actions ufsc-row-actions"><div class="ufsc-actions-grid">';
     $club_id = (int) ( $club->id ?? 0 );
     $view_url = admin_url( 'admin.php?page=ufsc-sql-clubs&action=view&id=' . $club_id );
     $edit_url = admin_url( 'admin.php?page=ufsc-sql-clubs&action=edit&id=' . $club_id );


### PR DESCRIPTION
### Motivation

- Prevent limited users from reaching sensitive UFSC pages by introducing explicit allowlists and blocked slugs for licences and competitions. 
- Provide stable compatibility parent pages to avoid WordPress parent-slug warnings from companion plugins. 
- Improve the clubs admin table layout and responsiveness and support distinct read-only vs manage modes for users without write permissions.

### Description

- Add multiple helper methods in `UFSC_Simplified_Admin` (`allowed_licence_page_slugs`, `read_competition_page_slugs`, `manage_competition_page_slugs`, `allowed_competition_page_slugs`, `blocked_limited_page_slugs`, `can_access_competition_page_slug`, and `capability_for_competition_slug`) to centralize allowed/blocked slugs and compute required capabilities for competition pages. 
- Make menu normalization and capability decisions use the new allowlists and blocked slugs by updating `capability_for_menu_item`, `is_sensitive_ufsc_slug`, `is_authorized_page_slug`, `is_licences_slug`, and `is_competitions_slug`. 
- Register hidden compatibility parent pages for additional `ufsc_lc_settings` / `ufsc-lc-settings` slugs to avoid WP notices and add `ufsc-licence-documents` to authorized licence aliases. 
- Change URL helpers: replace generic candidate lookup for `gestion`, `licences`, and `competitions` with `get_gestion_admin_url`, `get_licences_admin_url`, and `get_competitions_admin_url` to prefer canonical admin pages. 
- Update candidate admin paths ordering in `get_candidate_admin_urls` to reflect the preferred slugs and detection logic. 
- Refactor the clubs list table (`UFSC_Clubs_List_Table`) to add explicit column classes (e.g. `column-id`, `column-club`, `column-region`, etc.), add a form-level mode class (`ufsc-clubs-table-form--manage` / `ufsc-clubs-table-form--readonly`) and toggle bulk actions based on `UFSC_Permissions::CAP_GESTION_MANAGE`. 
- Update admin CSS (`assets/admin/css/ufsc-clubs-admin.css`) to support the new column classes, adjust min-widths and table layout, normalize word-break/white-space behavior, and set different column/action widths for manage vs readonly table modes.

### Testing

- No automated tests were added or modified for this change. 
- No automated test suite was executed as part of this rollout. 
- The changes are limited to admin UI and permission routing logic and should be covered by integration tests or manual verification in environments where companion UFSC plugins are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d9abbbc40832b90a19fb89fd0660a)