### PR TITLE
Fix admin licence bulk actions and club licence links

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -5372,7 +5372,7 @@ class UFSC_SQL_Admin
         }
 
         $page = isset( $_REQUEST['page'] ) ? sanitize_key( wp_unslash( $_REQUEST['page'] ) ) : '';
-        if ( 'ufsc-sql-licences' !== $page ) {
+        if ( ! in_array( $page, self::get_licences_admin_page_slugs(), true ) ) {
             return;
         }
 
@@ -5397,16 +5397,26 @@ class UFSC_SQL_Admin
         }
         $allowed_actions = array( 'validate', 'pending', 'delete', 'archive_duplicate' );
         $has_bulk_ids    = isset( $_POST['licence_ids'] ) && is_array( $_POST['licence_ids'] );
-        $raw_bulk_action = isset( $_POST['bulk_action'] ) ? sanitize_text_field( wp_unslash( $_POST['bulk_action'] ) ) : '';
-        if ( $has_bulk_ids && isset( $_POST['bulk_action'] ) && ( '' === $raw_bulk_action || '-1' === $raw_bulk_action ) ) {
+        $has_bulk_action = isset( $_POST['bulk_action'] );
+        $raw_bulk_action = $has_bulk_action ? sanitize_text_field( wp_unslash( $_POST['bulk_action'] ) ) : '';
+
+        if ( $has_bulk_action && ( '' === $raw_bulk_action || '-1' === $raw_bulk_action ) ) {
             if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'ufsc_bulk_actions' ) ) {
                 self::maybe_redirect( add_query_arg( array( 'bulk_message' => 'no_action' ), $redirect_base ) );
             }
             return;
         }
+
+        if ( $has_bulk_action && in_array( $action, $allowed_actions, true ) && ! $has_bulk_ids ) {
+            if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'ufsc_bulk_actions' ) ) {
+                self::maybe_redirect( add_query_arg( array( 'bulk_message' => 'no_selection' ), $redirect_base ) );
+            }
+            return;
+        }
+
         $is_bulk_request = $has_bulk_ids && in_array( $action, $allowed_actions, true );
         if ( ! $is_bulk_request ) {
-            if ( isset( $_POST['licence_ids'] ) || isset( $_POST['bulk_action'] ) ) {
+            if ( isset( $_POST['licence_ids'] ) || $has_bulk_action ) {
                 self::debug_log_bulk_licences( 'Skipped non-bulk POST.' );
             }
             return;

--- a/includes/admin/list-tables/class-ufsc-clubs-list-table.php
+++ b/includes/admin/list-tables/class-ufsc-clubs-list-table.php
@@ -822,9 +822,9 @@ class UFSC_Clubs_List_Table {
     $licence_count = isset( $licence_counts[ $club_id ] ) ? (int) $licence_counts[ $club_id ] : 0;
     $licence_url = add_query_arg(
         array(
-            'page' => 'ufsc-sql-licences',
-            'filter_club' => $club_id,
-            'filter_status' => 'valide'
+            'page'          => 'ufsc_lc_licences',
+            'filter_club'   => absint( $club_id ),
+            'filter_status' => 'valide',
         ),
         admin_url( 'admin.php' )
     );


### PR DESCRIPTION
### Motivation
- The licences admin bulk handler only accepted a single legacy page slug which prevented bulk actions from running when the canonical page (`ufsc_lc_licences`) was used. 
- The clubs table licence-count links pointed to a legacy slug causing clicks like “36 licences” to open the wrong licences screen. 

### Description
- Accept any recognised licences admin slug in `handle_bulk_actions()` by checking `self::get_licences_admin_page_slugs()` so the handler runs for `ufsc_lc_licences` and aliases (file: `includes/admin/class-sql-admin.php`).
- Improve bulk-action request validation by distinguishing presence of a `bulk_action` param, returning `bulk_message=no_action` when the select is empty, and returning `bulk_message=no_selection` when an action was chosen but no `licence_ids[]` were submitted (file: `includes/admin/class-sql-admin.php`).
- Fix the club licence-count link to point to the canonical licences admin page `ufsc_lc_licences`, apply `absint($club_id)` and build the URL with `add_query_arg()` + `admin_url()` and `esc_url()` on output (file: `includes/admin/list-tables/class-ufsc-clubs-list-table.php`).
- Files modified: `includes/admin/class-sql-admin.php` and `includes/admin/list-tables/class-ufsc-clubs-list-table.php`, while preserving `UFSC_SQL_Admin::render_licences()` and existing nonce/capability checks.

### Testing
- Ran `php -l includes/admin/class-sql-admin.php` and `php -l includes/admin/list-tables/class-ufsc-clubs-list-table.php` with no syntax errors.
- Ran `git diff --check` and `git diff --name-only` to ensure no style/whitespace issues and reviewed changed files; checks passed.
- Searched modified files for destructive SQL patterns and for unintended changes to competition plugin files and verified none were introduced with the diff commands used.
- Verified presence and names of form fields and nonces via code inspection to ensure `licence_ids[]`, `bulk_action` and `ufsc_bulk_actions` remain coherent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2230856334832bb3d4ee2f8a47a267)