### PR TITLE
Add compact UFSC Gestion admin quick navigation

### DIFF
--- a/assets/css/ufsc-admin.css
+++ b/assets/css/ufsc-admin.css
@@ -303,3 +303,111 @@
         position: static;
     }
 }
+
+/* Navigation rapide admin UFSC Gestion */
+.ufsc-admin-quicknav {
+    margin: 10px 0 16px;
+    border: 1px solid #c7d7e6;
+    border-radius: 14px;
+    background: linear-gradient(135deg, #f8fbff 0%, #eef6ff 58%, #ffffff 100%);
+    box-shadow: 0 8px 22px rgba(12, 74, 110, 0.08);
+}
+
+.ufsc-admin-quicknav__inner {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 10px 12px;
+}
+
+.ufsc-admin-quicknav__title {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    flex: 0 0 auto;
+    color: #0b4f78;
+    font-size: 13px;
+    font-weight: 800;
+    letter-spacing: 0.01em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.ufsc-admin-quicknav__title .dashicons {
+    width: 18px;
+    height: 18px;
+    font-size: 18px;
+    color: #0b6fa4;
+}
+
+.ufsc-admin-quicknav__links {
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+    overflow-x: auto;
+    padding: 1px 2px 3px;
+    scrollbar-width: thin;
+}
+
+.ufsc-admin-quicknav__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    flex: 0 0 auto;
+    min-height: 28px;
+    padding: 4px 11px;
+    border: 1px solid #d6e3ef;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.86);
+    color: #1f4e6d;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1.2;
+    text-decoration: none;
+    transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ufsc-admin-quicknav__link .dashicons {
+    width: 15px;
+    height: 15px;
+    font-size: 15px;
+    line-height: 1;
+}
+
+.ufsc-admin-quicknav__link:hover,
+.ufsc-admin-quicknav__link:focus {
+    border-color: #0b6fa4;
+    color: #073b5c;
+    background: #ffffff;
+    box-shadow: 0 0 0 1px rgba(11, 111, 164, 0.12);
+}
+
+.ufsc-admin-quicknav__link.is-active {
+    border-color: #0b4f78;
+    background: linear-gradient(135deg, #0b4f78 0%, #0b6fa4 100%);
+    color: #ffffff;
+    box-shadow: 0 6px 14px rgba(11, 79, 120, 0.22);
+}
+
+.ufsc-admin-quicknav__link.is-active .dashicons {
+    color: #ffffff;
+}
+
+@media (max-width: 782px) {
+    .ufsc-admin-quicknav__inner {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .ufsc-admin-quicknav__links {
+        width: 100%;
+        padding-bottom: 4px;
+    }
+
+    .ufsc-admin-quicknav__link {
+        min-height: 30px;
+    }
+}

--- a/inc/woocommerce/settings-woocommerce.php
+++ b/inc/woocommerce/settings-woocommerce.php
@@ -153,6 +153,7 @@ function ufsc_render_woocommerce_settings_page() {
     $woocommerce_active = ufsc_is_woocommerce_active();
     ?>
     <div class="wrap">
+        <?php if ( class_exists( 'UFSC_SQL_Admin' ) ) { UFSC_SQL_Admin::render_admin_quick_nav(); } ?>
         <h1><?php esc_html_e( 'Paramètres WooCommerce - UFSC Gestion', 'ufsc-clubs' ); ?></h1>
 
         <?php if ( ! $woocommerce_active ) : ?>

--- a/includes/admin/class-admin-menu.php
+++ b/includes/admin/class-admin-menu.php
@@ -161,6 +161,9 @@ class UFSC_CL_Admin_Menu {
 		$t_lics  = isset( $opts['table_licences'] ) ? $opts['table_licences'] : 'licences';
 
 		echo '<div class="wrap">';
+		if ( class_exists( 'UFSC_SQL_Admin' ) ) {
+			UFSC_SQL_Admin::render_admin_quick_nav();
+		}
 
 		include UFSC_CL_DIR . 'templates/partials/notice.php';
 

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -896,6 +896,227 @@ class UFSC_SQL_Admin
         return "'' AS {$key}";
     }
 
+
+    /**
+     * Render compact UFSC admin quick navigation across existing plugin pages.
+     *
+     * @return void
+     */
+    public static function render_admin_quick_nav()
+    {
+        static $rendered_pages = array();
+
+        $current_page = '';
+        if ( isset( $_GET['page'] ) ) {
+            $page_value   = wp_unslash( $_GET['page'] );
+            $current_page = is_scalar( $page_value ) ? sanitize_key( (string) $page_value ) : '';
+        }
+
+        if ( '' === $current_page ) {
+            return;
+        }
+
+        if ( isset( $rendered_pages[ $current_page ] ) ) {
+            return;
+        }
+
+        $items          = self::get_admin_quick_nav_items();
+        $current_section = self::get_admin_quick_nav_section_for_slug( $current_page );
+
+        if ( empty( $items ) ) {
+            return;
+        }
+
+        $rendered_pages[ $current_page ] = true;
+
+        echo '<nav class="ufsc-admin-quicknav" aria-label="' . esc_attr__( 'Navigation rapide UFSC Gestion', 'ufsc-clubs' ) . '">';
+        echo '<div class="ufsc-admin-quicknav__inner">';
+        echo '<div class="ufsc-admin-quicknav__title"><span class="dashicons dashicons-groups" aria-hidden="true"></span><span>' . esc_html__( 'UFSC Gestion', 'ufsc-clubs' ) . '</span></div>';
+        echo '<div class="ufsc-admin-quicknav__links">';
+
+        foreach ( $items as $item ) {
+            $slug       = sanitize_key( $item['slug'] );
+            $section    = sanitize_key( $item['section'] );
+            $is_active  = $section === $current_section;
+            $url        = add_query_arg( array( 'page' => $slug ), admin_url( 'admin.php' ) );
+            $link_class = 'ufsc-admin-quicknav__link' . ( $is_active ? ' is-active' : '' );
+
+            echo '<a class="' . esc_attr( $link_class ) . '" href="' . esc_url( $url ) . '"' . ( $is_active ? ' aria-current="page"' : '' ) . '>';
+            if ( ! empty( $item['icon'] ) ) {
+                echo '<span class="dashicons ' . esc_attr( sanitize_html_class( $item['icon'] ) ) . '" aria-hidden="true"></span>';
+            }
+            echo '<span>' . esc_html( $item['label'] ) . '</span>';
+            echo '</a>';
+        }
+
+        echo '</div></div></nav>';
+    }
+
+    /**
+     * Existing UFSC Gestion sections available for the quick navigation.
+     *
+     * @return array<int,array<string,string>>
+     */
+    private static function get_admin_quick_nav_items()
+    {
+        $items = array(
+            array(
+                'section' => 'dashboard',
+                'slug'    => 'ufsc-dashboard',
+                'label'   => __( 'Tableau de bord', 'ufsc-clubs' ),
+                'cap'     => UFSC_Permissions::CAP_GESTION_READ,
+                'icon'    => 'dashicons-dashboard',
+            ),
+            array(
+                'section' => 'clubs',
+                'slug'    => 'ufsc-clubs',
+                'label'   => __( 'Clubs', 'ufsc-clubs' ),
+                'cap'     => UFSC_Permissions::CAP_GESTION_READ,
+                'icon'    => 'dashicons-groups',
+            ),
+            array(
+                'section' => 'licences',
+                'slug'    => 'ufsc_lc_licences',
+                'label'   => __( 'Licences', 'ufsc-clubs' ),
+                'cap'     => UFSC_Permissions::CAP_LICENCES_READ,
+                'icon'    => 'dashicons-id',
+            ),
+            array(
+                'section' => 'exports',
+                'slug'    => 'ufsc-exports',
+                'label'   => __( 'Exports', 'ufsc-clubs' ),
+                'cap'     => UFSC_Permissions::CAP_GESTION_MANAGE,
+                'icon'    => 'dashicons-download',
+            ),
+            array(
+                'section' => 'import',
+                'slug'    => 'ufsc-import',
+                'label'   => __( 'Import', 'ufsc-clubs' ),
+                'cap'     => UFSC_Permissions::CAP_GESTION_MANAGE,
+                'icon'    => 'dashicons-upload',
+            ),
+            array(
+                'section' => 'settings',
+                'slug'    => 'ufsc-settings',
+                'label'   => __( 'Paramètres', 'ufsc-clubs' ),
+                'cap'     => UFSC_Permissions::CAP_SETTINGS_MANAGE,
+                'icon'    => 'dashicons-admin-settings',
+            ),
+            array(
+                'section' => 'woocommerce',
+                'slug'    => 'ufsc-woocommerce',
+                'label'   => __( 'WooCommerce', 'ufsc-clubs' ),
+                'cap'     => UFSC_Permissions::CAP_SETTINGS_MANAGE,
+                'icon'    => 'dashicons-cart',
+            ),
+            array(
+                'section' => 'communication',
+                'slug'    => 'ufsc-communication-clubs',
+                'label'   => __( 'Communication UFSC', 'ufsc-clubs' ),
+                'cap'     => defined( 'UFSC_Capabilities::CAP_MANAGE_COMMUNICATION' ) ? UFSC_Capabilities::CAP_MANAGE_COMMUNICATION : 'manage_options',
+                'icon'    => 'dashicons-email-alt2',
+            ),
+            array(
+                'section' => 'access',
+                'slug'    => 'ufsc-permissions',
+                'label'   => __( 'Droits & accès', 'ufsc-clubs' ),
+                'cap'     => 'manage_options',
+                'icon'    => 'dashicons-shield',
+            ),
+        );
+
+        return array_values(
+            array_filter(
+                $items,
+                static function ( $item ) {
+                    return self::current_user_can_quick_nav_item( $item['cap'] ) && self::admin_quick_nav_slug_is_registered( $item['slug'] );
+                }
+            )
+        );
+    }
+
+    /**
+     * Whether a target admin page slug is registered in the current WordPress admin menu.
+     *
+     * @param string $slug Admin page slug.
+     * @return bool
+     */
+    private static function admin_quick_nav_slug_is_registered( $slug )
+    {
+        $slug = sanitize_key( (string) $slug );
+        if ( '' === $slug ) {
+            return false;
+        }
+
+        global $menu, $submenu;
+
+        foreach ( (array) $menu as $menu_item ) {
+            if ( isset( $menu_item[2] ) && $slug === sanitize_key( (string) $menu_item[2] ) ) {
+                return true;
+            }
+        }
+
+        foreach ( (array) $submenu as $submenu_items ) {
+            foreach ( (array) $submenu_items as $submenu_item ) {
+                if ( isset( $submenu_item[2] ) && $slug === sanitize_key( (string) $submenu_item[2] ) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Verify current user capability for a quick navigation item.
+     *
+     * @param string $capability Capability name.
+     * @return bool
+     */
+    private static function current_user_can_quick_nav_item( $capability )
+    {
+        $capability = is_string( $capability ) ? $capability : '';
+        if ( '' === $capability ) {
+            return false;
+        }
+
+        if ( function_exists( 'ufsc_user_can' ) && ufsc_user_can( $capability ) ) {
+            return true;
+        }
+
+        return current_user_can( $capability );
+    }
+
+    /**
+     * Resolve active quick navigation section from current or historical page slug.
+     *
+     * @param string $slug Admin page slug.
+     * @return string
+     */
+    private static function get_admin_quick_nav_section_for_slug( $slug )
+    {
+        $slug    = sanitize_key( (string) $slug );
+        $aliases = array(
+            'dashboard'     => array( 'ufsc-dashboard', 'ufsc-gestion', 'ufsc_gestion', 'ufsc-sql' ),
+            'clubs'         => array( 'ufsc-clubs', 'ufsc-sql-clubs', 'ufsc_clubs', 'ufsc-gestion-clubs' ),
+            'licences'      => array( 'ufsc_lc_licences', 'ufsc-sql-licences', 'ufsc-sql-licenses', 'ufsc-gestion-licences', 'ufsc-licences', 'ufsc_licences', 'ufsc-licence', 'ufsc_licence', 'ufsc_lc', 'ufsc-lc' ),
+            'exports'       => array( 'ufsc-exports' ),
+            'import'        => array( 'ufsc-import' ),
+            'settings'      => array( 'ufsc-settings', 'ufsc-sql-settings', 'ufsc-gestion-parametres' ),
+            'woocommerce'   => array( 'ufsc-woocommerce', 'ufsc-gestion-woocommerce' ),
+            'communication' => array( 'ufsc-communication-clubs' ),
+            'access'        => array( 'ufsc-permissions', 'ufsc-user-club-mapping' ),
+        );
+
+        foreach ( $aliases as $section => $slugs ) {
+            if ( in_array( $slug, $slugs, true ) ) {
+                return $section;
+            }
+        }
+
+        return $slug;
+    }
+
     /* ---------------- Menus cachés pour accès direct ---------------- */
     public static function register_hidden_pages()
     {
@@ -928,7 +1149,9 @@ class UFSC_SQL_Admin
         $s = UFSC_SQL::get_settings();
         $c = (int) $wpdb->get_var("SELECT COUNT(*) FROM `{$s['table_clubs']}`");
         $l = (int) $wpdb->get_var("SELECT COUNT(*) FROM `{$s['table_licences']}`");
-        echo '<div class="wrap"><h1>UFSC – SQL</h1>';
+        echo '<div class="wrap">';
+        self::render_admin_quick_nav();
+        echo '<h1>UFSC – SQL</h1>';
         echo UFSC_CL_Utils::kpi_cards([
             ['label' => __('Clubs (SQL)', 'ufsc-clubs'), 'value' => $c],
             ['label' => __('Licences (SQL)', 'ufsc-clubs'), 'value' => $l],
@@ -953,7 +1176,9 @@ class UFSC_SQL_Admin
             echo '<div class="updated"><p>' . esc_html__('Réglages enregistrés.', 'ufsc-clubs') . '</p></div>';
         }
         $s = UFSC_SQL::get_settings();
-        echo '<div class="wrap"><h1>' . esc_html__('Réglages (SQL)', 'ufsc-clubs') . '</h1><form method="post">';
+        echo '<div class="wrap">';
+        self::render_admin_quick_nav();
+        echo '<h1>' . esc_html__('Réglages (SQL)', 'ufsc-clubs') . '</h1><form method="post">';
         wp_nonce_field('ufsc_sql_settings');
         echo '<table class="form-table">';
         echo '<tr><th>Table Clubs</th><td><input type="text" name="table_clubs" value="' . esc_attr($s['table_clubs']) . '" /></td></tr>';
@@ -1422,6 +1647,7 @@ class UFSC_SQL_Admin
             UFSC_Scope::assert_in_scope( $row->region );
         }
         echo '<div class="wrap ufsc-admin ufsc-admin-page">';
+        self::render_admin_quick_nav();
 
         echo '<h2 class="ufsc-admin-title">' . esc_html__( 'Fiche club — Suivi administratif et affiliation', 'ufsc-clubs' ) . '</h2>';
 
@@ -2730,7 +2956,9 @@ class UFSC_SQL_Admin
         );
 
         $current_season_label = self::get_admin_current_season_label();
-        echo '<div class="wrap ufsc-admin ufsc-admin-page"><h1 class="ufsc-admin-title">' . esc_html__( 'Licences UFSC — Gestion administrative par saison', 'ufsc-clubs' ) . '</h1>';
+        echo '<div class="wrap ufsc-admin ufsc-admin-page">';
+        self::render_admin_quick_nav();
+        echo '<h1 class="ufsc-admin-title">' . esc_html__( 'Licences UFSC — Gestion administrative par saison', 'ufsc-clubs' ) . '</h1>';
         echo '<p class="ufsc-admin-subtitle">' . esc_html__( 'Consultez, filtrez et mettez à jour les licences rattachées aux clubs pour la saison en cours. Les filtres permettent de contrôler rapidement les statuts, les paiements, les brouillons et les éventuels doublons d’identité.', 'ufsc-clubs' ) . '</p>';
         echo '<p class="ufsc-admin-help">' . esc_html__( 'Saison affichée :', 'ufsc-clubs' ) . ' ' . esc_html( $current_season_label ? $current_season_label : __( 'saison en cours', 'ufsc-clubs' ) ) . '</p>';
         echo '<div class="notice notice-info inline"><p>' . esc_html__( 'Renouvellement des licences : les licences sont suivies par saison. Lors du passage à la nouvelle saison, les licences pourront être renouvelées individuellement selon les règles définies par l’UFSC.', 'ufsc-clubs' ) . '</p></div>';
@@ -4666,6 +4894,7 @@ class UFSC_SQL_Admin
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         echo '<div class="wrap">';
+        self::render_admin_quick_nav();
         echo '<h1>' . esc_html__('Exports', 'ufsc-clubs') . '</h1>';
         echo '<p>' . esc_html__('Exportez vos données de clubs et licences avec des filtres personnalisés.', 'ufsc-clubs') . '</p>';
         if (! empty($_GET['error'])) {
@@ -4820,6 +5049,7 @@ class UFSC_SQL_Admin
             wp_die( __( 'Accès refusé.', 'ufsc-clubs' ) );
         }
         echo '<div class="wrap">';
+        self::render_admin_quick_nav();
         echo '<h1>' . esc_html__('Import', 'ufsc-clubs') . '</h1>';
         // Afficher les résultats de l'importation
         if (isset($_GET['imported'])) {

--- a/includes/admin/class-ufsc-settings-page.php
+++ b/includes/admin/class-ufsc-settings-page.php
@@ -47,7 +47,11 @@ class UFSC_Settings_Page {
             echo '<div class="updated"><p>' . esc_html__( 'Paramètres enregistrés.', 'ufsc-clubs' ) . '</p></div>';
         }
         $s = self::get_settings();
-        echo '<div class="wrap"><h1>' . esc_html__( 'Paramètres UFSC', 'ufsc-clubs' ) . '</h1>';
+        echo '<div class="wrap">';
+        if ( class_exists( 'UFSC_SQL_Admin' ) ) {
+            UFSC_SQL_Admin::render_admin_quick_nav();
+        }
+        echo '<h1>' . esc_html__( 'Paramètres UFSC', 'ufsc-clubs' ) . '</h1>';
         echo '<form method="post">';
         wp_nonce_field( 'ufsc_settings' );
         echo '<table class="form-table">';

--- a/includes/admin/class-user-club-admin.php
+++ b/includes/admin/class-user-club-admin.php
@@ -51,6 +51,7 @@ class UFSC_User_Club_Admin {
         $tab = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'associations';
         ?>
         <div class="wrap">
+            <?php if ( class_exists( 'UFSC_SQL_Admin' ) ) { UFSC_SQL_Admin::render_admin_quick_nav(); } ?>
             <h1><?php echo esc_html__( 'Gestion des Associations Utilisateurs-Clubs', 'ufsc-clubs' ); ?></h1>
 
             <nav class="nav-tab-wrapper">

--- a/includes/communication/class-ufsc-mail-service.php
+++ b/includes/communication/class-ufsc-mail-service.php
@@ -70,7 +70,9 @@ class UFSC_Mail_Service {
         if ( ! self::can_manage() ) { wp_die( esc_html__( 'Accès refusé.', 'ufsc-clubs' ) ); }
         global $wpdb; $view = isset( $_GET['view'] ) ? sanitize_key( wp_unslash( $_GET['view'] ) ) : 'list';
         $campaigns = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}ufsc_mail_campaigns ORDER BY id DESC LIMIT 30" );
-        echo '<div class="wrap ufsc-communication-wrap"><div class="ufsc-communication-header"><h1>Communication UFSC</h1><p class="ufsc-communication-sub">Créez, testez et envoyez des messages aux clubs, licenciés, responsables et listes personnalisées via une file d’attente sécurisée.</p></div>';
+        echo '<div class="wrap ufsc-communication-wrap">';
+        if ( class_exists( 'UFSC_SQL_Admin' ) ) { UFSC_SQL_Admin::render_admin_quick_nav(); }
+        echo '<div class="ufsc-communication-header"><h1>Communication UFSC</h1><p class="ufsc-communication-sub">Créez, testez et envoyez des messages aux clubs, licenciés, responsables et listes personnalisées via une file d’attente sécurisée.</p></div>';
         self::render_notices();
         echo '<p><a class="button button-primary" href="' . esc_url( admin_url( 'admin.php?page=ufsc-communication-clubs&view=new' ) ) . '">Nouvelle campagne</a> <a class="button" href="' . esc_url( admin_url( 'admin.php?page=ufsc-communication-clubs&view=history' ) ) . '">Historique</a> <a class="button" href="' . esc_url( admin_url( 'admin.php?page=ufsc-communication-clubs&view=contacts' ) ) . '">Carnet d’adresses</a> <a class="button" href="' . esc_url( admin_url( 'admin.php?page=ufsc-communication-clubs&view=lists' ) ) . '">Listes personnalisées</a> <a class="button" href="' . esc_url( admin_url( 'admin.php?page=ufsc-communication-clubs&view=settings' ) ) . '">Paramètres communication</a> <a class="button" href="' . esc_url( admin_url( 'admin.php?page=ufsc-communication-clubs&view=help' ) ) . '">Aide</a></p>';
         if ( 'new' === $view ) { self::render_new_campaign_form(); }

--- a/includes/permissions/class-ufsc-permissions.php
+++ b/includes/permissions/class-ufsc-permissions.php
@@ -207,6 +207,9 @@ class UFSC_Permissions {
         }
 
         echo '<div class="wrap ufsc-permissions-page">';
+        if ( class_exists( 'UFSC_SQL_Admin' ) ) {
+            UFSC_SQL_Admin::render_admin_quick_nav();
+        }
         echo '<h1>' . esc_html__( 'Droits & accès UFSC', 'ufsc-clubs' ) . '</h1>';
         echo '<p class="description">' . esc_html__( 'Les restrictions UFSC sont vérifiées côté serveur. Le masquage des boutons n’est qu’un confort visuel.', 'ufsc-clubs' ) . '</p>';
 


### PR DESCRIPTION
### Motivation
- Provide a compact, premium-looking quick navigation header in UFSC Gestion admin screens to ease access to the main plugin sections without changing business logic or menus. 
- Centralize the header rendering so it can be reused across the plugin admin pages and only shows links for actually registered slugs the current user can access.

### Description
- Added a centralized helper `UFSC_SQL_Admin::render_admin_quick_nav()` that detects the current `$_GET['page']`, guards against double rendering, builds links with `admin_url('admin.php')` + `add_query_arg()`, escapes URLs/labels with `esc_url()`/`esc_html()`, respects capabilities and highlights the active section via a slug->section mapping.  
- Implemented supporting methods: `get_admin_quick_nav_items()`, `admin_quick_nav_slug_is_registered()`, `current_user_can_quick_nav_item()` and `get_admin_quick_nav_section_for_slug()` to filter items by capability and registered slugs (including historical licence aliases).  
- Injected quick nav invocation at the top of the main UFSC admin pages so the banner appears on dashboard, clubs, licences, exports, import, settings, WooCommerce, communication, permissions, and user/club mapping screens without duplicating markup.  
- Added premium compact CSS to `assets/css/ufsc-admin.css` using the classes `.ufsc-admin-quicknav`, `.ufsc-admin-quicknav__inner`, `.ufsc-admin-quicknav__title`, `.ufsc-admin-quicknav__links`, `.ufsc-admin-quicknav__link` and `.ufsc-admin-quicknav__link.is-active` for responsive, pill-style buttons and subtle UFSC-brand styling.  
- Files modified: `includes/admin/class-sql-admin.php` (new helper + helpers + multiple render insertions), `includes/admin/class-admin-menu.php`, `includes/admin/class-ufsc-settings-page.php`, `includes/admin/class-user-club-admin.php`, `includes/communication/class-ufsc-mail-service.php`, `includes/permissions/class-ufsc-permissions.php`, `inc/woocommerce/settings-woocommerce.php`, and `assets/css/ufsc-admin.css`.
- The change explicitly avoids touching licence `Consulter`/`Éditer` buttons, licence/club/user IDs, business queries, statuses, competition plugin files, front-end files, destructive SQL or data migrations.

### Testing
- Ran `php -l` on each modified PHP file and received no syntax errors.  
- Executed `git diff --check` and a set of automatic grep checks for destructive SQL, competition/front-end paths and for accidental changes to `Consulter`/`Éditer` or licence-loading code, all of which returned clean results.  
- Verified programmatically that the quick-nav only lists registered slugs and filters items by capability via the new `admin_quick_nav_slug_is_registered()` and `current_user_can_quick_nav_item()` guards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225327aeb0832bb928ceaf7d7ad0cb)