### PR TITLE
Admin: unified form actions, robust licence ID handling, no-cache headers, and age-category fallback

### DIFF
--- a/assets/css/ufsc-admin.css
+++ b/assets/css/ufsc-admin.css
@@ -272,3 +272,34 @@
         text-align: center;
     }
 }
+
+.ufsc-admin .ufsc-admin-form-actions {
+    background: #f8f9fa;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    margin: 20px 0;
+    padding: 15px;
+}
+
+.ufsc-admin .ufsc-admin-form-actions--top {
+    position: sticky;
+    top: 42px;
+    z-index: 20;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.ufsc-admin .ufsc-admin-form-actions .description {
+    margin: 10px 0 0;
+}
+
+.ufsc-admin .ufsc-admin-form-actions .ufsc-button-payment {
+    background: #00a32a;
+    border-color: #00a32a;
+    color: #fff;
+}
+
+@media (max-width: 782px) {
+    .ufsc-admin .ufsc-admin-form-actions--top {
+        position: static;
+    }
+}

--- a/inc/common/season.php
+++ b/inc/common/season.php
@@ -306,6 +306,85 @@ if ( ! function_exists( 'ufsc_get_licence_season_label' ) ) {
 	}
 }
 
+
+if ( ! function_exists( 'ufsc_get_age_category_label' ) ) {
+	/**
+	 * Compute an UFSC age category label for display only.
+	 *
+	 * The calculation uses the season start year so 2025-2026 maps births
+	 * 2019/2018 to ages 6/7, matching the UFSC reference grid.
+	 *
+	 * @param string $birth_date Birth date in a parseable format, ideally YYYY-MM-DD.
+	 * @param string $sex        Licence sex label/code.
+	 * @param string $season     Season label, e.g. 2025-2026.
+	 * @return string Category label, or empty string when it cannot be computed.
+	 */
+	function ufsc_get_age_category_label( $birth_date, $sex = '', $season = '' ) {
+		$birth_date = trim( (string) $birth_date );
+		if ( '' === $birth_date || '0000-00-00' === $birth_date || '0000-00-00 00:00:00' === $birth_date ) {
+			return '';
+		}
+
+		if ( preg_match( '/^(\d{4})-(\d{2})-(\d{2})/', $birth_date, $birth_matches ) ) {
+			$birth_year = (int) $birth_matches[1];
+			if ( ! checkdate( (int) $birth_matches[2], (int) $birth_matches[3], $birth_year ) ) {
+				return '';
+			}
+		} else {
+			$timestamp = strtotime( $birth_date );
+			if ( false === $timestamp ) {
+				return '';
+			}
+			$birth_year = (int) gmdate( 'Y', $timestamp );
+		}
+
+		$season = trim( (string) $season );
+		if ( ! preg_match( '/^(\d{4})-(\d{4})$/', $season, $season_matches ) ) {
+			$season = function_exists( 'ufsc_get_current_season' ) ? (string) ufsc_get_current_season() : '';
+		}
+		if ( ! preg_match( '/^(\d{4})-(\d{4})$/', $season, $season_matches ) ) {
+			return '';
+		}
+
+		$reference_year = (int) $season_matches[1];
+		$age            = $reference_year - $birth_year;
+		if ( $age < 0 || $age > 120 ) {
+			return '';
+		}
+
+		$sex_normalized = strtolower( remove_accents( trim( (string) $sex ) ) );
+		$is_female      = in_array( $sex_normalized, array( 'f', 'femme', 'feminin', 'fille', 'female' ), true );
+		$is_male        = in_array( $sex_normalized, array( 'm', 'h', 'homme', 'masculin', 'garcon', 'male' ), true );
+
+		if ( $age >= 6 && $age <= 7 ) {
+			return __( 'Pré-poussins', 'ufsc-clubs' );
+		}
+		if ( $age >= 8 && $age <= 9 ) {
+			return __( 'Poussins', 'ufsc-clubs' );
+		}
+		if ( $age >= 10 && $age <= 11 ) {
+			return __( 'Benjamins', 'ufsc-clubs' );
+		}
+		if ( $age >= 12 && $age <= 13 ) {
+			return $is_female ? __( 'Minimes filles', 'ufsc-clubs' ) : ( $is_male ? __( 'Minimes garçons', 'ufsc-clubs' ) : __( 'Minimes', 'ufsc-clubs' ) );
+		}
+		if ( $age >= 14 && $age <= 15 ) {
+			return $is_female ? __( 'Cadettes', 'ufsc-clubs' ) : ( $is_male ? __( 'Cadets', 'ufsc-clubs' ) : __( 'Cadets/Cadettes', 'ufsc-clubs' ) );
+		}
+		if ( $age >= 16 && $age <= 17 ) {
+			return $is_female ? __( 'Juniors filles', 'ufsc-clubs' ) : ( $is_male ? __( 'Juniors garçons', 'ufsc-clubs' ) : __( 'Juniors', 'ufsc-clubs' ) );
+		}
+		if ( $age >= 18 && $age <= 40 ) {
+			return $is_female ? __( 'Seniors femmes', 'ufsc-clubs' ) : ( $is_male ? __( 'Seniors hommes', 'ufsc-clubs' ) : __( 'Seniors', 'ufsc-clubs' ) );
+		}
+		if ( $age >= 41 && $age <= 50 ) {
+			return $is_female ? __( 'Vétérans féminines', 'ufsc-clubs' ) : ( $is_male ? __( 'Vétérans masculins', 'ufsc-clubs' ) : __( 'Vétérans', 'ufsc-clubs' ) );
+		}
+
+		return '';
+	}
+}
+
 if ( ! function_exists( 'ufsc_set_licence_season' ) ) {
 	function ufsc_set_licence_season( $licence_id, $season ) {
 		global $wpdb;

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -289,6 +289,78 @@ class UFSC_SQL_Admin
     }
 
     /**
+     * Admin UFSC Gestion pages that must never be served from a stale cache.
+     *
+     * These screens display sensitive, dynamic SQL data and row-specific action
+     * links. In particular, licence Consulter/Éditer URLs must always be freshly
+     * rendered with the current row ID; return_to is only navigation metadata.
+     *
+     * @return string[]
+     */
+    private static function get_admin_nocache_page_slugs() {
+        return array_values( array_unique( array_merge(
+            array(
+                'ufsc-dashboard',
+                'ufsc-gestion',
+                'ufsc_gestion',
+                'ufsc-clubs',
+                'ufsc_clubs',
+                'ufsc-sql-clubs',
+                'ufsc-sql',
+                'ufsc-sql-settings',
+                'ufsc-exports',
+                'ufsc-import',
+                'ufsc-settings',
+                'ufsc-woocommerce',
+                'ufsc-communication-clubs',
+                'ufsc-permissions',
+                'ufsc-user-club-mapping',
+                'ufsc-limited-dashboard',
+                'ufsc-home',
+            ),
+            self::get_licences_admin_page_slugs(),
+            array(
+                'ufsc_licences',
+                'ufsc-licence',
+                'ufsc_licence',
+                'ufsc-licence-documents',
+                'ufsc-licences-dashboard',
+            )
+        ) ) );
+    }
+
+    /**
+     * Send no-cache headers only for UFSC Gestion admin pages.
+     *
+     * Some production caches may keep admin HTML and replay stale licence action
+     * links. Restricting nocache_headers() to UFSC Gestion pages prevents stale
+     * Consulter/Éditer links without disabling cache globally for WordPress.
+     *
+     * @return void
+     */
+    public static function maybe_send_admin_nocache_headers() {
+        if ( ! is_admin() ) {
+            return;
+        }
+
+        $page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+        if ( '' === $page || ! in_array( $page, self::get_admin_nocache_page_slugs(), true ) ) {
+            return;
+        }
+
+        if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+            define( 'DONOTCACHEPAGE', true );
+        }
+
+        if ( headers_sent() ) {
+            return;
+        }
+
+        nocache_headers();
+        header( 'X-UFSC-Admin-No-Cache: 1' );
+    }
+
+    /**
      * Current slug for the historical administrative licences page.
      */
     private static function get_licences_admin_page_slug() {
@@ -351,7 +423,17 @@ class UFSC_SQL_Admin
             $candidate = wp_get_referer();
         }
 
-        if ( ! $candidate || ! wp_validate_redirect( $candidate, false ) ) {
+        $candidate = is_string( $candidate ) ? trim( $candidate ) : '';
+        if ( '' === $candidate ) {
+            return $fallback;
+        }
+
+        $candidate = esc_url_raw( $candidate );
+        if ( ! wp_parse_url( $candidate, PHP_URL_SCHEME ) && false !== strpos( $candidate, '%3A%2F%2F' ) ) {
+            $candidate = esc_url_raw( rawurldecode( $candidate ) );
+        }
+
+        if ( ! wp_validate_redirect( $candidate, false ) ) {
             return $fallback;
         }
 
@@ -361,12 +443,59 @@ class UFSC_SQL_Admin
         }
 
         parse_str( $parts['query'], $query );
-        $page = isset( $query['page'] ) ? sanitize_key( (string) $query['page'] ) : '';
+        $page   = isset( $query['page'] ) ? sanitize_key( (string) $query['page'] ) : '';
+        $action = isset( $query['action'] ) ? sanitize_key( (string) $query['action'] ) : '';
+
+        if ( in_array( $page, self::get_licences_admin_page_slugs(), true ) && in_array( $action, array( 'edit', 'view', 'new' ), true ) ) {
+            $nested_return = isset( $query['return_to'] ) ? esc_url_raw( rawurldecode( (string) $query['return_to'] ) ) : '';
+            if ( '' !== $nested_return && wp_validate_redirect( $nested_return, false ) ) {
+                $nested_parts = wp_parse_url( $nested_return );
+                $nested_query = array();
+                if ( ! empty( $nested_parts['query'] ) ) {
+                    parse_str( $nested_parts['query'], $nested_query );
+                }
+                $nested_page = isset( $nested_query['page'] ) ? sanitize_key( (string) $nested_query['page'] ) : '';
+                if ( in_array( $nested_page, self::get_licences_admin_page_slugs(), true ) ) {
+                    return remove_query_arg( array( 'updated', 'deleted', 'deleted_id', 'error' ), $nested_return );
+                }
+            }
+
+            return $fallback;
+        }
+
         if ( ! in_array( $page, array_merge( self::get_licences_admin_page_slugs(), array( 'ufsc-sql-clubs' ) ), true ) ) {
             return $fallback;
         }
 
         return remove_query_arg( array( 'updated', 'deleted', 'deleted_id', 'error' ), $candidate );
+    }
+
+    /**
+     * Render shared admin form action buttons without duplicating business logic.
+     *
+     * @param string $return_url Safe list URL.
+     * @param string $context    Form context: licence or club.
+     * @param int    $id         Edited entity ID.
+     * @param string $position   Position marker for CSS.
+     * @return void
+     */
+    private static function render_admin_form_actions( $return_url, $context, $id = 0, $position = 'bottom' ) {
+        $context  = sanitize_key( (string) $context );
+        $position = sanitize_key( (string) $position );
+
+        echo '<div class="ufsc-admin-form-actions ufsc-admin-form-actions--' . esc_attr( $position ) . '">';
+        echo '<div class="ufsc-button-group">';
+        echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__( 'Retour', 'ufsc-clubs' ) . '</a>';
+        echo '<button type="submit" name="save_action" value="save" class="button button-primary">' . esc_html__( 'Enregistrer', 'ufsc-clubs' ) . '</button>';
+        if ( 'licence' === $context && $id ) {
+            echo '<button type="submit" name="save_action" value="save_and_payment" class="button button-secondary ufsc-button-payment">' . esc_html__( 'Enregistrer et envoyer pour paiement', 'ufsc-clubs' ) . '</button>';
+        }
+        echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__( 'Annuler', 'ufsc-clubs' ) . '</a>';
+        echo '</div>';
+        if ( 'licence' === $context && ! $id ) {
+            echo '<p class="description">' . esc_html__( 'Note: Le bouton "Envoyer pour paiement" sera disponible après le premier enregistrement.', 'ufsc-clubs' ) . '</p>';
+        }
+        echo '</div>';
     }
 
     /**
@@ -1335,6 +1464,7 @@ class UFSC_SQL_Admin
             echo '<input type="hidden" name="action" value="ufsc_sql_save_club" />';
             echo '<input type="hidden" name="id" value="' . (int) $id . '" />';
             echo '<input type="hidden" name="page" value="ufsc-sql-clubs"/>';
+            self::render_admin_form_actions( admin_url( 'admin.php?page=ufsc-sql-clubs' ), 'club', (int) $id, 'top' );
         }
 
         echo '<section class="ufsc-admin-header">';
@@ -1432,7 +1562,7 @@ class UFSC_SQL_Admin
         }
 
         if (! $readonly) {
-            echo '<p><button class="button button-primary">' . esc_html__('Enregistrer', 'ufsc-clubs') . '</button> <a class="button" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-clubs')) . '">' . esc_html__('Annuler', 'ufsc-clubs') . '</a></p>';
+            self::render_admin_form_actions( admin_url( 'admin.php?page=ufsc-sql-clubs' ), 'club', (int) $id, 'bottom' );
             echo '</form>';
         } else {
             echo '<p><a class="button" href="' . esc_url(admin_url('admin.php?page=ufsc-sql-clubs')) . '">' . esc_html__('Retour à la liste', 'ufsc-clubs') . '</a>';
@@ -2374,6 +2504,79 @@ class UFSC_SQL_Admin
     }
 
     /**
+     * Resolve the strict admin primary key used to open a licence fiche.
+     *
+     * Admin view/edit URLs carry the database row ID. Prefer the physical `id`
+     * column whenever it exists; the configurable pk is only a fallback for
+     * non-standard tables without an `id` column.
+     *
+     * @param string[] $columns       Existing licence table columns.
+     * @param string   $configured_pk Configured primary key fallback.
+     * @return string
+     */
+    private static function get_admin_licence_primary_key( array $columns, $configured_pk = 'id' ) {
+        if ( in_array( 'id', $columns, true ) ) {
+            return 'id';
+        }
+
+        $configured_pk = preg_replace( '/[^a-zA-Z0-9_]/', '', (string) $configured_pk );
+        if ( '' !== $configured_pk && in_array( $configured_pk, $columns, true ) ) {
+            return $configured_pk;
+        }
+
+        return '';
+    }
+
+    /**
+     * Resolve the canonical licence ID for an admin list row.
+     *
+     * @param object $row Licence row returned by the admin list query.
+     * @param string $pk  Strict admin primary key column name.
+     * @return int
+     */
+    private static function get_admin_licence_row_id( $row, $pk ) {
+        if ( isset( $row->licence_id ) ) {
+            return absint( $row->licence_id );
+        }
+
+        if ( is_string( $pk ) && '' !== $pk && isset( $row->{$pk} ) ) {
+            return absint( $row->{$pk} );
+        }
+
+        return isset( $row->id ) ? absint( $row->id ) : 0;
+    }
+
+    /**
+     * Load exactly one requested licence row for admin view/edit.
+     *
+     * @param string $table Licences table name.
+     * @param string $pk    Strict admin primary key column name.
+     * @param int    $id    Requested licence ID from the URL.
+     * @return object|null
+     */
+    private static function get_admin_licence_by_id( $table, $pk, $id ) {
+        global $wpdb;
+
+        $id = absint( $id );
+        if ( $id <= 0 || '' === (string) $table || '' === (string) $pk ) {
+            return null;
+        }
+
+        return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `{$table}` WHERE `{$pk}` = %d LIMIT 1", $id ) );
+    }
+
+    /**
+     * Render a clean admin error when a view/edit licence ID is missing or invalid.
+     *
+     * @param string $return_url Safe licences list URL.
+     * @return void
+     */
+    private static function render_invalid_licence_admin_notice( $return_url ) {
+        echo UFSC_CL_Utils::show_error( __( 'Licence introuvable ou identifiant invalide.', 'ufsc-clubs' ) );
+        echo '<p><a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__( 'Retour aux licences', 'ufsc-clubs' ) . '</a></p>';
+    }
+
+    /**
      * Human-readable season for a licence row.
      *
      * @param object $licence Licence row.
@@ -2424,6 +2627,7 @@ class UFSC_SQL_Admin
         $club_columns    = self::get_table_columns($clubs_table);
         $has_club_id     = in_array('club_id', $licence_columns, true);
         $pk             = $s['pk_licence'];
+        $admin_pk       = self::get_admin_licence_primary_key( $licence_columns, $pk );
 
         // Handle search and filters
         $filters       = self::get_licence_filters_from_request( 'get' );
@@ -2462,7 +2666,8 @@ class UFSC_SQL_Admin
 
         // Get data with JOIN to show club names
         $select_fields = array(
-            (in_array($pk, $licence_columns, true) ? "l.{$pk}" : "0 AS {$pk}"),
+            ( '' !== $admin_pk ? "l.{$admin_pk} AS licence_id" : "0 AS licence_id" ),
+            ( in_array( $pk, $licence_columns, true ) ? "l.{$pk} AS {$pk}" : "0 AS {$pk}" ),
             self::build_select_column('l', 'prenom', $licence_columns),
             self::build_select_column('l', 'nom', $licence_columns),
             self::build_select_column('l', 'date_naissance', $licence_columns),
@@ -2490,6 +2695,8 @@ class UFSC_SQL_Admin
             self::build_first_existing_select_column( $licence_columns, array( 'saison', 'season', 'paid_season', 'season_end_year' ), 'season_resolved' ),
             self::get_duplicate_filter_sql_clause( $licences_table, $licence_columns, $filter_visibility, $pk ) . ' AS is_duplicate_identity',
         );
+
+        $select_fields = array_filter( $select_fields );
 
         if ($join_sql && in_array('nom', $club_columns, true)) {
             $select_fields[] = 'c.nom AS club_nom';
@@ -2622,13 +2829,25 @@ class UFSC_SQL_Admin
             if ( ! ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE ) ) {
                 wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
             }
-            $id = (int) $_GET['id'];
-            self::render_licence_form($id);
+            $id = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
+            $licence_row = self::get_admin_licence_by_id( $licences_table, $admin_pk, $id );
+            if ( ! $licence_row ) {
+                self::render_invalid_licence_admin_notice( self::get_admin_return_url( $licences_page_slug ) );
+                echo '</div>';
+                return;
+            }
+            self::render_licence_form( $id, false, $licence_row, $admin_pk );
             echo '</div>';
             return;
         } elseif (isset($_GET['action']) && $_GET['action'] === 'view') {
-            $id = (int) $_GET['id'];
-            self::render_licence_form($id, true); // true = readonly mode
+            $id = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0;
+            $licence_row = self::get_admin_licence_by_id( $licences_table, $admin_pk, $id );
+            if ( ! $licence_row ) {
+                self::render_invalid_licence_admin_notice( self::get_admin_return_url( $licences_page_slug ) );
+                echo '</div>';
+                return;
+            }
+            self::render_licence_form( $id, true, $licence_row, $admin_pk ); // true = readonly mode
             echo '</div>';
             return;
         } elseif (isset($_GET['action']) && $_GET['action'] === 'new') {
@@ -2796,12 +3015,14 @@ class UFSC_SQL_Admin
                     $normalized_status = 'en_attente';
                 }
 
-                $return_to    = rawurlencode( self::build_licences_redirect_url() );
-                $view_url     = self::get_licences_admin_page_url( array( 'action' => 'view', 'id' => $r->$pk, 'return_to' => $return_to ) );
-                $edit_url     = self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $r->$pk, 'return_to' => $return_to ) );
-                $trash_url    = wp_nonce_url(admin_url('admin-post.php?action=ufsc_sql_trash_licence&id=' . $r->$pk), 'ufsc_sql_trash_licence');
-                $restore_url  = wp_nonce_url(admin_url('admin-post.php?action=ufsc_sql_restore_licence&id=' . $r->$pk), 'ufsc_sql_restore_licence');
-                $force_delete_url = wp_nonce_url(admin_url('admin-post.php?action=ufsc_sql_force_delete_licence&id=' . $r->$pk), 'ufsc_sql_force_delete_licence');
+                $licence_id   = self::get_admin_licence_row_id( $r, $admin_pk );
+                // return_to is only used for navigation back to the list; the licence record is loaded exclusively from the id query argument.
+                $return_to    = self::build_licences_redirect_url();
+                $view_url     = self::get_licences_admin_page_url( array( 'action' => 'view', 'id' => $licence_id, 'return_to' => $return_to ) );
+                $edit_url     = self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $licence_id, 'return_to' => $return_to ) );
+                $trash_url    = wp_nonce_url( add_query_arg( array( 'action' => 'ufsc_sql_trash_licence', 'id' => $licence_id ), admin_url( 'admin-post.php' ) ), 'ufsc_sql_trash_licence' );
+                $restore_url  = wp_nonce_url( add_query_arg( array( 'action' => 'ufsc_sql_restore_licence', 'id' => $licence_id ), admin_url( 'admin-post.php' ) ), 'ufsc_sql_restore_licence' );
+                $force_delete_url = wp_nonce_url( add_query_arg( array( 'action' => 'ufsc_sql_force_delete_licence', 'id' => $licence_id ), admin_url( 'admin-post.php' ) ), 'ufsc_sql_force_delete_licence' );
                 $name         = trim($r->prenom . ' ' . $r->nom);
                 $club_display = $r->club_nom ? esc_html($r->club_nom) : esc_html__('Club #', 'ufsc-clubs') . $r->club_id;
                 $club_id_for_row = isset( $r->club_id ) ? (int) $r->club_id : 0;
@@ -2811,9 +3032,9 @@ class UFSC_SQL_Admin
 
                 echo '<tr>';
                 if ( $can_manage_licences ) {
-                    echo '<th class="check-column"><input type="checkbox" name="licence_ids[]" value="' . (int) $r->$pk . '" /></th>';
+                    echo '<th class="check-column"><input type="checkbox" name="licence_ids[]" value="' . $licence_id . '" /></th>';
                 }
-                $licence_number = isset( $r->numero_licence_resolved ) && '' !== trim( (string) $r->numero_licence_resolved ) ? (string) $r->numero_licence_resolved : (string) (int) $r->$pk;
+                $licence_number = isset( $r->numero_licence_resolved ) && '' !== trim( (string) $r->numero_licence_resolved ) ? (string) $r->numero_licence_resolved : (string) $licence_id;
                 $asptt_number   = isset( $r->numero_asptt_resolved ) && '' !== trim( (string) $r->numero_asptt_resolved ) ? (string) $r->numero_asptt_resolved : '—';
                 $season_label   = self::get_licence_row_season_label( $r );
                 echo '<td>' . esc_html( $licence_number ) . '</td>';
@@ -2840,7 +3061,7 @@ class UFSC_SQL_Admin
                 }
                 $is_paid = self::is_licence_paid( $r );
                 if ( $can_manage_licences && ! $is_paid ) {
-                    $payment_url = wp_nonce_url(admin_url('admin-post.php?action=ufsc_send_license_payment&license_id=' . $r->$pk), 'ufsc_send_license_payment_' . $r->$pk);
+                    $payment_url = wp_nonce_url(add_query_arg( array( 'action' => 'ufsc_send_license_payment', 'license_id' => $licence_id ), admin_url( 'admin-post.php' ) ), 'ufsc_send_license_payment_' . $licence_id);
                     echo '<a class="button button-small" href="' . esc_url($payment_url) . '" title="' . esc_attr__('Envoyer pour paiement', 'ufsc-clubs') . '" aria-label="' . esc_attr__('Envoyer pour paiement', 'ufsc-clubs') . '" style="background: #00a32a; border-color: #00a32a; color: white;">' . esc_html__('Paiement', 'ufsc-clubs') . '</a>';
                 }
                 $delete_block_reason = self::get_licence_delete_block_reason( $r );
@@ -2850,7 +3071,7 @@ class UFSC_SQL_Admin
                 } elseif ( $can_manage_licences && '' === $delete_block_reason ) {
                     echo '<a class="button button-small button-link-delete" href="' . esc_url($trash_url) . '" title="' . esc_attr__('Mettre en corbeille', 'ufsc-clubs') . '" aria-label="' . esc_attr__('Mettre en corbeille', 'ufsc-clubs') . '" onclick="return confirm(\'' . esc_js(__('Êtes-vous sûr de vouloir mettre cette licence en corbeille ?', 'ufsc-clubs')) . '\')">' . esc_html__('Corbeille', 'ufsc-clubs') . '</a>';
                 } elseif ( $can_manage_licences ) {
-                    echo '<button type="button" class="button button-small ufsc-cancel-licence" data-licence-id="' . (int) $r->$pk . '" title="' . esc_attr( $delete_block_reason ) . '">' . esc_html__( 'Annuler', 'ufsc-clubs' ) . '</button>';
+                    echo '<button type="button" class="button button-small ufsc-cancel-licence" data-licence-id="' . $licence_id . '" title="' . esc_attr( $delete_block_reason ) . '">' . esc_html__( 'Annuler', 'ufsc-clubs' ) . '</button>';
                 }
                 echo '</div>';
                 echo '</td>';
@@ -3018,14 +3239,19 @@ class UFSC_SQL_Admin
         echo '</section>';
     }
 
-    private static function render_licence_form($id, $readonly = false)
+    private static function render_licence_form( $id, $readonly = false, $row = null, $admin_pk = '' )
     {
         global $wpdb;
-        $s      = UFSC_SQL::get_settings();
-        $t      = $s['table_licences'];
-        $pk     = $s['pk_licence'];
-        $fields = UFSC_SQL::get_licence_fields();
-        $row    = $id ? $wpdb->get_row($wpdb->prepare("SELECT * FROM `$t` WHERE `$pk`=%d", $id)) : null;
+        $s       = UFSC_SQL::get_settings();
+        $t       = $s['table_licences'];
+        $pk      = $s['pk_licence'];
+        $columns = self::get_table_columns( $t );
+        $admin_pk = $admin_pk ? $admin_pk : self::get_admin_licence_primary_key( $columns, $pk );
+        $fields  = UFSC_SQL::get_licence_fields();
+        $id      = absint( $id );
+        if ( $id && ! is_object( $row ) ) {
+            $row = self::get_admin_licence_by_id( $t, $admin_pk, $id );
+        }
         $licences_page_slug = self::get_licences_admin_page_slug();
         $return_url = self::get_admin_return_url( $licences_page_slug );
         if ( $row ) {
@@ -3080,7 +3306,8 @@ class UFSC_SQL_Admin
             echo '<input type="hidden" name="action" value="ufsc_sql_save_licence" />';
             echo '<input type="hidden" name="id" value="' . (int) $id . '" />';
             echo '<input type="hidden" name="page" value="' . esc_attr( $licences_page_slug ) . '"/>';
-            echo '<input type="hidden" name="return_to" value="' . esc_url( $return_url ) . '" />';
+            echo '<input type="hidden" name="return_to" value="' . esc_attr( $return_url ) . '" />';
+            self::render_admin_form_actions( $return_url, 'licence', (int) $id, 'top' );
         }
 
         $club_name = '';
@@ -3137,20 +3364,7 @@ class UFSC_SQL_Admin
         }
 
         if (! $readonly) {
-            echo '<div class="ufsc-form-actions" style="background: #f8f9fa; padding: 15px; margin: 20px 0; border-radius: 4px;">';
-            echo '<div class="ufsc-button-group">';
-            echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Retour', 'ufsc-clubs') . '</a>';
-            echo '<button type="submit" name="save_action" value="save" class="button button-primary">' . esc_html__('Enregistrer', 'ufsc-clubs') . '</button>';
-            if ($id) {
-                // Only show payment button for existing licenses
-                echo '<button type="submit" name="save_action" value="save_and_payment" class="button button-secondary" style="background: #00a32a; border-color: #00a32a; color: white;">' . esc_html__('Enregistrer et envoyer pour paiement', 'ufsc-clubs') . '</button>';
-            }
-            echo '<a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Annuler', 'ufsc-clubs') . '</a>';
-            echo '</div>';
-            if (! $id) {
-                echo '<p class="description" style="margin-top: 10px;">' . esc_html__('Note: Le bouton "Envoyer pour paiement" sera disponible après le premier enregistrement.', 'ufsc-clubs') . '</p>';
-            }
-            echo '</div>';
+            self::render_admin_form_actions( $return_url, 'licence', (int) $id, 'bottom' );
             echo '</form>';
         } else {
             echo '<p><a class="button" href="' . esc_url( $return_url ) . '">' . esc_html__('Retour à la liste', 'ufsc-clubs') . '</a>';
@@ -3419,6 +3633,7 @@ class UFSC_SQL_Admin
         $pk     = $s['pk_licence'];
         $fields = UFSC_SQL::get_licence_fields();
         $id     = isset($_POST['id']) ? (int) $_POST['id'] : 0;
+        $return_to = self::get_admin_return_url( self::get_licences_admin_page_slug() );
         if ( $id ) {
             $existing_club_id = (int) $wpdb->get_var( $wpdb->prepare(
                 "SELECT club_id FROM `{$t}` WHERE `{$pk}` = %d",
@@ -3492,11 +3707,11 @@ class UFSC_SQL_Admin
             if ( $id ) {
                 $snapshot = UFSC_Licence_Payments::get_payment_snapshot( $id );
                 if ( $snapshot && ! UFSC_Licence_Payments::can_validate_licence( $snapshot, $manual_exception_reason ) ) {
-                    self::maybe_redirect( self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $id, 'error' => __( 'Validation bloquée: rattachez un paiement ou renseignez un motif d\'exception.', 'ufsc-clubs' ) ) ) );
+                    self::maybe_redirect( self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $id, 'return_to' => $return_to, 'error' => __( 'Validation bloquée: rattachez un paiement ou renseignez un motif d\'exception.', 'ufsc-clubs' ) ) ) );
                     return;
                 }
             } elseif ( ! $is_paid_submission && '' === trim( $manual_exception_reason ) ) {
-                self::maybe_redirect( self::get_licences_admin_page_url( array( 'action' => 'new', 'error' => __( 'Validation bloquée: créez d\'abord la licence en brouillon/en attente puis rattachez un paiement.', 'ufsc-clubs' ) ) ) );
+                self::maybe_redirect( self::get_licences_admin_page_url( array( 'action' => 'new', 'return_to' => $return_to, 'error' => __( 'Validation bloquée: créez d\'abord la licence en brouillon/en attente puis rattachez un paiement.', 'ufsc-clubs' ) ) ) );
                 return;
             }
         }
@@ -3505,7 +3720,7 @@ class UFSC_SQL_Admin
         $validation_errors = UFSC_CL_Utils::validate_licence_data($data);
         if (! empty($validation_errors)) {
             $error_message = implode(', ', $validation_errors);
-            self::maybe_redirect(self::get_licences_admin_page_url( array_merge( $id ? array( 'action' => 'edit', 'id' => $id ) : array( 'action' => 'new' ), array( 'error' => $error_message ) ) ));
+            self::maybe_redirect(self::get_licences_admin_page_url( array_merge( $id ? array( 'action' => 'edit', 'id' => $id ) : array( 'action' => 'new' ), array( 'return_to' => $return_to, 'error' => $error_message ) ) ));
             return;
         }
 
@@ -3516,7 +3731,7 @@ class UFSC_SQL_Admin
             if (! empty($upload['url'])) {
                 $data['certificat_url'] = esc_url_raw($upload['url']);
             } elseif (! empty($upload['error'])) {
-                self::maybe_redirect(self::get_licences_admin_page_url( array_merge( $id ? array( 'action' => 'edit', 'id' => $id ) : array( 'action' => 'new' ), array( 'error' => 'Erreur upload fichier: ' . $upload['error'] ) ) ));
+                self::maybe_redirect(self::get_licences_admin_page_url( array_merge( $id ? array( 'action' => 'edit', 'id' => $id ) : array( 'action' => 'new' ), array( 'return_to' => $return_to, 'error' => 'Erreur upload fichier: ' . $upload['error'] ) ) ));
                 return;
             }
         } else {
@@ -3590,9 +3805,9 @@ class UFSC_SQL_Admin
         // Gestion bouton "save_and_payment"
         $save_action = isset($_POST['save_action']) ? sanitize_text_field($_POST['save_action']) : 'save';
         if ($save_action === 'save_and_payment' && $id) {
-            self::maybe_redirect(admin_url('admin-post.php?action=ufsc_send_license_payment&license_id=' . $id . '&_wpnonce=' . wp_create_nonce('ufsc_send_license_payment_' . $id)));
+            self::maybe_redirect(add_query_arg( 'return_to', $return_to, admin_url('admin-post.php?action=ufsc_send_license_payment&license_id=' . $id . '&_wpnonce=' . wp_create_nonce('ufsc_send_license_payment_' . $id)) ));
         } else {
-            self::maybe_redirect(self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $id, 'updated' => 1 ) ));
+            self::maybe_redirect(self::get_licences_admin_page_url( array( 'action' => 'edit', 'id' => $id, 'return_to' => $return_to, 'updated' => 1 ) ));
         }
         return;
     }

--- a/includes/frontend/class-frontend-shortcodes.php
+++ b/includes/frontend/class-frontend-shortcodes.php
@@ -610,6 +610,9 @@ class UFSC_Frontend_Shortcodes {
                                 $licence_number = self::get_first_licence_field( $licence, array( 'numero_licence', 'num_licence', 'licence_number', 'numero' ) );
                                 $asptt_number   = self::get_first_licence_field( $licence, array( 'numero_asptt', 'num_asptt', 'asptt_number', 'numero_licence_delegataire' ) );
                                 $category       = self::get_first_licence_field( $licence, array( 'categorie', 'category', 'type_licence', 'cat' ) );
+                                if ( '' === $category && function_exists( 'ufsc_get_age_category_label' ) ) {
+                                    $category = ufsc_get_age_category_label( $licence->date_naissance ?? '', $licence->sexe ?? '', $season );
+                                }
                                 $created_at     = self::get_first_licence_field( $licence, array( 'date_creation', 'created_at', 'date_inscription' ) );
 
                                 $practice = isset( $licence->competition ) && $licence->competition

--- a/ufsc-clubs-licences-sql.php
+++ b/ufsc-clubs-licences-sql.php
@@ -106,6 +106,7 @@ final class UFSC_CL_Bootstrap {
 
         // SQL Admin CRUD actions (pages cachées mais enregistrées pour les actions directes)
         add_action( 'admin_menu', array( 'UFSC_SQL_Admin', 'register_hidden_pages' ) );
+        add_action( 'admin_init', array( 'UFSC_SQL_Admin', 'maybe_send_admin_nocache_headers' ), 0 );
         add_action( 'admin_enqueue_scripts', array( 'UFSC_SQL_Admin', 'enqueue_admin_assets' ) );
         add_action( 'admin_post_ufsc_sql_save_club', array( 'UFSC_SQL_Admin', 'handle_save_club' ) );
         add_action( 'admin_post_ufsc_sql_delete_club', array( 'UFSC_SQL_Admin', 'handle_delete_club' ) );


### PR DESCRIPTION
### Motivation
- Improve admin UX by introducing consistent form action blocks and visual styles for licence/club edit screens.
- Prevent stale cached admin pages from exposing outdated action links by selectively sending no-cache headers for UFSC Gestion screens.
- Make admin CRUD resilient to non-standard database schemas by resolving a strict primary key for licence rows and using a canonical licence ID everywhere.
- Provide a fallback age category label calculation for front-end listings when `categorie` is missing. 

### Description
- Added admin UI styles in `assets/css/ufsc-admin.css` and a reusable form action block renderer `render_admin_form_actions()` in `includes/admin/class-sql-admin.php`, and replaced duplicated HTML with calls to this helper at the top and bottom of licence and club forms.
- Implemented selective no-cache behavior by adding `get_admin_nocache_page_slugs()` and `maybe_send_admin_nocache_headers()` and registering it on `admin_init` in the bootstrap file to avoid stale cached admin pages.
- Hardened return URL handling with safer trimming, `esc_url_raw`/`rawurldecode` handling and nested `return_to` extraction in `get_admin_return_url()` to avoid stale or unsafe redirects.
- Introduced strict admin primary key helpers: `get_admin_licence_primary_key()`, `get_admin_licence_row_id()`, and `get_admin_licence_by_id()` and an error renderer `render_invalid_licence_admin_notice()` to correctly load licence rows for view/edit across varied table schemas; updated listing, actions, nonces and admin-post URLs to use the canonical licence ID and `add_query_arg` where appropriate.
- Added `ufsc_get_age_category_label()` in `inc/common/season.php` and used it as a fallback in the frontend shortcodes in `includes/frontend/class-frontend-shortcodes.php` when a licence `categorie` is not provided.
- Minor related fixes: sanitized `return_to` form fields, preserve `return_to` on validation/error redirects and file upload errors, and small refactors to select/checkbox ID handling and duplicate-badge logic. 

### Testing
- Performed PHP syntax checks (`php -l`) on the modified PHP files and they passed.
- Verified that updated admin pages render the new form action block and that list/view/edit flows return early with a clear error when an invalid licence ID is requested (local automated smoke checks).
- No plugin unit tests were added or present for these areas, so changes were limited to static checks and integration smoke validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a223f13f7d8832baeae429f6d7526b3)