### PR TITLE
Format licence birthdate for ASPTT CSV export (d/m/Y)

### DIFF
--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -5029,11 +5029,66 @@ class UFSC_SQL_Admin
 
         // Data rows
         foreach ($data as $row) {
+            if (is_array($row) && array_key_exists('date_naissance', $row)) {
+                $row['date_naissance'] = self::ufsc_format_birthdate_for_asptt_csv($row['date_naissance']);
+            }
+
             fputcsv($output, $row, ';');
         }
 
         fclose($output);
         exit;
+    }
+
+    /**
+     * Format a licence birthdate for the ASPTT CSV import.
+     *
+     * @param mixed $value Raw birthdate value from the export row.
+     * @return string Birthdate formatted as d/m/Y, or an empty string for empty/invalid values.
+     */
+    private static function ufsc_format_birthdate_for_asptt_csv($value)
+    {
+        if ($value === null || is_array($value) || is_object($value)) {
+            return '';
+        }
+
+        $value = trim((string) $value);
+        if ($value === '') {
+            return '';
+        }
+
+        $zero_dates = [
+            '0000-00-00',
+            '0000-00-00 00:00:00',
+            '0000/00/00',
+            '00/00/0000',
+        ];
+        if (in_array($value, $zero_dates, true)) {
+            return '';
+        }
+
+        $formats = [
+            'Y-m-d H:i:s' => '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/',
+            'Y-m-d'       => '/^\d{4}-\d{2}-\d{2}$/',
+            'Y/m/d'       => '/^\d{4}\/\d{2}\/\d{2}$/',
+            'd/m/Y'       => '/^\d{2}\/\d{2}\/\d{4}$/',
+        ];
+
+        foreach ($formats as $format => $pattern) {
+            if (! preg_match($pattern, $value)) {
+                continue;
+            }
+
+            $date = DateTimeImmutable::createFromFormat('!' . $format, $value);
+            $errors = DateTimeImmutable::getLastErrors();
+            $has_errors = is_array($errors) && ($errors['warning_count'] > 0 || $errors['error_count'] > 0);
+
+            if ($date instanceof DateTimeImmutable && ! $has_errors && (int) $date->format('Y') > 0) {
+                return $date->format('d/m/Y');
+            }
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
### Motivation
- The licences CSV contained `Date de naissance` in SQL/ISO `YYYY-MM-DD` which is rejected by the ASPTT importer that expects `JJ/MM/AAAA`.
- The conversion must happen only at CSV write time without changing stored data, headers, separator or BOM.

### Description
- Modified `includes/admin/class-sql-admin.php` to apply a transformation right before writing each CSV row so the `date_naissance` cell is converted when present.
- Added a new private formatter method `ufsc_format_birthdate_for_asptt_csv()` which accepts `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, `YYYY/MM/DD` and `DD/MM/YYYY` and returns `d/m/Y` with leading zeros, or an empty string for empty/zero/invalid values.
- The change preserves the existing semicolon separator, UTF-8 BOM and all CSV headers and only affects the export path, not the database or import logic.

### Testing
- Ran `php -l includes/admin/class-sql-admin.php` to validate PHP syntax and it succeeded.
- Executed a small PHP check calling the new formatter against sample inputs and verified expected outputs, including `2011-07-03` -> `03/07/2011` and that zero/invalid dates produce an empty string.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27085c81a4832bab164467059a2227)