### PR TITLE
Remove duplicate is_licence_id_debug_enabled() in UFSC_SQL_Admin

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -361,21 +361,6 @@ class UFSC_SQL_Admin
     }
 
     /**
-     * Whether the temporary licence ID diagnostic is enabled for a trusted admin.
-     *
-     * @return bool
-     */
-    private static function is_licence_id_debug_enabled() {
-        if ( ! isset( $_GET['ufsc_debug_ids'] ) || '1' !== (string) wp_unslash( $_GET['ufsc_debug_ids'] ) ) {
-            return false;
-        }
-
-        return current_user_can( 'manage_options' )
-            || ufsc_user_can( UFSC_Permissions::CAP_LICENCES_MANAGE )
-            || ufsc_user_can( UFSC_Permissions::CAP_GESTION_MANAGE );
-    }
-
-    /**
      * Add non-data cache-busting/debug args to dynamic admin licence action URLs.
      *
      * @param string $url URL to adjust.


### PR DESCRIPTION
### Motivation
- A duplicate declaration of `is_licence_id_debug_enabled()` caused a fatal PHP error (`Cannot redeclare UFSC_SQL_Admin::is_licence_id_debug_enabled()`), preventing the plugin from activating.
- The aim is to keep the single robust admin-only diagnostic helper and remove the earlier unsafe duplicate to avoid future regressions.

### Description
- Removed the first, weaker implementation of `is_licence_id_debug_enabled()` from `includes/admin/class-sql-admin.php` and retained the robust admin-only version that uses `is_admin()`, `sanitize_text_field( wp_unslash(...) )`, strict `'1'` check, safe `UFSC_Permissions`/`ufsc_user_can` guards, and a `current_user_can( 'manage_options' )` fallback.
- Verified the file contains the existing anti-double-inclusion guard `if ( class_exists( 'UFSC_SQL_Admin', false ) ) { return; }` before the class declaration and did not duplicate it.
- Ensured the other diagnostic methods (`add_admin_licence_action_url_args()`, `get_current_admin_url_for_debug()`, `render_licence_row_id_debug()`, `render_licence_form_id_debug()`, `add_dynamic_licence_link_args()`) remain and now call the single kept helper.
- Only `includes/admin/class-sql-admin.php` was changed and no business logic, front-end, competition files, or database-related code was modified.

### Testing
- Ran `rg -n "function is_licence_id_debug_enabled" includes/admin/class-sql-admin.php` and confirmed a single occurrence remained (success).
- Confirmed a single class declaration with `rg -n "class UFSC_SQL_Admin" . --glob "*.php" --glob "!vendor/**"` (success).
- Validated PHP syntax with `php -l includes/admin/class-sql-admin.php`, `php -l class-sql-admin.php`, and `php -l ufsc-clubs-licences-sql.php` (all succeeded).
- Checked no destructive DB statements were added with `git diff -U0 | rg -n "^\+.*\b(DROP|TRUNCATE|DELETE\s+FROM|ALTER\s+TABLE)\b"` (no matches).
- Verified no competition-related files were altered with `git diff --name-only | rg -n "compet|competition|compétition"` (no matches).
- Built an archive with `git archive` and inspected the extracted ZIP to confirm a single `is_licence_id_debug_enabled` occurrence in the packaged code (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22b331ff38832ba6a6043e47dae94e)