### PR TITLE
Corrige bouton Retour admin, ajoute actions rapides en haut et calcul catégorie d'âge front

### DIFF
--- a/assets/css/ufsc-admin.css
+++ b/assets/css/ufsc-admin.css
@@ -272,3 +272,34 @@
         text-align: center;
     }
 }
+
+.ufsc-admin .ufsc-admin-form-actions {
+    background: #f8f9fa;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    margin: 20px 0;
+    padding: 15px;
+}
+
+.ufsc-admin .ufsc-admin-form-actions--top {
+    position: sticky;
+    top: 42px;
+    z-index: 20;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.ufsc-admin .ufsc-admin-form-actions .description {
+    margin: 10px 0 0;
+}
+
+.ufsc-admin .ufsc-admin-form-actions .ufsc-button-payment {
+    background: #00a32a;
+    border-color: #00a32a;
+    color: #fff;
+}
+
+@media (max-width: 782px) {
+    .ufsc-admin .ufsc-admin-form-actions--top {
+        position: static;
+    }
+}

--- a/inc/common/season.php
+++ b/inc/common/season.php
@@ -306,6 +306,85 @@ if ( ! function_exists( 'ufsc_get_licence_season_label' ) ) {
 	}
 }
 
+
+if ( ! function_exists( 'ufsc_get_age_category_label' ) ) {
+	/**
+	 * Compute an UFSC age category label for display only.
+	 *
+	 * The calculation uses the season start year so 2025-2026 maps births
+	 * 2019/2018 to ages 6/7, matching the UFSC reference grid.
+	 *
+	 * @param string $birth_date Birth date in a parseable format, ideally YYYY-MM-DD.
+	 * @param string $sex        Licence sex label/code.
+	 * @param string $season     Season label, e.g. 2025-2026.
+	 * @return string Category label, or empty string when it cannot be computed.
+	 */
+	function ufsc_get_age_category_label( $birth_date, $sex = '', $season = '' ) {
+		$birth_date = trim( (string) $birth_date );
+		if ( '' === $birth_date || '0000-00-00' === $birth_date || '0000-00-00 00:00:00' === $birth_date ) {
+			return '';
+		}
+
+		if ( preg_match( '/^(\d{4})-(\d{2})-(\d{2})/', $birth_date, $birth_matches ) ) {
+			$birth_year = (int) $birth_matches[1];
+			if ( ! checkdate( (int) $birth_matches[2], (int) $birth_matches[3], $birth_year ) ) {
+				return '';
+			}
+		} else {
+			$timestamp = strtotime( $birth_date );
+			if ( false === $timestamp ) {
+				return '';
+			}
+			$birth_year = (int) gmdate( 'Y', $timestamp );
+		}
+
+		$season = trim( (string) $season );
+		if ( ! preg_match( '/^(\d{4})-(\d{4})$/', $season, $season_matches ) ) {
+			$season = function_exists( 'ufsc_get_current_season' ) ? (string) ufsc_get_current_season() : '';
+		}
+		if ( ! preg_match( '/^(\d{4})-(\d{4})$/', $season, $season_matches ) ) {
+			return '';
+		}
+
+		$reference_year = (int) $season_matches[1];
+		$age            = $reference_year - $birth_year;
+		if ( $age < 0 || $age > 120 ) {
+			return '';
+		}
+
+		$sex_normalized = strtolower( remove_accents( trim( (string) $sex ) ) );
+		$is_female      = in_array( $sex_normalized, array( 'f', 'femme', 'feminin', 'fille', 'female' ), true );
+		$is_male        = in_array( $sex_normalized, array( 'm', 'h', 'homme', 'masculin', 'garcon', 'male' ), true );
+
+		if ( $age >= 6 && $age <= 7 ) {
+			return __( 'Pré-poussins', 'ufsc-clubs' );
+		}
+		if ( $age >= 8 && $age <= 9 ) {
+			return __( 'Poussins', 'ufsc-clubs' );
+		}
+		if ( $age >= 10 && $age <= 11 ) {
+			return __( 'Benjamins', 'ufsc-clubs' );
+		}
+		if ( $age >= 12 && $age <= 13 ) {
+			return $is_female ? __( 'Minimes filles', 'ufsc-clubs' ) : ( $is_male ? __( 'Minimes garçons', 'ufsc-clubs' ) : __( 'Minimes', 'ufsc-clubs' ) );
+		}
+		if ( $age >= 14 && $age <= 15 ) {
+			return $is_female ? __( 'Cadettes', 'ufsc-clubs' ) : ( $is_male ? __( 'Cadets', 'ufsc-clubs' ) : __( 'Cadets/Cadettes', 'ufsc-clubs' ) );
+		}
+		if ( $age >= 16 && $age <= 17 ) {
+			return $is_female ? __( 'Juniors filles', 'ufsc-clubs' ) : ( $is_male ? __( 'Juniors garçons', 'ufsc-clubs' ) : __( 'Juniors', 'ufsc-clubs' ) );
+		}
+		if ( $age >= 18 && $age <= 40 ) {
+			return $is_female ? __( 'Seniors femmes', 'ufsc-clubs' ) : ( $is_male ? __( 'Seniors hommes', 'ufsc-clubs' ) : __( 'Seniors', 'ufsc-clubs' ) );
+		}
+		if ( $age >= 41 && $age <= 50 ) {
+			return $is_female ? __( 'Vétérans féminines', 'ufsc-clubs' ) : ( $is_male ? __( 'Vétérans masculins', 'ufsc-clubs' ) : __( 'Vétérans', 'ufsc-clubs' ) );
+		}
+
+		return '';
+	}
+}
+
 if ( ! function_exists( 'ufsc_set_licence_season' ) ) {
 	function ufsc_set_licence_season( $licence_id, $season ) {
 		global $wpdb;

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -351,7 +351,17 @@ class UFSC_SQL_Admin
             $candidate = wp_get_referer();
         }
 
-        if ( ! $candidate || ! wp_validate_redirect( $candidate, false ) ) {
+        $candidate = is_string( $candidate ) ? trim( $candidate ) : '';
+        if ( '' === $candidate ) {
+            return $fallback;
+        }
+
+        $candidate = esc_url_raw( $candidate );
+        if ( ! wp_parse_url( $candidate, PHP_URL_SCHEME ) && false !== strpos( $candidate, '%3A%2F%2F' ) ) {
+            $candidate = esc_url_raw( rawurldecode( $candidate ) );
+        }
+
+        if ( ! wp_validate_redirect( $candidate, false ) ) {
             return $fallback;
         }
 
@@ -361,12 +371,59 @@ class UFSC_SQL_Admin
         }
 
         parse_str( $parts['query'], $query );
-        $page = isset( $query['page'] ) ? sanitize_key( (string) $query['page'] ) : '';
+        $page   = isset( $query['page'] ) ? sanitize_key( (string) $query['page'] ) : '';
+        $action = isset( $query['action'] ) ? sanitize_key( (string) $query['action'] ) : '';
+
+        if ( in_array( $page, self::get_licences_admin_page_slugs(), true ) && in_array( $action, array( 'edit', 'view', 'new' ), true ) ) {
+            $nested_return = isset( $query['return_to'] ) ? esc_url_raw( rawurldecode( (string) $query['return_to'] ) ) : '';
+            if ( '' !== $nested_return && wp_validate_redirect( $nested_return, false ) ) {
+                $nested_parts = wp_parse_url( $nested_return );
+                $nested_query = array();
+                if ( ! empty( $nested_parts['query'] ) ) {
+                    parse_str( $nested_parts['query'], $nested_query );
+                }
+                $nested_page = isset( $nested_query['page'] ) ? sanitize_key( (string) $nested_query['page'] ) : '';
+                if ( in_array( $nested_page, self::get_licences_admin_page_slugs(), true ) ) {
+                    return remove_query_arg( array( 'updated', 'deleted', 'deleted_id', 'error' ), $nested_return );
+                }
+            }
+
+            return $fallback;
+        }
+
         if ( ! in_array( $page, array_merge( self::get_licences_admin_page_slugs(), array( 'ufsc-sql-clubs' ) ), true ) ) {
             return $fallback;
         }
 
         return remove_query_arg( array( 'updated', 'deleted', 'deleted_id', 'error' ), $candidate );
+    }
+
+    /**
+     * Render shared admin form action buttons without duplicating business logic.
+     *
+     * @param string $return_url Safe list URL.
+     * @param string $context    Form context: licence or club.
+     * @param int    $id         Edited entity ID.
+     * @param string $position   Position marker for CSS.
+     * @return void
+     */
+    private static function render_admin_form_actions( $return_url, $context, $id = 0, $position = 'bottom' ) {
+        $context  = sanitize_key( (string) $context );
+        $position = sanitize_key( (string) $position );
+
+        echo '<div class="ufsc-admin-form-actions ufsc-admin-form-actions--' . esc_attr( $position ) . '">';
+        echo '<div class="ufsc-button-group">';
+        echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__( 'Retour', 'ufsc-clubs' ) . '</a>';
+        echo '<button type="submit" name="save_action" value="save" class="button button-primary">' . esc_html__( 'Enregistrer', 'ufsc-clubs' ) . '</button>';
+        if ( 'licence' === $context && $id ) {
+            echo '<button type="submit" name="save_action" value="save_and_payment" class="button button-secondary ufsc-button-payment">' . esc_html__( 'Enregistrer et envoyer pour paiement', 'ufsc-clubs' ) . '</button>';
+        }
+        echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__( 'Annuler', 'ufsc-clubs' ) . '</a>';
+        echo '</div>';
+        if ( 'licence' === $context && ! $id ) {
+            echo '<p class="description">' . esc_html__( 'Note: Le bouton "Envoyer pour paiement" sera disponible après le premier enregistrement.', 'ufsc-clubs' ) . '</p>';
+        }
+        echo '</div>';
     }
 
     /**
@@ -1335,6 +1392,7 @@ class UFSC_SQL_Admin
             echo '<input type="hidden" name="action" value="ufsc_sql_save_club" />';
             echo '<input type="hidden" name="id" value="' . (int) $id . '" />';
             echo '<input type="hidden" name="page" value="ufsc-sql-clubs"/>';
+            self::render_admin_form_actions( admin_url( 'admin.php?page=ufsc-sql-clubs' ), 'club', (int) $id, 'top' );
         }
 
         echo '<section class="ufsc-admin-header">';
@@ -1432,7 +1490,7 @@ class UFSC_SQL_Admin
         }
 
         if (! $readonly) {
-            echo '<p><button class="button button-primary">' . esc_html__('Enregistrer', 'ufsc-clubs') . '</button> <a class="button" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-clubs')) . '">' . esc_html__('Annuler', 'ufsc-clubs') . '</a></p>';
+            self::render_admin_form_actions( admin_url( 'admin.php?page=ufsc-sql-clubs' ), 'club', (int) $id, 'bottom' );
             echo '</form>';
         } else {
             echo '<p><a class="button" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-clubs')) . '">' . esc_html__('Retour à la liste', 'ufsc-clubs') . '</a>';
@@ -2796,7 +2854,7 @@ class UFSC_SQL_Admin
                     $normalized_status = 'en_attente';
                 }
 
-                $return_to    = rawurlencode( self::build_licences_redirect_url() );
+                $return_to    = self::build_licences_redirect_url();
                 $view_url     = self::get_licences_admin_page_url( array( 'action' => 'view', 'id' => $r->$pk, 'return_to' => $return_to ) );
                 $edit_url     = self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $r->$pk, 'return_to' => $return_to ) );
                 $trash_url    = wp_nonce_url(admin_url('admin-post.php?action=ufsc_sql_trash_licence&id=' . $r->$pk), 'ufsc_sql_trash_licence');
@@ -3080,7 +3138,8 @@ class UFSC_SQL_Admin
             echo '<input type="hidden" name="action" value="ufsc_sql_save_licence" />';
             echo '<input type="hidden" name="id" value="' . (int) $id . '" />';
             echo '<input type="hidden" name="page" value="' . esc_attr( $licences_page_slug ) . '"/>';
-            echo '<input type="hidden" name="return_to" value="' . esc_url( $return_url ) . '" />';
+            echo '<input type="hidden" name="return_to" value="' . esc_attr( $return_url ) . '" />';
+            self::render_admin_form_actions( $return_url, 'licence', (int) $id, 'top' );
         }
 
         $club_name = '';
@@ -3137,20 +3196,7 @@ class UFSC_SQL_Admin
         }
 
         if (! $readonly) {
-            echo '<div class="ufsc-form-actions" style="background: #f8f9fa; padding: 15px; margin: 20px 0; border-radius: 4px;">';
-            echo '<div class="ufsc-button-group">';
-            echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Retour', 'ufsc-clubs') . '</a>';
-            echo '<button type="submit" name="save_action" value="save" class="button button-primary">' . esc_html__('Enregistrer', 'ufsc-clubs') . '</button>';
-            if ($id) {
-                // Only show payment button for existing licenses
-                echo '<button type="submit" name="save_action" value="save_and_payment" class="button button-secondary" style="background: #00a32a; border-color: #00a32a; color: white;">' . esc_html__('Enregistrer et envoyer pour paiement', 'ufsc-clubs') . '</button>';
-            }
-            echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Annuler', 'ufsc-clubs') . '</a>';
-            echo '</div>';
-            if (! $id) {
-                echo '<p class="description" style="margin-top: 10px;">' . esc_html__('Note: Le bouton "Envoyer pour paiement" sera disponible après le premier enregistrement.', 'ufsc-clubs') . '</p>';
-            }
-            echo '</div>';
+            self::render_admin_form_actions( $return_url, 'licence', (int) $id, 'bottom' );
             echo '</form>';
         } else {
             echo '<p><a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Retour à la liste', 'ufsc-clubs') . '</a>';
@@ -3419,6 +3465,7 @@ class UFSC_SQL_Admin
         $pk     = $s['pk_licence'];
         $fields = UFSC_SQL::get_licence_fields();
         $id     = isset($_POST['id']) ? (int) $_POST['id'] : 0;
+        $return_to = self::get_admin_return_url( self::get_licences_admin_page_slug() );
         if ( $id ) {
             $existing_club_id = (int) $wpdb->get_var( $wpdb->prepare(
                 "SELECT club_id FROM `{$t}` WHERE `{$pk}` = %d",
@@ -3492,11 +3539,11 @@ class UFSC_SQL_Admin
             if ( $id ) {
                 $snapshot = UFSC_Licence_Payments::get_payment_snapshot( $id );
                 if ( $snapshot && ! UFSC_Licence_Payments::can_validate_licence( $snapshot, $manual_exception_reason ) ) {
-                    self::maybe_redirect( self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $id, 'error' => __( 'Validation bloquée: rattachez un paiement ou renseignez un motif d\'exception.', 'ufsc-clubs' ) ) ) );
+                    self::maybe_redirect( self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $id, 'return_to' => $return_to, 'error' => __( 'Validation bloquée: rattachez un paiement ou renseignez un motif d\'exception.', 'ufsc-clubs' ) ) ) );
                     return;
                 }
             } elseif ( ! $is_paid_submission && '' === trim( $manual_exception_reason ) ) {
-                self::maybe_redirect( self::get_licences_admin_page_url( array( 'action' => 'new', 'error' => __( 'Validation bloquée: créez d\'abord la licence en brouillon/en attente puis rattachez un paiement.', 'ufsc-clubs' ) ) ) );
+                self::maybe_redirect( self::get_licences_admin_page_url( array( 'action' => 'new', 'return_to' => $return_to, 'error' => __( 'Validation bloquée: créez d\'abord la licence en brouillon/en attente puis rattachez un paiement.', 'ufsc-clubs' ) ) ) );
                 return;
             }
         }
@@ -3505,7 +3552,7 @@ class UFSC_SQL_Admin
         $validation_errors = UFSC_CL_Utils::validate_licence_data($data);
         if (! empty($validation_errors)) {
             $error_message = implode(', ', $validation_errors);
-            self::maybe_redirect(self::get_licences_admin_page_url( array_merge( $id ? array( 'action' => 'edit', 'id' => $id ) : array( 'action' => 'new' ), array( 'error' => $error_message ) ) ));
+            self::maybe_redirect(self::get_licences_admin_page_url( array_merge( $id ? array( 'action' => 'edit', 'id' => $id ) : array( 'action' => 'new' ), array( 'return_to' => $return_to, 'error' => $error_message ) ) ));
             return;
         }
 
@@ -3516,7 +3563,7 @@ class UFSC_SQL_Admin
             if (! empty($upload['url'])) {
                 $data['certificat_url'] = esc_url_raw($upload['url']);
             } elseif (! empty($upload['error'])) {
-                self::maybe_redirect(self::get_licences_admin_page_url( array_merge( $id ? array( 'action' => 'edit', 'id' => $id ) : array( 'action' => 'new' ), array( 'error' => 'Erreur upload fichier: ' . $upload['error'] ) ) ));
+                self::maybe_redirect(self::get_licences_admin_page_url( array_merge( $id ? array( 'action' => 'edit', 'id' => $id ) : array( 'action' => 'new' ), array( 'return_to' => $return_to, 'error' => 'Erreur upload fichier: ' . $upload['error'] ) ) ));
                 return;
             }
         } else {
@@ -3590,9 +3637,9 @@ class UFSC_SQL_Admin
         // Gestion bouton "save_and_payment"
         $save_action = isset($_POST['save_action']) ? sanitize_text_field($_POST['save_action']) : 'save';
         if ($save_action === 'save_and_payment' && $id) {
-            self::maybe_redirect(admin_url('admin-post.php?action=ufsc_send_license_payment&license_id=' . $id . '&_wpnonce=' . wp_create_nonce('ufsc_send_license_payment_' . $id)));
+            self::maybe_redirect(add_query_arg( 'return_to', $return_to, admin_url('admin-post.php?action=ufsc_send_license_payment&license_id=' . $id . '&_wpnonce=' . wp_create_nonce('ufsc_send_license_payment_' . $id)) ));
         } else {
-            self::maybe_redirect(self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $id, 'updated' => 1 ) ));
+            self::maybe_redirect(self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $id, 'return_to' => $return_to, 'updated' => 1 ) ));
         }
         return;
     }

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -610,6 +610,9 @@ class UFSC_Frontend_Shortcodes {
                                 $licence_number = self::get_first_licence_field( $licence, array( 'numero_licence', 'num_licence', 'licence_number', 'numero' ) );
                                 $asptt_number   = self::get_first_licence_field( $licence, array( 'numero_asptt', 'num_asptt', 'asptt_number', 'numero_licence_delegataire' ) );
                                 $category       = self::get_first_licence_field( $licence, array( 'categorie', 'category', 'type_licence', 'cat' ) );
+                                if ( '' === $category && function_exists( 'ufsc_get_age_category_label' ) ) {
+                                    $category = ufsc_get_age_category_label( $licence->date_naissance ?? '', $licence->sexe ?? '', $season );
+                                }
                                 $created_at     = self::get_first_licence_field( $licence, array( 'date_creation', 'created_at', 'date_inscription' ) );
 
                                 $practice = isset( $licence->competition ) && $licence->competition


### PR DESCRIPTION
### Motivation
- Corriger le comportement du bouton « Retour » en édition licence pour qu’il respecte le paramètre `return_to` sécurisé et revienne au tableau (filtré si applicable). 
- Afficher une catégorie d’âge lisible en front quand la colonne `categorie` est vide en calculant un fallback depuis la date de naissance, le sexe et la saison. 
- Éviter de faire descendre les utilisateurs jusqu’en bas des formulaires longs en exposant les mêmes actions critiques en haut du formulaire (sans supprimer celles du bas). 

### Description
- Sécurisation et robustification de la résolution de l’URL de retour via `UFSC_SQL_Admin::get_admin_return_url()`: lecture avec `wp_unslash()`, nettoyage avec `esc_url_raw()`, décodage contrôlé `rawurldecode()` quand l’URL est encodée, validation via `wp_validate_redirect()` et restriction des pages acceptées; fallback vers `admin.php?page=ufsc_lc_licences` si invalide. (fichier modifié: `includes/admin/class-sql-admin.php`).
- Ajout d’un helper réutilisable `render_admin_form_actions($return_url,$context,$id,$position)` et remplacement des blocs d’actions existants par des appels à ce helper pour afficher les mêmes boutons en haut (`--top`) et conserver ceux du bas (`--bottom`), le bouton « Retour » est rendu comme un lien `<a>` (non submit). (fichier modifié: `includes/admin/class-sql-admin.php`).
- Passage de la valeur `return_to` dans les URLs sans double-encodage et propagation sécurisée du `return_to` lors des redirections et erreurs de validation (`handle_save_licence`), et ajout du paramètre `return_to` lors de la redirection vers l’action paiement pour conserver le retour. (fichier modifié: `includes/admin/class-sql-admin.php`).
- Implémentation d’un helper d’affichage `ufsc_get_age_category_label($birth_date,$sex,$season)` non destructive qui calcule la catégorie UFSC selon la grille fournie (saison de référence basée sur l’année de début). Le helper est ajouté à `inc/common/season.php` et utilisé uniquement en fallback côté front. (fichier modifié: `inc/common/season.php`, `includes/frontend/class-frontend-shortcodes.php`).
- Ajout d’un style léger pour le bloc d’actions rapides admin, avec option `position: sticky` non intrusive et désactivée sur mobile. (fichier modifié: `assets/css/ufsc-admin.css`).
- Aucun stockage en base des catégories calculées n’est effectué et aucune logique métier supplémentaire n’a été introduite; toutes les modifications préservent les nonces et les comportements existants.

### Testing
- Exécution de `php -l` sur les fichiers modifiés: `includes/admin/class-sql-admin.php`, `includes/frontend/class-frontend-shortcodes.php`, `inc/common/season.php` — tous sans erreurs de syntaxe (succès). 
- Exécution de `git diff --check` et recherche grep pour opérations destructrices SQL et pour modifications du plugin compétitions — pas de requêtes destructives ni de modification des fichiers compétition (succès).
- Tests automatisés manuels via CLI PHP stub (simulation des helpers WP) pour `ufsc_get_age_category_label()` avec cas couvrant la grille 2025-2026 (exemples fournis) — résultats conformes (succès).
- Vérification que `return_to` est géré, non double-encodé et que le bouton « Retour » est un lien (validation statique par inspection des diffs et exécution PHP lint).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a223f13f7d8832baeae429f6d7526b3)