### PR TITLE
Finalize non-destructive 2026-2027 season renewals

### DIFF
--- a/inc/woocommerce/cart-integration.php
+++ b/inc/woocommerce/cart-integration.php
@@ -254,6 +254,17 @@ function ufsc_wc_find_equivalent_renewed_licence_id( $source, $club_id, $target_
     }
 
     $source_id = absint( $source->id ?? 0 );
+    if ( $source_id > 0 && in_array( 'previous_licence_id', $columns, true ) ) {
+        $trace_clauses = $clauses;
+        $trace_values  = $values;
+        $trace_clauses[] = 'previous_licence_id = %d';
+        $trace_values[]  = $source_id;
+        $trace_sql = "SELECT id FROM `{$table}` WHERE " . implode( ' AND ', $trace_clauses ) . ' LIMIT 1';
+        $trace_id  = absint( $wpdb->get_var( $wpdb->prepare( $trace_sql, ...$trace_values ) ) );
+        if ( $trace_id > 0 ) {
+            return $trace_id;
+        }
+    }
     if ( $source_id > 0 ) {
         $clauses[] = 'id <> %d';
         $values[]  = $source_id;

--- a/inc/woocommerce/hooks.php
+++ b/inc/woocommerce/hooks.php
@@ -356,6 +356,7 @@ function ufsc_wc_process_renewal_items( $order ) {
 				if ( in_array( $season_col, $columns, true ) ) { $data[ $season_col ] = $target_season; }
 			}
 			if ( in_array( 'season_end_year', $columns, true ) && function_exists( 'ufsc_get_season_end_year_from_label' ) ) { $data['season_end_year'] = ufsc_get_season_end_year_from_label( $target_season ); }
+			if ( in_array( 'previous_licence_id', $columns, true ) ) { $data['previous_licence_id'] = $source_id; }
 			if ( in_array( 'renewed_from_licence_id', $columns, true ) ) { $data['renewed_from_licence_id'] = $source_id; }
 			if ( in_array( 'renewal_status', $columns, true ) ) { $data['renewal_status'] = 'renouvellement_en_attente'; }
 			if ( in_array( 'order_id', $columns, true ) ) { $data['order_id'] = (int) $order->get_id(); }

--- a/includes/admin/class-sql-admin.php
+++ b/includes/admin/class-sql-admin.php
@@ -672,14 +672,14 @@ class UFSC_SQL_Admin
      * @return string
      */
     private static function get_admin_current_season_label() {
+        if ( function_exists( 'ufsc_get_admin_current_season_label' ) ) {
+            return (string) ufsc_get_admin_current_season_label();
+        }
         if ( class_exists( 'UFSC_Season_Service' ) ) {
             return (string) UFSC_Season_Service::get_current_season();
         }
         if ( function_exists( 'ufsc_get_current_season' ) ) {
             return (string) ufsc_get_current_season();
-        }
-        if ( function_exists( 'ufsc_get_admin_current_season_label' ) ) {
-            return (string) ufsc_get_admin_current_season_label();
         }
         return __( 'saison en cours', 'ufsc-clubs' );
     }
@@ -2929,6 +2929,59 @@ class UFSC_SQL_Admin
         );
     }
 
+
+    /**
+     * Build a season SQL predicate without mutating legacy rows.
+     *
+     * Empty season values are considered current-season rows only for the
+     * current-season filter so historical data remains visible until a safe
+     * idempotent migration stores an explicit season.
+     */
+    private static function build_licence_season_condition( $season_column, $filter_season ) {
+        global $wpdb;
+
+        $season_column  = sanitize_key( (string) $season_column );
+        $filter_season  = sanitize_text_field( (string) $filter_season );
+        $current_season = self::get_admin_current_season_label();
+
+        if ( '' === $season_column || 'all' === $filter_season ) {
+            return '';
+        }
+
+        if ( 'season_end_year' === $season_column ) {
+            $current_end_year = self::get_season_end_year_from_label( $current_season );
+            if ( '__archives' === $filter_season ) {
+                return $current_end_year > 0 ? $wpdb->prepare( "COALESCE(l.season_end_year, 0) > 0 AND l.season_end_year < %d", $current_end_year ) : '';
+            }
+
+            $target_season   = ( '__current' === $filter_season || '' === $filter_season ) ? $current_season : $filter_season;
+            $target_end_year = self::get_season_end_year_from_label( $target_season );
+            if ( $target_end_year <= 0 ) {
+                return '';
+            }
+
+            return ( '__current' === $filter_season || '' === $filter_season )
+                ? $wpdb->prepare( "(COALESCE(l.season_end_year, 0) = 0 OR l.season_end_year = %d)", $target_end_year )
+                : $wpdb->prepare( "l.season_end_year = %d", $target_end_year );
+        }
+
+        if ( '__archives' === $filter_season ) {
+            $current_start_year = self::get_season_start_year_from_label( $current_season );
+            return $current_start_year > 0
+                ? $wpdb->prepare( "COALESCE(NULLIF(l.{$season_column}, ''), '') REGEXP %s AND CAST(SUBSTRING(REPLACE(l.{$season_column}, '/', '-'), 1, 4) AS UNSIGNED) < %d", '^[0-9]{4}[-/][0-9]{4}$', $current_start_year )
+                : '';
+        }
+
+        $target_season = ( '__current' === $filter_season || '' === $filter_season ) ? $current_season : $filter_season;
+        if ( '' === $target_season ) {
+            return '';
+        }
+
+        return ( '__current' === $filter_season || '' === $filter_season )
+            ? $wpdb->prepare( "(COALESCE(NULLIF(REPLACE(l.{$season_column}, '/', '-'), ''), '') = '' OR REPLACE(l.{$season_column}, '/', '-') = %s)", $target_season )
+            : $wpdb->prepare( "REPLACE(l.{$season_column}, '/', '-') = %s", str_replace( '/', '-', $target_season ) );
+    }
+
     private static function build_licence_where_conditions( $filters, $licence_columns, $club_columns, $has_club_id ) {
         global $wpdb;
         $where_conditions = array();
@@ -2983,43 +3036,9 @@ class UFSC_SQL_Admin
 
         if ( 'all' !== $filter_season ) {
             $season_column = self::get_first_existing_column( $licence_columns, array( 'paid_season', 'season', 'saison', 'season_end_year' ) );
-            if ( '' !== $season_column ) {
-                $current_season = self::get_admin_current_season_label();
-                $target_season  = '';
-                if ( '__current' === $filter_season || '' === $filter_season ) {
-                    $target_season = $current_season;
-                } elseif ( '__archives' !== $filter_season ) {
-                    $target_season = $filter_season;
-                }
-
-                if ( 'season_end_year' === $season_column ) {
-                    $current_end_year = self::get_season_end_year_from_label( $current_season );
-                    $target_end_year  = self::get_season_end_year_from_label( $target_season );
-                    if ( '__archives' === $filter_season && $current_end_year > 0 ) {
-                        $where_conditions[] = $wpdb->prepare( "COALESCE(l.season_end_year, 0) > 0 AND l.season_end_year < %d", $current_end_year );
-                    } elseif ( $target_end_year > 0 ) {
-                        if ( '__current' === $filter_season || '' === $filter_season ) {
-                            $where_conditions[] = $wpdb->prepare( "(COALESCE(l.season_end_year, 0) = 0 OR l.season_end_year = %d)", $target_end_year );
-                        } else {
-                            $where_conditions[] = $wpdb->prepare( "l.season_end_year = %d", $target_end_year );
-                        }
-                    }
-                } elseif ( '__archives' === $filter_season && '' !== $current_season ) {
-                    $current_start_year = self::get_season_start_year_from_label( $current_season );
-                    if ( $current_start_year > 0 ) {
-                        $where_conditions[] = $wpdb->prepare(
-                            "COALESCE(NULLIF(l.{$season_column}, ''), '') REGEXP %s AND CAST(SUBSTRING(REPLACE(l.{$season_column}, '/', '-'), 1, 4) AS UNSIGNED) < %d",
-                            '^[0-9]{4}[-/][0-9]{4}$',
-                            $current_start_year
-                        );
-                    }
-                } elseif ( '' !== $target_season ) {
-                    if ( '__current' === $filter_season || '' === $filter_season ) {
-                        $where_conditions[] = $wpdb->prepare( "(COALESCE(NULLIF(l.{$season_column}, ''), '') = '' OR l.{$season_column} = %s)", $target_season );
-                    } else {
-                        $where_conditions[] = $wpdb->prepare( "l.{$season_column} = %s", $target_season );
-                    }
-                }
+            $season_condition = self::build_licence_season_condition( $season_column, $filter_season );
+            if ( '' !== $season_condition ) {
+                $where_conditions[] = $season_condition;
             }
         }
 

--- a/includes/core/class-ufsc-db-migrations.php
+++ b/includes/core/class-ufsc-db-migrations.php
@@ -10,7 +10,7 @@ class UFSC_DB_Migrations {
     /**
      * Current migration version
      */
-    const MIGRATION_VERSION = '1.3.0';
+    const MIGRATION_VERSION = '1.3.1';
 
     /**
      * Option key for tracking migration version
@@ -35,9 +35,10 @@ class UFSC_DB_Migrations {
 
         if ( version_compare( $current_version, self::MIGRATION_VERSION, '<' ) ) {
             self::migrate_to_innodb();
+            self::ensure_licences_soft_delete_columns();
+            self::ensure_licences_renewal_columns();
             self::create_indexes();
             self::create_unique_constraints();
-            self::ensure_licences_soft_delete_columns();
             $category_columns_ready = self::ensure_licences_category_columns();
             self::create_events_table();
 
@@ -77,6 +78,37 @@ class UFSC_DB_Migrations {
 
         if ( ! in_array( 'deleted_by', $columns, true ) ) {
             $wpdb->query( "ALTER TABLE `{$licences_table}` ADD COLUMN `deleted_by` bigint(20) unsigned NULL DEFAULT NULL" );
+        }
+    }
+
+    /**
+     * Ensure licences table can store non-destructive renewal lineage.
+     */
+    public static function ensure_licences_renewal_columns() {
+        global $wpdb;
+
+        $settings       = UFSC_SQL::get_settings();
+        $licences_table = $settings['table_licences'];
+
+        if ( ! self::table_exists( $licences_table ) ) {
+            return;
+        }
+
+        $columns = $wpdb->get_col( "SHOW COLUMNS FROM `{$licences_table}`", 0 );
+        if ( ! is_array( $columns ) ) {
+            return;
+        }
+
+        if ( ! in_array( 'previous_licence_id', $columns, true ) ) {
+            $wpdb->query( "ALTER TABLE `{$licences_table}` ADD COLUMN `previous_licence_id` bigint(20) unsigned NULL DEFAULT NULL" );
+        }
+
+        if ( ! self::index_exists( $licences_table, 'idx_licences_previous_licence_id' ) ) {
+            $wpdb->query( "ALTER TABLE `{$licences_table}` ADD INDEX `idx_licences_previous_licence_id` (`previous_licence_id`)" );
+        }
+
+        if ( function_exists( 'ufsc_flush_table_columns_cache' ) ) {
+            ufsc_flush_table_columns_cache();
         }
     }
 
@@ -208,6 +240,7 @@ class UFSC_DB_Migrations {
             'idx_licences_gender'                  => 'gender',
             'idx_licences_practice'                => 'practice',
             'idx_licences_birthdate'               => 'birthdate',
+            'idx_licences_previous_licence_id'     => 'previous_licence_id',
         );
 
         self::create_table_indexes( $settings['table_licences'], $licences_indexes );

--- a/tests/test-renewal-season-static.php
+++ b/tests/test-renewal-season-static.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Static safeguards for 2026-2027 non-destructive renewals.
+ */
+
+$root = dirname( __DIR__ );
+$season = file_get_contents( $root . '/inc/common/season.php' );
+$hooks  = file_get_contents( $root . '/inc/woocommerce/hooks.php' );
+$cart   = file_get_contents( $root . '/inc/woocommerce/cart-integration.php' );
+$admin  = file_get_contents( $root . '/includes/admin/class-sql-admin.php' );
+$migration = file_get_contents( $root . '/includes/core/class-ufsc-db-migrations.php' );
+
+$assert = static function ( $condition, $message ) {
+    if ( ! $condition ) {
+        fwrite( STDERR, "FAIL: {$message}\n" );
+        exit( 1 );
+    }
+};
+
+$assert( strpos( $season, "'numero_licence_delegataire'" ) === false, 'ASPTT licence numbers must not be copied on renewal.' );
+$assert( strpos( $hooks, "'previous_licence_id'" ) !== false, 'Renewed licences must store previous_licence_id when the column exists.' );
+$assert( strpos( $hooks, 'ufsc_get_renewed_licence_marker' ) !== false, 'Paid renewal processing must guard duplicate renewals.' );
+$assert( strpos( $cart, 'previous_licence_id = %d' ) !== false, 'Cart duplicate guard must detect previous_licence_id lineage.' );
+$assert( strpos( $admin, 'build_licence_season_condition' ) !== false, 'Admin licences list must centralize season filtering.' );
+$assert( strpos( $admin, "REPLACE(l.{\$season_column}, '/', '-')" ) !== false, 'Admin season filter must normalize slash/dash labels.' );
+$assert( strpos( $migration, 'ensure_licences_renewal_columns' ) !== false, 'Renewal columns migration must be idempotent.' );
+$assert( strpos( $migration, 'previous_licence_id' ) !== false, 'Migration must add previous_licence_id without renaming columns.' );
+
+echo "Renewal/season static safeguards OK\n";


### PR DESCRIPTION
### Motivation
- Préparer la gestion non destructive des saisons 2026-2027 en garantissant qu’aucune donnée historique n’est modifiée et que l’identifiant des clubs et les colonnes existantes restent inchangés.
- Empêcher les doubles renouvellements tout en conservant la compatibilité avec le plugin séparé Licence & Compétition.
- Améliorer le filtrage admin par saison pour afficher correctement les lignes historiques sans réécriture de données.

### Description
- Ajout d’un prédicat centralisé de filtrage de saison `build_licence_season_condition` dans `includes/admin/class-sql-admin.php` qui normalise `YYYY/YYYY`/`YYYY-YYYY`, considère les saisons vides comme "courantes" pour le filtre courant et évite de muter les lignes historiques.
- Priorisation du helper admin lorsqu’il existe : `get_admin_current_season_label` utilise `ufsc_get_admin_current_season_label()` en priorité pour l’UX admin.
- Introduction non destructive de la colonne de traçabilité `previous_licence_id` via une migration idempotente `ensure_licences_renewal_columns()` dans `includes/core/class-ufsc-db-migrations.php` (ajout de la colonne + index) et incrément de la version de migration à `1.3.1`.
- Conservation de la compatibilité : lors d’un renouvellement payé `inc/woocommerce/hooks.php` renseigne `previous_licence_id` si la colonne existe tout en conservant `renewed_from_licence_id` pour l’intégration existante.
- Renforcement des gardes anti-doublon côté panier/commande `inc/woocommerce/cart-integration.php` en recherchant d’abord une correspondance via `previous_licence_id` (linéage) avant d’appliquer les autres heuristiques.
- Ajout d’un test statique de garde `tests/test-renewal-season-static.php` vérifiant : non-copie des numéros ASPTT, présence de `previous_licence_id` dans le flux de renouvellement, marqueurs d’idempotence, centralisation du filtrage saison et présence de la migration.

### Testing
- Exécution du test statique : `php tests/test-renewal-season-static.php` — succès (`Renewal/season static safeguards OK`).
- Vérification de la syntaxe PHP sur tous les fichiers : `find . -path './vendor' -prune -o -path './node_modules' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l` — tous les fichiers valides.
- Exécution de `phpunit` non disponible dans l’environnement (aucun run automatique de tests unitaires complets possible ici).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a633fed8c5c832b9a3e78966a5346e8)